### PR TITLE
[backend] Avoid raising stack trace instead of returning a 404

### DIFF
--- a/openbas-api/src/main/java/io/openbas/config/GlobalExceptionHandler.java
+++ b/openbas-api/src/main/java/io/openbas/config/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package io.openbas.config;
+
+import io.openbas.rest.exception.ElementNotFoundException;
+import lombok.extern.java.Log;
+import org.springdoc.api.ErrorMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Log
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ElementNotFoundException.class)
+    public ResponseEntity<ErrorMessage> handleElementNotFoundException() {
+        ErrorMessage message = new ErrorMessage("Not found");
+        return new ResponseEntity<ErrorMessage>(message, HttpStatus.NOT_FOUND);
+    }
+
+}

--- a/openbas-api/src/main/java/io/openbas/helper/DatabaseHelper.java
+++ b/openbas-api/src/main/java/io/openbas/helper/DatabaseHelper.java
@@ -1,6 +1,7 @@
 package io.openbas.helper;
 
 import io.openbas.database.model.Base;
+import io.openbas.rest.exception.ElementNotFoundException;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
@@ -32,6 +33,6 @@ public class DatabaseHelper {
     }
 
     public static <T> T resolveRelation(String inputRelationId, CrudRepository<T, String> repository) {
-        return repository.findById(inputRelationId).orElseThrow();
+        return repository.findById(inputRelationId).orElseThrow(ElementNotFoundException::new);
     }
 }

--- a/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
@@ -2,11 +2,11 @@ package io.openbas.rest.atomic_testing;
 
 import io.openbas.database.model.Inject;
 import io.openbas.database.model.InjectExpectation;
-import io.openbas.database.model.InjectStatus;
 import io.openbas.inject_expectation.InjectExpectationService;
 import io.openbas.rest.atomic_testing.form.AtomicTestingInput;
 import io.openbas.rest.atomic_testing.form.AtomicTestingUpdateTagsInput;
 import io.openbas.rest.atomic_testing.form.InjectResultDTO;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.service.AtomicTestingService;
 import io.openbas.utils.AtomicTestingMapper;
@@ -48,12 +48,12 @@ public class AtomicTestingApi extends RestBehavior {
   public InjectResultDTO findAtomicTesting(@PathVariable String injectId) {
     return atomicTestingService.findById(injectId)
         .map(AtomicTestingMapper::toDtoWithTargetResults)
-        .orElseThrow();
+        .orElseThrow(ElementNotFoundException::new);
   }
 
   @GetMapping("/{injectId}/update")
   public Inject findAtomicTestingForUpdate(@PathVariable String injectId) {
-    return atomicTestingService.findById(injectId).orElseThrow();
+    return atomicTestingService.findById(injectId).orElseThrow(ElementNotFoundException::new);
   }
 
   @PostMapping()

--- a/openbas-api/src/main/java/io/openbas/rest/attack_pattern/AttackPatternApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/attack_pattern/AttackPatternApi.java
@@ -10,6 +10,7 @@ import io.openbas.database.specification.InjectorContractSpecification;
 import io.openbas.rest.attack_pattern.form.AttackPatternCreateInput;
 import io.openbas.rest.attack_pattern.form.AttackPatternUpdateInput;
 import io.openbas.rest.attack_pattern.form.AttackPatternUpsertInput;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.utils.pagination.SearchPaginationInput;
 import jakarta.transaction.Transactional;
@@ -74,7 +75,7 @@ public class AttackPatternApi extends RestBehavior {
 
     @GetMapping("/api/attack_patterns/{attackPatternId}")
     public AttackPattern attackPattern(@PathVariable String attackPatternId) {
-        return attackPatternRepository.findById(attackPatternId).orElseThrow();
+        return attackPatternRepository.findById(attackPatternId).orElseThrow(ElementNotFoundException::new);
     }
 
     @Secured(ROLE_ADMIN)
@@ -89,7 +90,7 @@ public class AttackPatternApi extends RestBehavior {
 
     @GetMapping("/api/attack_patterns/{attackPatternId}/injector_contracts")
     public Iterable<InjectorContract> injectorContracts(@PathVariable String attackPatternId) {
-        attackPatternRepository.findById(attackPatternId).orElseThrow();
+        attackPatternRepository.findById(attackPatternId).orElseThrow(ElementNotFoundException::new);
         return injectorContractRepository.findAll(InjectorContractSpecification.fromAttackPattern(attackPatternId));
     }
 
@@ -98,7 +99,7 @@ public class AttackPatternApi extends RestBehavior {
     public AttackPattern updateAttackPattern(
             @NotBlank @PathVariable final String attackPatternId,
             @Valid @RequestBody AttackPatternUpdateInput input) {
-        AttackPattern attackPattern = this.attackPatternRepository.findById(attackPatternId).orElseThrow();
+        AttackPattern attackPattern = this.attackPatternRepository.findById(attackPatternId).orElseThrow(ElementNotFoundException::new);
         attackPattern.setUpdateAttributes(input);
         attackPattern.setKillChainPhases(fromIterable(this.killChainPhaseRepository.findAllById(input.getKillChainPhasesIds())));
         attackPattern.setUpdatedAt(Instant.now());
@@ -115,7 +116,7 @@ public class AttackPatternApi extends RestBehavior {
                     fromIterable(killChainPhaseRepository.findAllById(attackPatternInput.getKillChainPhasesIds()))
                     : List.of();
             AttackPattern attackPatternParent = attackPatternInput.getParentId() != null ?
-                    attackPatternRepository.findByStixId(attackPatternInput.getParentId()).orElseThrow() : null;
+                    attackPatternRepository.findByStixId(attackPatternInput.getParentId()).orElseThrow(ElementNotFoundException::new) : null;
             if (optionalAttackPattern.isEmpty()) {
                 AttackPattern newAttackPattern = new AttackPattern();
                 newAttackPattern.setStixId(attackPatternInput.getStixId());

--- a/openbas-api/src/main/java/io/openbas/rest/challenge/ChallengeApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/challenge/ChallengeApi.java
@@ -9,6 +9,7 @@ import io.openbas.rest.challenge.form.ChallengeUpdateInput;
 import io.openbas.rest.challenge.response.ChallengeInformation;
 import io.openbas.rest.challenge.response.ChallengeResult;
 import io.openbas.rest.challenge.response.ChallengesReader;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.service.ChallengeService;
 import io.openbas.service.ScenarioService;
@@ -101,7 +102,7 @@ public class ChallengeApi extends RestBehavior {
   public Challenge updateChallenge(
       @PathVariable String challengeId,
       @Valid @RequestBody ChallengeUpdateInput input) {
-    Challenge challenge = challengeRepository.findById(challengeId).orElseThrow();
+    Challenge challenge = challengeRepository.findById(challengeId).orElseThrow(ElementNotFoundException::new);
     challenge.setTags(fromIterable(tagRepository.findAllById(input.getTagIds())));
     challenge.setDocuments(fromIterable(documentRepository.findAllById(input.getDocumentIds())));
     challenge.setUpdateAttributes(input);
@@ -149,7 +150,7 @@ public class ChallengeApi extends RestBehavior {
 
   @GetMapping("/api/player/challenges/{exerciseId}")
   public ChallengesReader playerChallenges(@PathVariable String exerciseId, @RequestParam Optional<String> userId) {
-    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     final User user = impersonateUser(userRepository, userId);
     if (user.getId().equals(ANONYMOUS)) {
       throw new UnsupportedOperationException("User must be logged or dynamic player is required");
@@ -172,7 +173,7 @@ public class ChallengeApi extends RestBehavior {
 
   @GetMapping("/api/observer/challenges/{exerciseId}")
   public ChallengesReader observerChallenges(@PathVariable String exerciseId) {
-    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     ChallengesReader challengesReader = new ChallengesReader(exercise);
     Iterable<Challenge> challenges = exerciseChallenges(exerciseId);
     challengesReader.setExerciseChallenges(fromIterable(challenges).stream()
@@ -205,7 +206,7 @@ public class ChallengeApi extends RestBehavior {
 
   @PostMapping("/api/challenges/{challengeId}/try")
   public ChallengeResult tryChallenge(@PathVariable String challengeId, @Valid @RequestBody ChallengeTryInput input) {
-    Challenge challenge = challengeRepository.findById(challengeId).orElseThrow();
+    Challenge challenge = challengeRepository.findById(challengeId).orElseThrow(ElementNotFoundException::new);
     for (ChallengeFlag flag : challenge.getFlags()) {
       if (checkFlag(flag, input.getValue())) {
         return new ChallengeResult(true);

--- a/openbas-api/src/main/java/io/openbas/rest/collector/CollectorApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/collector/CollectorApi.java
@@ -3,10 +3,10 @@ package io.openbas.rest.collector;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openbas.config.OpenBASConfig;
 import io.openbas.database.model.Collector;
-import io.openbas.database.model.Injector;
 import io.openbas.database.repository.CollectorRepository;
 import io.openbas.rest.collector.form.CollectorCreateInput;
 import io.openbas.rest.collector.form.CollectorUpdateInput;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.service.FileService;
 import jakarta.annotation.Resource;
@@ -63,7 +63,7 @@ public class CollectorApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PutMapping("/api/collectors/{collectorId}")
     public Collector updateCollector(@PathVariable String collectorId, @Valid @RequestBody CollectorUpdateInput input) {
-        Collector collector = collectorRepository.findById(collectorId).orElseThrow();
+        Collector collector = collectorRepository.findById(collectorId).orElseThrow(ElementNotFoundException::new);
         return updateCollector(collector, collector.getType(), collector.getName(), collector.getPeriod(), input.getLastExecution());
     }
 

--- a/openbas-api/src/main/java/io/openbas/rest/comcheck/ComcheckApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/comcheck/ComcheckApi.java
@@ -1,18 +1,19 @@
 package io.openbas.rest.comcheck;
 
 import io.openbas.database.model.*;
-import io.openbas.database.repository.TeamRepository;
 import io.openbas.database.repository.ComcheckRepository;
 import io.openbas.database.repository.ComcheckStatusRepository;
 import io.openbas.database.repository.ExerciseRepository;
+import io.openbas.database.repository.TeamRepository;
 import io.openbas.rest.comcheck.form.ComcheckInput;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
 import java.util.List;
 
 import static io.openbas.helper.StreamHelper.fromIterable;
@@ -49,7 +50,7 @@ public class ComcheckApi extends RestBehavior {
     @Transactional(rollbackOn = Exception.class)
     @GetMapping("/api/comcheck/{comcheckStatusId}")
     public ComcheckStatus checkValidation(@PathVariable String comcheckStatusId) {
-        ComcheckStatus comcheckStatus = comcheckStatusRepository.findById(comcheckStatusId).orElseThrow();
+        ComcheckStatus comcheckStatus = comcheckStatusRepository.findById(comcheckStatusId).orElseThrow(ElementNotFoundException::new);
         Comcheck comcheck = comcheckStatus.getComcheck();
         if (!comcheck.getState().equals(Comcheck.COMCHECK_STATUS.RUNNING)) {
             throw new UnsupportedOperationException("This comcheck is closed.");
@@ -80,7 +81,7 @@ public class ComcheckApi extends RestBehavior {
         check.setUpdateAttributes(comCheck);
         check.setName(comCheck.getName());
         check.setStart(now());
-        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
         check.setExercise(exercise);
         // 02. Get users
         List<String> teamIds = comCheck.getTeamIds();

--- a/openbas-api/src/main/java/io/openbas/rest/exception/ElementNotFoundException.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exception/ElementNotFoundException.java
@@ -1,0 +1,12 @@
+package io.openbas.rest.exception;
+
+public class ElementNotFoundException extends RuntimeException{
+
+    public ElementNotFoundException() {
+        super();
+    }
+
+    public ElementNotFoundException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/openbas-api/src/main/java/io/openbas/rest/executor/ExecutorApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/executor/ExecutorApi.java
@@ -3,6 +3,7 @@ package io.openbas.rest.executor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openbas.database.model.Executor;
 import io.openbas.database.repository.ExecutorRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.executor.form.ExecutorCreateInput;
 import io.openbas.rest.executor.form.ExecutorUpdateInput;
 import io.openbas.rest.helper.RestBehavior;
@@ -56,7 +57,7 @@ public class ExecutorApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PutMapping("/api/executors/{executorId}")
     public Executor updateExecutor(@PathVariable String executorId, @Valid @RequestBody ExecutorUpdateInput input) {
-        Executor executor = executorRepository.findById(executorId).orElseThrow();
+        Executor executor = executorRepository.findById(executorId).orElseThrow(ElementNotFoundException::new);
         return updateExecutor(executor, executor.getType(), executor.getName(), executor.getPlatforms());
     }
 

--- a/openbas-api/src/main/java/io/openbas/rest/exercise/ExercisePlayerApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/ExercisePlayerApi.java
@@ -3,6 +3,7 @@ package io.openbas.rest.exercise;
 import io.openbas.database.model.Exercise;
 import io.openbas.database.repository.ExerciseRepository;
 import io.openbas.database.repository.UserRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.exercise.response.PublicExercise;
 import io.openbas.rest.helper.RestBehavior;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,7 @@ public class ExercisePlayerApi extends RestBehavior {
   @GetMapping(EXERCISE_URI + "/{exerciseId}")
   public PublicExercise playerExercise(@PathVariable String exerciseId, @RequestParam Optional<String> userId) {
     impersonateUser(this.userRepository, userId);
-    Exercise exercise = this.exerciseRepository.findById(exerciseId).orElseThrow();
+    Exercise exercise = this.exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     return new PublicExercise(exercise);
   }
 

--- a/openbas-api/src/main/java/io/openbas/rest/group/GroupApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/group/GroupApi.java
@@ -3,6 +3,7 @@ package io.openbas.rest.group;
 import io.openbas.database.audit.BaseEvent;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.*;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.group.form.GroupCreateInput;
 import io.openbas.rest.group.form.GroupGrantInput;
 import io.openbas.rest.group.form.GroupUpdateUsersInput;
@@ -94,7 +95,7 @@ public class GroupApi extends RestBehavior {
 
     @GetMapping("/api/groups/{groupId}")
     public Group group(@PathVariable String groupId) {
-        return groupRepository.findById(groupId).orElseThrow();
+        return groupRepository.findById(groupId).orElseThrow(ElementNotFoundException::new);
     }
 
     @Secured(ROLE_ADMIN)
@@ -111,7 +112,7 @@ public class GroupApi extends RestBehavior {
     @PutMapping("/api/groups/{groupId}/users")
     public Group updateGroupUsers(@PathVariable String groupId,
                                   @Valid @RequestBody GroupUpdateUsersInput input) {
-        Group group = groupRepository.findById(groupId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow(ElementNotFoundException::new);
         Spliterator<User> userSpliterator = userRepository.findAllById(input.getUserIds()).spliterator();
         group.setUsers(stream(userSpliterator, false).collect(toList()));
         Group savedGroup = groupRepository.save(group);
@@ -133,7 +134,7 @@ public class GroupApi extends RestBehavior {
     public Group updateGroupInformation(
             @PathVariable String groupId,
             @Valid @RequestBody GroupCreateInput input) {
-        Group group = groupRepository.findById(groupId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow(ElementNotFoundException::new);
         group.setUpdateAttributes(input);
         group.setExercisesDefaultGrants(input.defaultExerciseGrants());
         group.setScenariosDefaultGrants(input.defaultScenarioGrants());
@@ -149,7 +150,7 @@ public class GroupApi extends RestBehavior {
         }
 
         // Resolve dependencies
-        Group group = groupRepository.findById(groupId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow(ElementNotFoundException::new);
         Optional<Exercise> exerciseOpt = input.getExerciseId() == null ? Optional.empty() : exerciseRepository.findById(input.getExerciseId());
         Optional<Scenario> scenarioOpt = input.getScenarioId() == null ? Optional.empty() : scenarioRepository.findById(input.getScenarioId());
 
@@ -189,8 +190,8 @@ public class GroupApi extends RestBehavior {
     @PostMapping("/api/groups/{groupId}/organizations")
     public Group groupOrganization(@PathVariable String groupId, @Valid @RequestBody OrganizationGrantInput input) {
         // Resolve dependencies
-        Group group = groupRepository.findById(groupId).orElseThrow();
-        Organization organization = organizationRepository.findById(input.getOrganizationId()).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow(ElementNotFoundException::new);
+        Organization organization = organizationRepository.findById(input.getOrganizationId()).orElseThrow(ElementNotFoundException::new);
         group.getOrganizations().add(organization);
         return groupRepository.save(group);
     }
@@ -198,8 +199,8 @@ public class GroupApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @DeleteMapping("/api/groups/{groupId}/organizations/{organizationId}")
     public Group deleteGroupOrganization(@PathVariable String groupId, @PathVariable String organizationId) {
-        Group group = groupRepository.findById(groupId).orElseThrow();
-        Organization organization = organizationRepository.findById(organizationId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow(ElementNotFoundException::new);
+        Organization organization = organizationRepository.findById(organizationId).orElseThrow(ElementNotFoundException::new);
         group.getOrganizations().remove(organization);
         return groupRepository.save(group);
     }

--- a/openbas-api/src/main/java/io/openbas/rest/injector/InjectorApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/injector/InjectorApi.java
@@ -1,6 +1,5 @@
 package io.openbas.rest.injector;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,6 +13,7 @@ import io.openbas.database.model.InjectorContract;
 import io.openbas.database.repository.AttackPatternRepository;
 import io.openbas.database.repository.InjectorContractRepository;
 import io.openbas.database.repository.InjectorRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.injector.form.InjectorCreateInput;
 import io.openbas.rest.injector.form.InjectorUpdateInput;
@@ -81,7 +81,7 @@ public class InjectorApi extends RestBehavior {
 
     @GetMapping("/api/injectors/{injectorId}/injector_contracts")
     public Collection<JsonNode> injectorInjectTypes(@PathVariable String injectorId) {
-        Injector injector = injectorRepository.findById(injectorId).orElseThrow();
+        Injector injector = injectorRepository.findById(injectorId).orElseThrow(ElementNotFoundException::new);
         return fromIterable(injectorContractRepository.findInjectorContractsByInjector(injector)).stream()
                 .map(contract -> {
                     try {
@@ -161,7 +161,7 @@ public class InjectorApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PutMapping("/api/injectors/{injectorId}")
     public Injector updateInjector(@PathVariable String injectorId, @Valid @RequestBody InjectorUpdateInput input) {
-        Injector injector = injectorRepository.findById(injectorId).orElseThrow();
+        Injector injector = injectorRepository.findById(injectorId).orElseThrow(ElementNotFoundException::new);
         return updateInjector(
                 injector,
                 injector.getType(),
@@ -177,7 +177,7 @@ public class InjectorApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @GetMapping("/api/injectors/{injectorId}")
     public Injector injector(@PathVariable String injectorId) {
-        return injectorRepository.findById(injectorId).orElseThrow();
+        return injectorRepository.findById(injectorId).orElseThrow(ElementNotFoundException::new);
     }
 
     @Secured(ROLE_ADMIN)

--- a/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractApi.java
@@ -7,6 +7,7 @@ import io.openbas.database.repository.AttackPatternRepository;
 import io.openbas.database.repository.InjectorContractRepository;
 import io.openbas.database.repository.InjectorRepository;
 import io.openbas.database.specification.InjectorContractSpecification;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.injector_contract.form.InjectorContractAddInput;
 import io.openbas.rest.injector_contract.form.InjectorContractUpdateInput;
@@ -97,7 +98,7 @@ public class InjectorContractApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @GetMapping("/api/injector_contracts/{injectorContractId}")
     public InjectorContract injectorContract(@PathVariable String injectorContractId) {
-        return injectorContractRepository.findById(injectorContractId).orElseThrow();
+        return injectorContractRepository.findById(injectorContractId).orElseThrow(ElementNotFoundException::new);
     }
 
     @Secured(ROLE_ADMIN)
@@ -118,7 +119,7 @@ public class InjectorContractApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PutMapping("/api/injector_contracts/{injectorContractId}")
     public InjectorContract updateInjectorContract(@PathVariable String injectorContractId, @Valid @RequestBody InjectorContractUpdateInput input) {
-        InjectorContract injectorContract = injectorContractRepository.findById(injectorContractId).orElseThrow();
+        InjectorContract injectorContract = injectorContractRepository.findById(injectorContractId).orElseThrow(ElementNotFoundException::new);
         injectorContract.setUpdateAttributes(input);
         injectorContract.setAttackPatterns(fromIterable(attackPatternRepository.findAllById(input.getAttackPatternsIds())));
         injectorContract.setUpdatedAt(Instant.now());
@@ -128,7 +129,7 @@ public class InjectorContractApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PutMapping("/api/injector_contracts/{injectorContractId}/mapping")
     public InjectorContract updateInjectorContractMapping(@PathVariable String injectorContractId, @Valid @RequestBody InjectorContractUpdateMappingInput input) {
-        InjectorContract injectorContract = injectorContractRepository.findById(injectorContractId).orElseThrow();
+        InjectorContract injectorContract = injectorContractRepository.findById(injectorContractId).orElseThrow(ElementNotFoundException::new);
         injectorContract.setAttackPatterns(fromIterable(attackPatternRepository.findAllById(input.getAttackPatternsIds())));
         injectorContract.setUpdatedAt(Instant.now());
         return injectorContractRepository.save(injectorContract);

--- a/openbas-api/src/main/java/io/openbas/rest/kill_chain_phase/KillChainPhaseApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/kill_chain_phase/KillChainPhaseApi.java
@@ -1,9 +1,8 @@
 package io.openbas.rest.kill_chain_phase;
 
-import io.openbas.database.model.Channel;
 import io.openbas.database.model.KillChainPhase;
 import io.openbas.database.repository.KillChainPhaseRepository;
-import io.openbas.rest.channel.form.ChannelUpdateInput;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.kill_chain_phase.form.KillChainPhaseCreateInput;
 import io.openbas.rest.kill_chain_phase.form.KillChainPhaseUpdateInput;
@@ -54,14 +53,14 @@ public class KillChainPhaseApi extends RestBehavior {
 
   @GetMapping("/api/kill_chain_phases/{killChainPhaseId}")
   public KillChainPhase killChainPhase(@PathVariable String killChainPhaseId) {
-    return killChainPhaseRepository.findById(killChainPhaseId).orElseThrow();
+    return killChainPhaseRepository.findById(killChainPhaseId).orElseThrow(ElementNotFoundException::new);
   }
 
   @Secured(ROLE_ADMIN)
   @PutMapping("/api/kill_chain_phases/{killChainPhaseId}")
   public KillChainPhase updateKillChainPhase(@PathVariable String killChainPhaseId,
       @Valid @RequestBody KillChainPhaseUpdateInput input) {
-    KillChainPhase killchainPhase = killChainPhaseRepository.findById(killChainPhaseId).orElseThrow();
+    KillChainPhase killchainPhase = killChainPhaseRepository.findById(killChainPhaseId).orElseThrow(ElementNotFoundException::new);
     killchainPhase.setUpdateAttributes(input);
     killchainPhase.setUpdatedAt(Instant.now());
     return killChainPhaseRepository.save(killchainPhase);

--- a/openbas-api/src/main/java/io/openbas/rest/lessons/LessonsApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/lessons/LessonsApi.java
@@ -5,14 +5,15 @@ import io.openbas.database.repository.*;
 import io.openbas.database.specification.LessonsAnswerSpecification;
 import io.openbas.database.specification.LessonsCategorySpecification;
 import io.openbas.database.specification.LessonsQuestionSpecification;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.lessons.form.*;
 import io.openbas.service.MailingService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 
@@ -81,8 +82,8 @@ public class LessonsApi extends RestBehavior {
   @PreAuthorize("isExercisePlanner(#exerciseId)")
   public Iterable<LessonsCategory> applyExerciseLessonsTemplate(@PathVariable String exerciseId,
       @PathVariable String lessonsTemplateId) {
-    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
-    LessonsTemplate lessonsTemplate = lessonsTemplateRepository.findById(lessonsTemplateId).orElseThrow();
+    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
+    LessonsTemplate lessonsTemplate = lessonsTemplateRepository.findById(lessonsTemplateId).orElseThrow(ElementNotFoundException::new);
     List<LessonsTemplateCategory> lessonsTemplateCategories = lessonsTemplate.getCategories().stream().toList();
     for (LessonsTemplateCategory lessonsTemplateCategory : lessonsTemplateCategories) {
       LessonsCategory lessonsCategory = new LessonsCategory();
@@ -109,7 +110,7 @@ public class LessonsApi extends RestBehavior {
   @PreAuthorize("isExercisePlanner(#exerciseId)")
   public LessonsCategory createExerciseLessonsCategory(@PathVariable String exerciseId,
       @Valid @RequestBody LessonsCategoryCreateInput input) {
-    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     LessonsCategory lessonsCategory = new LessonsCategory();
     lessonsCategory.setUpdateAttributes(input);
     lessonsCategory.setExercise(exercise);
@@ -145,7 +146,7 @@ public class LessonsApi extends RestBehavior {
   @PreAuthorize("isExercisePlanner(#exerciseId)")
   public LessonsCategory updateExerciseLessonsCategory(@PathVariable String exerciseId,
       @PathVariable String lessonsCategoryId, @Valid @RequestBody LessonsCategoryUpdateInput input) {
-    LessonsCategory lessonsTemplateCategory = lessonsCategoryRepository.findById(lessonsCategoryId).orElseThrow();
+    LessonsCategory lessonsTemplateCategory = lessonsCategoryRepository.findById(lessonsCategoryId).orElseThrow(ElementNotFoundException::new);
     lessonsTemplateCategory.setUpdateAttributes(input);
     lessonsTemplateCategory.setUpdated(now());
     return lessonsCategoryRepository.save(lessonsTemplateCategory);
@@ -161,7 +162,7 @@ public class LessonsApi extends RestBehavior {
   @PreAuthorize("isExercisePlanner(#exerciseId)")
   public LessonsCategory updateExerciseLessonsCategoryTeams(@PathVariable String exerciseId,
       @PathVariable String lessonsCategoryId, @Valid @RequestBody LessonsCategoryTeamsInput input) {
-    LessonsCategory lessonsCategory = lessonsCategoryRepository.findById(lessonsCategoryId).orElseThrow();
+    LessonsCategory lessonsCategory = lessonsCategoryRepository.findById(lessonsCategoryId).orElseThrow(ElementNotFoundException::new);
     Iterable<Team> lessonsCategoryTeams = teamRepository.findAllById(input.getTeamIds());
     lessonsCategory.setTeams(fromIterable(lessonsCategoryTeams));
     return lessonsCategoryRepository.save(lessonsCategory);
@@ -186,7 +187,7 @@ public class LessonsApi extends RestBehavior {
   @PreAuthorize("isExercisePlanner(#exerciseId)")
   public LessonsQuestion createExerciseLessonsQuestion(@PathVariable String exerciseId,
       @PathVariable String lessonsCategoryId, @Valid @RequestBody LessonsQuestionCreateInput input) {
-    LessonsCategory lessonsCategory = lessonsCategoryRepository.findById(lessonsCategoryId).orElseThrow();
+    LessonsCategory lessonsCategory = lessonsCategoryRepository.findById(lessonsCategoryId).orElseThrow(ElementNotFoundException::new);
     LessonsQuestion lessonsQuestion = new LessonsQuestion();
     lessonsQuestion.setUpdateAttributes(input);
     lessonsQuestion.setCategory(lessonsCategory);
@@ -197,7 +198,7 @@ public class LessonsApi extends RestBehavior {
   @PreAuthorize("isExercisePlanner(#exerciseId)")
   public LessonsQuestion updateExerciseLessonsQuestion(@PathVariable String exerciseId,
       @PathVariable String lessonsQuestionId, @Valid @RequestBody LessonsQuestionUpdateInput input) {
-    LessonsQuestion lessonsQuestion = lessonsQuestionRepository.findById(lessonsQuestionId).orElseThrow();
+    LessonsQuestion lessonsQuestion = lessonsQuestionRepository.findById(lessonsQuestionId).orElseThrow(ElementNotFoundException::new);
     lessonsQuestion.setUpdateAttributes(input);
     lessonsQuestion.setUpdated(now());
     return lessonsQuestionRepository.save(lessonsQuestion);
@@ -212,7 +213,7 @@ public class LessonsApi extends RestBehavior {
   @PostMapping("/api/exercises/{exerciseId}/lessons_send")
   @PreAuthorize("isExercisePlanner(#exerciseId)")
   public void sendExerciseLessons(@PathVariable String exerciseId, @Valid @RequestBody LessonsSendInput input) {
-    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     List<LessonsCategory> lessonsCategories = lessonsCategoryRepository.findAll(
         LessonsCategorySpecification.fromExercise(exerciseId)).stream().toList();
     List<User> users = lessonsCategories.stream().flatMap(lessonsCategory -> lessonsCategory.getTeams().stream()
@@ -265,7 +266,7 @@ public class LessonsApi extends RestBehavior {
       @PathVariable String lessonsQuestionId, @Valid @RequestBody LessonsAnswerCreateInput input,
       @RequestParam Optional<String> userId) {
     User user = impersonateUser(userRepository, userId);
-    LessonsQuestion lessonsQuestion = lessonsQuestionRepository.findById(lessonsQuestionId).orElseThrow();
+    LessonsQuestion lessonsQuestion = lessonsQuestionRepository.findById(lessonsQuestionId).orElseThrow(ElementNotFoundException::new);
     LessonsAnswer lessonsAnswer = new LessonsAnswer();
     lessonsAnswer.setQuestion(lessonsQuestion);
     lessonsAnswer.setScore(input.getScore());

--- a/openbas-api/src/main/java/io/openbas/rest/lessons_template/LessonsTemplateApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/lessons_template/LessonsTemplateApi.java
@@ -8,6 +8,7 @@ import io.openbas.database.repository.LessonsTemplateQuestionRepository;
 import io.openbas.database.repository.LessonsTemplateRepository;
 import io.openbas.database.specification.LessonsTemplateCategorySpecification;
 import io.openbas.database.specification.LessonsTemplateQuestionSpecification;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.lessons_template.form.*;
 import jakarta.validation.Valid;
@@ -58,7 +59,7 @@ public class LessonsTemplateApi extends RestBehavior {
     @PutMapping("/api/lessons_templates/{lessonsTemplateId}")
     public LessonsTemplate updateLessonsTemplate(@PathVariable String lessonsTemplateId,
                                                  @Valid @RequestBody LessonsTemplateUpdateInput input) {
-        LessonsTemplate lessonsTemplate = lessonsTemplateRepository.findById(lessonsTemplateId).orElseThrow();
+        LessonsTemplate lessonsTemplate = lessonsTemplateRepository.findById(lessonsTemplateId).orElseThrow(ElementNotFoundException::new);
         lessonsTemplate.setUpdateAttributes(input);
         lessonsTemplate.setUpdated(now());
         return lessonsTemplateRepository.save(lessonsTemplate);
@@ -78,7 +79,7 @@ public class LessonsTemplateApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PostMapping("/api/lessons_templates/{lessonsTemplateId}/lessons_template_categories")
     public LessonsTemplateCategory createLessonsTemplateCategory(@PathVariable String lessonsTemplateId, @Valid @RequestBody LessonsTemplateCategoryCreateInput input) {
-        LessonsTemplate lessonsTemplate = lessonsTemplateRepository.findById(lessonsTemplateId).orElseThrow();
+        LessonsTemplate lessonsTemplate = lessonsTemplateRepository.findById(lessonsTemplateId).orElseThrow(ElementNotFoundException::new);
         LessonsTemplateCategory lessonsTemplateCategory = new LessonsTemplateCategory();
         lessonsTemplateCategory.setUpdateAttributes(input);
         lessonsTemplateCategory.setTemplate(lessonsTemplate);
@@ -88,7 +89,7 @@ public class LessonsTemplateApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PutMapping("/api/lessons_templates/{lessonsTemplateId}/lessons_template_categories/{lessonsTemplateCategoryId}")
     public LessonsTemplateCategory updateLessonsTemplateCategory(@PathVariable String lessonsTemplateCategoryId, @Valid @RequestBody LessonsTemplateCategoryUpdateInput input) {
-        LessonsTemplateCategory lessonsTemplateCategory = lessonsTemplateCategoryRepository.findById(lessonsTemplateCategoryId).orElseThrow();
+        LessonsTemplateCategory lessonsTemplateCategory = lessonsTemplateCategoryRepository.findById(lessonsTemplateCategoryId).orElseThrow(ElementNotFoundException::new);
         lessonsTemplateCategory.setUpdateAttributes(input);
         lessonsTemplateCategory.setUpdated(now());
         return lessonsTemplateCategoryRepository.save(lessonsTemplateCategory);
@@ -114,7 +115,7 @@ public class LessonsTemplateApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PostMapping("/api/lessons_templates/{lessonsTemplateId}/lessons_template_categories/{lessonsTemplateCategoryId}/lessons_template_questions")
     public LessonsTemplateQuestion createLessonsTemplateQuestion(@PathVariable String lessonsTemplateCategoryId, @Valid @RequestBody LessonsTemplateQuestionCreateInput input) {
-        LessonsTemplateCategory lessonsTemplateCategory = lessonsTemplateCategoryRepository.findById(lessonsTemplateCategoryId).orElseThrow();
+        LessonsTemplateCategory lessonsTemplateCategory = lessonsTemplateCategoryRepository.findById(lessonsTemplateCategoryId).orElseThrow(ElementNotFoundException::new);
         LessonsTemplateQuestion lessonsTemplateQuestion = new LessonsTemplateQuestion();
         lessonsTemplateQuestion.setUpdateAttributes(input);
         lessonsTemplateQuestion.setCategory(lessonsTemplateCategory);
@@ -124,7 +125,7 @@ public class LessonsTemplateApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PutMapping("/api/lessons_templates/{lessonsTemplateId}/lessons_template_categories/{lessonsTemplateCategoryId}/lessons_template_questions/{lessonsTemplateQuestionId}")
     public LessonsTemplateQuestion updateLessonsTemplateQuestion(@PathVariable String lessonsTemplateQuestionId, @Valid @RequestBody LessonsTemplateQuestionUpdateInput input) {
-        LessonsTemplateQuestion lessonsTemplateQuestion = lessonsTemplateQuestionRepository.findById(lessonsTemplateQuestionId).orElseThrow();
+        LessonsTemplateQuestion lessonsTemplateQuestion = lessonsTemplateQuestionRepository.findById(lessonsTemplateQuestionId).orElseThrow(ElementNotFoundException::new);
         lessonsTemplateQuestion.setUpdateAttributes(input);
         lessonsTemplateQuestion.setUpdated(now());
         return lessonsTemplateQuestionRepository.save(lessonsTemplateQuestion);

--- a/openbas-api/src/main/java/io/openbas/rest/mitigation/MitigationApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/mitigation/MitigationApi.java
@@ -5,6 +5,7 @@ import io.openbas.database.model.Mitigation;
 import io.openbas.database.repository.AttackPatternRepository;
 import io.openbas.database.repository.MitigationRepository;
 import io.openbas.database.specification.AttackPatternSpecification;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.mitigation.form.MitigationCreateInput;
 import io.openbas.rest.mitigation.form.MitigationUpdateInput;
@@ -64,7 +65,7 @@ public class MitigationApi extends RestBehavior {
 
   @GetMapping("/api/mitigations/{mitigationId}")
   public Mitigation mitigation(@PathVariable String mitigationId) {
-    return mitigationRepository.findById(mitigationId).orElseThrow();
+    return mitigationRepository.findById(mitigationId).orElseThrow(ElementNotFoundException::new);
   }
 
   @Secured(ROLE_ADMIN)
@@ -78,7 +79,7 @@ public class MitigationApi extends RestBehavior {
 
   @GetMapping("/api/mitigations/{mitigationId}/attack_patterns")
   public Iterable<AttackPattern> injectorContracts(@PathVariable String mitigationId) {
-    mitigationRepository.findById(mitigationId).orElseThrow();
+    mitigationRepository.findById(mitigationId).orElseThrow(ElementNotFoundException::new);
     return attackPatternRepository.findAll(AttackPatternSpecification.fromAttackPattern(mitigationId));
   }
 
@@ -87,7 +88,7 @@ public class MitigationApi extends RestBehavior {
   public Mitigation updateMitigation(
       @NotBlank @PathVariable final String mitigationId,
       @Valid @RequestBody MitigationUpdateInput input) {
-    Mitigation mitigation = this.mitigationRepository.findById(mitigationId).orElseThrow();
+    Mitigation mitigation = this.mitigationRepository.findById(mitigationId).orElseThrow(ElementNotFoundException::new);
     mitigation.setUpdateAttributes(input);
     mitigation.setAttackPatterns(fromIterable(this.attackPatternRepository.findAllById(input.getAttackPatternsIds())));
     mitigation.setUpdatedAt(Instant.now());

--- a/openbas-api/src/main/java/io/openbas/rest/objective/ObjectiveApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/objective/ObjectiveApi.java
@@ -9,15 +9,15 @@ import io.openbas.database.repository.ObjectiveRepository;
 import io.openbas.database.repository.UserRepository;
 import io.openbas.database.specification.EvaluationSpecification;
 import io.openbas.database.specification.ObjectiveSpecification;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.objective.form.EvaluationInput;
 import io.openbas.rest.objective.form.ObjectiveInput;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
 
 import static io.openbas.config.SessionHelper.currentUser;
 import static io.openbas.helper.DatabaseHelper.resolveRelation;
@@ -62,7 +62,7 @@ public class ObjectiveApi extends RestBehavior {
   @PreAuthorize("isExercisePlanner(#exerciseId)")
   public Objective createObjective(@PathVariable String exerciseId,
       @Valid @RequestBody ObjectiveInput input) {
-    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     Objective objective = new Objective();
     objective.setUpdateAttributes(input);
     objective.setExercise(exercise);
@@ -74,7 +74,7 @@ public class ObjectiveApi extends RestBehavior {
   public Objective updateObjective(@PathVariable String exerciseId,
       @PathVariable String objectiveId,
       @Valid @RequestBody ObjectiveInput input) {
-    Objective objective = objectiveRepository.findById(objectiveId).orElseThrow();
+    Objective objective = objectiveRepository.findById(objectiveId).orElseThrow(ElementNotFoundException::new);
     objective.setUpdateAttributes(input);
     return objectiveRepository.save(objective);
   }
@@ -90,7 +90,7 @@ public class ObjectiveApi extends RestBehavior {
   @GetMapping("/api/exercises/{exerciseId}/objectives/{objectiveId}/evaluations/{evaluationId}")
   @PreAuthorize("isExerciseObserver(#exerciseId)")
   public Evaluation getEvaluation(@PathVariable String exerciseId, @PathVariable String evaluationId) {
-    return evaluationRepository.findById(evaluationId).orElseThrow();
+    return evaluationRepository.findById(evaluationId).orElseThrow(ElementNotFoundException::new);
   }
 
   @GetMapping("/api/exercises/{exerciseId}/objectives/{objectiveId}/evaluations")
@@ -109,11 +109,11 @@ public class ObjectiveApi extends RestBehavior {
     evaluation.setUpdateAttributes(input);
     Objective objective = resolveRelation(objectiveId, objectiveRepository);
     evaluation.setObjective(objective);
-    evaluation.setUser(userRepository.findById(currentUser().getId()).orElseThrow());
+    evaluation.setUser(userRepository.findById(currentUser().getId()).orElseThrow(ElementNotFoundException::new));
     Evaluation result = evaluationRepository.save(evaluation);
     objective.setUpdatedAt(now());
     objectiveRepository.save(objective);
-    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     exercise.setUpdatedAt(now());
     exerciseRepository.save(exercise);
     return result;
@@ -125,13 +125,13 @@ public class ObjectiveApi extends RestBehavior {
       @PathVariable String objectiveId,
       @PathVariable String evaluationId,
       @Valid @RequestBody EvaluationInput input) {
-    Evaluation evaluation = evaluationRepository.findById(evaluationId).orElseThrow();
+    Evaluation evaluation = evaluationRepository.findById(evaluationId).orElseThrow(ElementNotFoundException::new);
     evaluation.setUpdateAttributes(input);
     Evaluation result = evaluationRepository.save(evaluation);
-    Objective objective = objectiveRepository.findById(objectiveId).orElseThrow();
+    Objective objective = objectiveRepository.findById(objectiveId).orElseThrow(ElementNotFoundException::new);
     objective.setUpdatedAt(now());
     objectiveRepository.save(objective);
-    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     exercise.setUpdatedAt(now());
     exerciseRepository.save(exercise);
     return result;

--- a/openbas-api/src/main/java/io/openbas/rest/organization/OrganizationApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/organization/OrganizationApi.java
@@ -8,6 +8,7 @@ import io.openbas.database.repository.InjectRepository;
 import io.openbas.database.repository.OrganizationRepository;
 import io.openbas.database.repository.TagRepository;
 import io.openbas.database.repository.UserRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.organization.form.OrganizationCreateInput;
 import io.openbas.rest.organization.form.OrganizationUpdateInput;
@@ -60,7 +61,7 @@ public class OrganizationApi extends RestBehavior {
     if (currentUser.isAdmin()) {
       organizations = fromIterable(organizationRepository.findAll());
     } else {
-      User local = userRepository.findById(currentUser.getId()).orElseThrow();
+      User local = userRepository.findById(currentUser.getId()).orElseThrow(ElementNotFoundException::new);
       organizations = local.getGroups().stream()
           .flatMap(group -> group.getOrganizations().stream()).toList();
     }
@@ -82,7 +83,7 @@ public class OrganizationApi extends RestBehavior {
   public Organization updateOrganization(@PathVariable String organizationId,
       @Valid @RequestBody OrganizationUpdateInput input) {
     checkOrganizationAccess(userRepository, organizationId);
-    Organization organization = organizationRepository.findById(organizationId).orElseThrow();
+    Organization organization = organizationRepository.findById(organizationId).orElseThrow(ElementNotFoundException::new);
     organization.setUpdateAttributes(input);
     organization.setUpdatedAt(now());
     organization.setTags(fromIterable(tagRepository.findAllById(input.getTagIds())));

--- a/openbas-api/src/main/java/io/openbas/rest/payload/PayloadApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/payload/PayloadApi.java
@@ -3,6 +3,7 @@ package io.openbas.rest.payload;
 import io.openbas.database.model.Payload;
 import io.openbas.database.repository.PayloadRepository;
 import io.openbas.database.repository.TagRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.payload.form.PayloadCreateInput;
 import io.openbas.rest.payload.form.PayloadUpdateInput;
@@ -58,7 +59,7 @@ public class PayloadApi extends RestBehavior {
 
     @GetMapping("/api/payloads/{payloadId}")
     public Payload payload(@PathVariable String payloadId) {
-        return payloadRepository.findById(payloadId).orElseThrow();
+        return payloadRepository.findById(payloadId).orElseThrow(ElementNotFoundException::new);
     }
 
     @PostMapping("/api/payloads")
@@ -75,7 +76,7 @@ public class PayloadApi extends RestBehavior {
     public Payload updatePayload(
             @NotBlank @PathVariable final String payloadId,
             @Valid @RequestBody PayloadUpdateInput input) {
-        Payload payload = this.payloadRepository.findById(payloadId).orElseThrow();
+        Payload payload = this.payloadRepository.findById(payloadId).orElseThrow(ElementNotFoundException::new);
         payload.setUpdateAttributes(input);
         payload.setTags(fromIterable(tagRepository.findAllById(input.getTagIds())));
         payload.setUpdatedAt(Instant.now());

--- a/openbas-api/src/main/java/io/openbas/rest/report/ReportApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/report/ReportApi.java
@@ -1,16 +1,18 @@
 package io.openbas.rest.report;
 
-import io.openbas.database.model.*;
-import io.openbas.database.repository.*;
+import io.openbas.database.model.Exercise;
+import io.openbas.database.model.Report;
+import io.openbas.database.repository.ExerciseRepository;
+import io.openbas.database.repository.ReportRepository;
 import io.openbas.database.specification.ReportSpecification;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.report.form.ReportCreateInput;
 import io.openbas.rest.report.form.ReportUpdateInput;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import jakarta.validation.Valid;
 
 import static java.time.Instant.now;
 
@@ -39,7 +41,7 @@ public class ReportApi extends RestBehavior {
     @PostMapping("/api/exercises/{exerciseId}/reports")
     @PreAuthorize("isExercisePlanner(#exerciseId)")
     public Report createExerciseReport(@PathVariable String exerciseId, @Valid @RequestBody ReportCreateInput input) {
-        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
         Report report = new Report();
         report.setUpdateAttributes(input);
         report.setExercise(exercise);
@@ -49,7 +51,7 @@ public class ReportApi extends RestBehavior {
     @PutMapping("/api/exercises/{exerciseId}/reports/{reportId}")
     @PreAuthorize("isExercisePlanner(#exerciseId)")
     public Report updateExerciseReport(@PathVariable String exerciseId,@PathVariable String reportId, @Valid @RequestBody ReportUpdateInput input) {
-        Report report = reportRepository.findById(reportId).orElseThrow();
+        Report report = reportRepository.findById(reportId).orElseThrow(ElementNotFoundException::new);
         report.setUpdateAttributes(input);
         report.setUpdated(now());
         return reportRepository.save(report);

--- a/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
@@ -6,6 +6,7 @@ import io.openbas.database.model.User;
 import io.openbas.database.repository.TagRepository;
 import io.openbas.database.repository.TeamRepository;
 import io.openbas.database.repository.UserRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.exercise.form.ExerciseSimple;
 import io.openbas.rest.exercise.form.ScenarioTeamPlayersEnableInput;
 import io.openbas.rest.scenario.form.*;
@@ -213,7 +214,7 @@ public class ScenarioApi {
       @PathVariable @NotBlank final String scenarioId,
       @PathVariable @NotBlank final String teamId,
       @Valid @RequestBody final ScenarioTeamPlayersEnableInput input) {
-    Team team = teamRepository.findById(teamId).orElseThrow();
+    Team team = teamRepository.findById(teamId).orElseThrow(ElementNotFoundException::new);
     Iterable<User> teamUsers = userRepository.findAllById(input.getPlayersIds());
     team.getUsers().addAll(fromIterable(teamUsers));
     teamRepository.save(team);
@@ -227,7 +228,7 @@ public class ScenarioApi {
       @PathVariable @NotBlank final String scenarioId,
       @PathVariable @NotBlank final String teamId,
       @Valid @RequestBody final ScenarioTeamPlayersEnableInput input) {
-    Team team = teamRepository.findById(teamId).orElseThrow();
+    Team team = teamRepository.findById(teamId).orElseThrow(ElementNotFoundException::new);
     Iterable<User> teamUsers = userRepository.findAllById(input.getPlayersIds());
     team.getUsers().removeAll(fromIterable(teamUsers));
     teamRepository.save(team);

--- a/openbas-api/src/main/java/io/openbas/rest/tag/TagApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/tag/TagApi.java
@@ -1,8 +1,8 @@
 package io.openbas.rest.tag;
 
-import io.openbas.database.model.KillChainPhase;
 import io.openbas.database.model.Tag;
 import io.openbas.database.repository.TagRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.tag.form.TagCreateInput;
 import io.openbas.rest.tag.form.TagUpdateInput;
@@ -49,7 +49,7 @@ public class TagApi extends RestBehavior {
     @PutMapping("/api/tags/{tagId}")
     public Tag updateTag(@PathVariable String tagId,
                          @Valid @RequestBody TagUpdateInput input) {
-        Tag tag = tagRepository.findById(tagId).orElseThrow();
+        Tag tag = tagRepository.findById(tagId).orElseThrow(ElementNotFoundException::new);
         tag.setUpdateAttributes(input);
         return tagRepository.save(tag);
     }

--- a/openbas-api/src/main/java/io/openbas/rest/user/MeApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/user/MeApi.java
@@ -6,6 +6,7 @@ import io.openbas.database.model.User;
 import io.openbas.database.repository.OrganizationRepository;
 import io.openbas.database.repository.TokenRepository;
 import io.openbas.database.repository.UserRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.exception.InputValidationException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.user.form.me.UpdateMePasswordInput;
@@ -70,13 +71,13 @@ public class MeApi extends RestBehavior {
   @Secured(ROLE_USER)
   @GetMapping("/api/me")
   public User me() {
-    return userRepository.findById(currentUser().getId()).orElseThrow();
+    return userRepository.findById(currentUser().getId()).orElseThrow(ElementNotFoundException::new);
   }
 
   @Secured(ROLE_USER)
   @PutMapping("/api/me/profile")
   public User updateProfile(@Valid @RequestBody UpdateProfileInput input) {
-    User user = userRepository.findById(currentUser().getId()).orElseThrow();
+    User user = userRepository.findById(currentUser().getId()).orElseThrow(ElementNotFoundException::new);
     user.setUpdateAttributes(input);
     user.setOrganization(updateRelation(input.getOrganizationId(), user.getOrganization(), organizationRepository));
     User savedUser = userRepository.save(user);
@@ -87,7 +88,7 @@ public class MeApi extends RestBehavior {
   @Secured(ROLE_USER)
   @PutMapping("/api/me/information")
   public User updateInformation(@Valid @RequestBody UpdateUserInfoInput input) {
-    User user = userRepository.findById(currentUser().getId()).orElseThrow();
+    User user = userRepository.findById(currentUser().getId()).orElseThrow(ElementNotFoundException::new);
     user.setUpdateAttributes(input);
     User savedUser = userRepository.save(user);
     sessionManager.refreshUserSessions(savedUser);
@@ -97,7 +98,7 @@ public class MeApi extends RestBehavior {
   @Secured(ROLE_USER)
   @PutMapping("/api/me/password")
   public User updatePassword(@Valid @RequestBody UpdateMePasswordInput input) throws InputValidationException {
-    User user = userRepository.findById(currentUser().getId()).orElseThrow();
+    User user = userRepository.findById(currentUser().getId()).orElseThrow(ElementNotFoundException::new);
     if (userService.isUserPasswordValid(user, input.getCurrentPassword())) {
       user.setPassword(userService.encodeUserPassword(input.getPassword()));
       return userRepository.save(user);
@@ -110,8 +111,8 @@ public class MeApi extends RestBehavior {
   @PostMapping("/api/me/token/refresh")
   @Transactional(rollbackOn = Exception.class)
   public Token renewToken(@Valid @RequestBody RenewTokenInput input) throws InputValidationException {
-    User user = userRepository.findById(currentUser().getId()).orElseThrow();
-    Token token = tokenRepository.findById(input.getTokenId()).orElseThrow();
+    User user = userRepository.findById(currentUser().getId()).orElseThrow(ElementNotFoundException::new);
+    Token token = tokenRepository.findById(input.getTokenId()).orElseThrow(ElementNotFoundException::new);
     if (!user.equals(token.getUser())) {
       throw new AccessDeniedException("You are not allowed to renew this token");
     }

--- a/openbas-api/src/main/java/io/openbas/rest/user/PlayerApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/user/PlayerApi.java
@@ -4,6 +4,7 @@ import io.openbas.config.OpenBASPrincipal;
 import io.openbas.config.SessionManager;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.*;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.user.form.player.CreatePlayerInput;
 import io.openbas.rest.user.form.player.UpdatePlayerInput;
@@ -84,7 +85,7 @@ public class PlayerApi extends RestBehavior {
     if (currentUser.isAdmin()) {
       players = fromIterable(userRepository.findAll());
     } else {
-      User local = userRepository.findById(currentUser.getId()).orElseThrow();
+      User local = userRepository.findById(currentUser.getId()).orElseThrow(ElementNotFoundException::new);
       List<String> organizationIds = local.getGroups().stream()
           .flatMap(group -> group.getOrganizations().stream())
           .map(Organization::getId)
@@ -102,7 +103,7 @@ public class PlayerApi extends RestBehavior {
       playersFunction = (Specification<User> specification, Pageable pageable) -> this.userRepository
           .findAll(specification, pageable);
     } else {
-      User local = userRepository.findById(currentUser.getId()).orElseThrow();
+      User local = userRepository.findById(currentUser.getId()).orElseThrow(ElementNotFoundException::new);
       List<String> organizationIds = local.getGroups().stream()
           .flatMap(group -> group.getOrganizations().stream())
           .map(Organization::getId)
@@ -176,7 +177,7 @@ public class PlayerApi extends RestBehavior {
   @PreAuthorize("isPlanner()")
   public User updatePlayer(@PathVariable String userId, @Valid @RequestBody UpdatePlayerInput input) {
     checkUserAccess(userRepository, userId);
-    User user = userRepository.findById(userId).orElseThrow();
+    User user = userRepository.findById(userId).orElseThrow(ElementNotFoundException::new);
     if (!currentUser().isAdmin() && user.isManager() && !currentUser().getId().equals(userId)) {
       throw new UnsupportedOperationException("You dont have the right to update this user");
     }
@@ -190,7 +191,7 @@ public class PlayerApi extends RestBehavior {
   @PreAuthorize("isPlanner()")
   public void deletePlayer(@PathVariable String userId) {
     checkUserAccess(userRepository, userId);
-    User user = userRepository.findById(userId).orElseThrow();
+    User user = userRepository.findById(userId).orElseThrow(ElementNotFoundException::new);
     if (!currentUser().isAdmin() && user.isManager()) {
       throw new UnsupportedOperationException("You dont have the right to delete this user");
     }

--- a/openbas-api/src/main/java/io/openbas/rest/user/UserApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/user/UserApi.java
@@ -5,6 +5,7 @@ import io.openbas.database.model.User;
 import io.openbas.database.repository.OrganizationRepository;
 import io.openbas.database.repository.TagRepository;
 import io.openbas.database.repository.UserRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.exception.InputValidationException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.user.form.login.LoginUserInput;
@@ -119,7 +120,7 @@ public class UserApi extends RestBehavior {
             if (!passwordValidation.equals(password)) {
                 throw new InputValidationException("password_validation", "Bad password validation");
             }
-            User changeUser = userRepository.findById(userId).orElseThrow();
+            User changeUser = userRepository.findById(userId).orElseThrow(ElementNotFoundException::new);
             changeUser.setPassword(userService.encodeUserPassword(password));
             User savedUser = userRepository.save(changeUser);
             resetTokenMap.remove(token);
@@ -154,7 +155,7 @@ public class UserApi extends RestBehavior {
     @PutMapping("/api/users/{userId}/password")
     public User changePassword(@PathVariable String userId,
                                @Valid @RequestBody ChangePasswordInput input) {
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow(ElementNotFoundException::new);
         user.setPassword(userService.encodeUserPassword(input.getPassword()));
         return userRepository.save(user);
     }
@@ -169,7 +170,7 @@ public class UserApi extends RestBehavior {
     @Secured(ROLE_ADMIN)
     @PutMapping("/api/users/{userId}")
     public User updateUser(@PathVariable String userId, @Valid @RequestBody UpdateUserInput input) {
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow(ElementNotFoundException::new);
         user.setUpdateAttributes(input);
         user.setTags(fromIterable(tagRepository.findAllById(input.getTagIds())));
         user.setOrganization(updateRelation(input.getOrganizationId(), user.getOrganization(), organizationRepository));

--- a/openbas-api/src/main/java/io/openbas/rest/variable/VariableApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/variable/VariableApi.java
@@ -4,6 +4,7 @@ import io.openbas.database.model.Exercise;
 import io.openbas.database.model.Scenario;
 import io.openbas.database.model.Variable;
 import io.openbas.database.repository.ExerciseRepository;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.variable.form.VariableInput;
 import io.openbas.service.ScenarioService;
@@ -39,7 +40,7 @@ public class VariableApi extends RestBehavior {
       @Valid @RequestBody final VariableInput input) {
     Variable variable = new Variable();
     variable.setUpdateAttributes(input);
-    Exercise exercise = this.exerciseRepository.findById(exerciseId).orElseThrow();
+    Exercise exercise = this.exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     variable.setExercise(exercise);
     return this.variableService.createVariable(variable);
   }

--- a/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
@@ -5,6 +5,7 @@ import io.openbas.config.OpenBASConfig;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.*;
 import io.openbas.database.specification.ScenarioSpecification;
+import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.exercise.exports.ExerciseExportMixins;
 import io.openbas.rest.exercise.exports.ExerciseFileExport;
 import io.openbas.rest.exercise.exports.VariableMixin;
@@ -127,12 +128,12 @@ public class ScenarioService {
 
   public Scenario scenario(@NotBlank final String scenarioId) {
     return this.scenarioRepository.findById(scenarioId)
-        .orElseThrow(() -> new IllegalStateException("Scenario not found"));
+        .orElseThrow(() -> new ElementNotFoundException("Scenario not found"));
   }
 
   public Scenario scenarioByExternalReference(@NotBlank final String scenarioExternalReference) {
     return this.scenarioRepository.findByExternalReference(scenarioExternalReference)
-            .orElseThrow(() -> new IllegalStateException("Scenario not found"));
+            .orElseThrow(() -> new ElementNotFoundException("Scenario not found"));
   }
   public Scenario updateScenario(@NotNull final Scenario scenario) {
     scenario.setUpdatedAt(now());


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Instead of raising IllegalStateException or the generic NoSuchElementException, we're raising a custom defined Exception to keep the hand on where it is raised
* Adding a global exception handler to take care of the new exception and return a proper 404. The handler could be extended to add more intel when an exception is raised.

### Related issues

* issue #867 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

