### PR TITLE
[backend] Change external reference resolution for OpenCTI integration

### DIFF
--- a/openbas-api/src/main/java/io/openbas/opencti/OpenCTIApi.java
+++ b/openbas-api/src/main/java/io/openbas/opencti/OpenCTIApi.java
@@ -1,0 +1,43 @@
+package io.openbas.opencti;
+
+import io.openbas.database.model.Exercise;
+import io.openbas.rest.exercise.form.ExerciseSimple;
+import io.openbas.service.ScenarioService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import static io.openbas.database.model.User.ROLE_USER;
+
+@RequiredArgsConstructor
+@RestController
+@Secured(ROLE_USER)
+public class OpenCTIApi {
+
+  public static final String OPENCTI_URI = "/api/opencti/v1";
+
+  private final ScenarioService scenarioService;
+
+  @Operation(summary = "Retrieve the latest exercise by external reference ID (example: a report ID")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Found the exercise",
+          content = {
+              @Content(mediaType = "application/json", schema = @Schema(implementation = ExerciseSimple.class))
+          }),
+      @ApiResponse(responseCode = "404", description = "Exercise not found", content = @Content)
+  })
+  @GetMapping(OPENCTI_URI + "/exercises/latest/{externalReferenceId}")
+  public ExerciseSimple latestExerciseByExternalReference(@PathVariable @NotBlank final String externalReferenceId) {
+    Exercise exercise = this.scenarioService.latestExerciseByExternalReference(externalReferenceId);
+    return ExerciseSimple.fromExercise(exercise);
+  }
+
+}

--- a/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
@@ -1,9 +1,6 @@
 package io.openbas.rest.scenario;
 
-import io.openbas.database.model.Scenario;
-import io.openbas.database.model.Team;
-import io.openbas.database.model.TeamSimple;
-import io.openbas.database.model.User;
+import io.openbas.database.model.*;
 import io.openbas.database.raw.RawPaginationScenario;
 import io.openbas.database.repository.*;
 import io.openbas.rest.exception.ElementNotFoundException;
@@ -108,11 +105,6 @@ public class ScenarioApi {
     return scenarioService.scenario(scenarioId);
   }
 
-  @GetMapping(SCENARIO_URI + "/external_reference/{externalReferenceId}")
-  public Scenario scenarioByExternalId(@PathVariable @NotBlank final String externalReferenceId) {
-    return scenarioService.scenarioByExternalReference(externalReferenceId);
-  }
-
   @PutMapping(SCENARIO_URI + "/{scenarioId}")
   @PreAuthorize("isScenarioPlanner(#scenarioId)")
   public Scenario updateScenario(
@@ -176,7 +168,6 @@ public class ScenarioApi {
 
   // -- SIMULATION --
 
-  // region scenarios
   @GetMapping(SCENARIO_URI + "/{scenarioId}/exercises")
   @PreAuthorize("isScenarioObserver(#scenarioId)")
   public Iterable<ExerciseSimple> scenarioExercises(@PathVariable @NotBlank final String scenarioId) {
@@ -184,7 +175,11 @@ public class ScenarioApi {
     return scenario.getExercises().stream().map(ExerciseSimple::fromExercise).toList();
   }
 
-  // endregion
+  @GetMapping(SCENARIO_URI + "/external_reference/{externalReferenceId}")
+  public ExerciseSimple latestExerciseByExternalReference(@PathVariable @NotBlank final String externalReferenceId) {
+    Exercise exercise = this.scenarioService.latestExerciseByExternalReference(externalReferenceId);
+    return ExerciseSimple.fromExercise(exercise);
+  }
 
   // -- TEAMS --
 

--- a/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
@@ -175,12 +175,6 @@ public class ScenarioApi {
     return scenario.getExercises().stream().map(ExerciseSimple::fromExercise).toList();
   }
 
-  @GetMapping(SCENARIO_URI + "/external_reference/{externalReferenceId}")
-  public ExerciseSimple latestExerciseByExternalReference(@PathVariable @NotBlank final String externalReferenceId) {
-    Exercise exercise = this.scenarioService.latestExerciseByExternalReference(externalReferenceId);
-    return ExerciseSimple.fromExercise(exercise);
-  }
-
   // -- TEAMS --
 
   @Transactional(rollbackOn = Exception.class)

--- a/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
@@ -234,7 +234,7 @@ public class ScenarioService {
     if (latestEndedExercise.isPresent()) {
       return latestEndedExercise.get();
     } else {
-      throw new ElementNotFoundException("Most recent simulation not found");
+      throw new ElementNotFoundException("Latest exercise not found");
     }
   }
 

--- a/openbas-api/src/main/java/io/openbas/utils/ResultUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/ResultUtils.java
@@ -1,9 +1,11 @@
 package io.openbas.utils;
 
-import io.openbas.utils.AtomicTestingMapper.ExpectationResultsByType;
+import io.openbas.database.model.AttackPattern;
+import io.openbas.database.model.Inject;
+import io.openbas.database.model.InjectExpectation;
 import io.openbas.rest.atomic_testing.form.InjectTargetWithResult;
-import io.openbas.database.model.*;
 import io.openbas.rest.inject.form.InjectExpectationResultsByAttackPattern;
+import io.openbas.utils.AtomicTestingMapper.ExpectationResultsByType;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
@@ -14,41 +16,45 @@ import static io.openbas.utils.AtomicTestingUtils.getTargetsWithResults;
 
 public class ResultUtils {
 
-    // -- GLOBAL SCORE --
+  private ResultUtils() {
+  }
 
-    public static List<ExpectationResultsByType> computeGlobalExpectationResults(@NotNull final List<Inject> injects) {
-        List<InjectExpectation> expectations = injects
-                .stream()
-                .flatMap((inject) -> inject.getExpectations().stream())
-                .toList();
-        return AtomicTestingUtils.getExpectationResultByTypes(expectations);
-    }
+  // -- GLOBAL SCORE --
 
-    public static List<InjectExpectationResultsByAttackPattern> computeInjectExpectationResults(@NotNull final List<Inject> injects) {
-        Map<AttackPattern, List<Inject>> groupedByAttackPattern = injects.stream()
-                .flatMap((inject) -> inject.getInjectorContract()
-                        .getAttackPatterns()
-                        .stream()
-                        .map(attackPattern -> Map.entry(attackPattern, inject))
-                )
-                .collect(Collectors.groupingBy(
-                        java.util.Map.Entry::getKey,
-                        Collectors.mapping(java.util.Map.Entry::getValue, Collectors.toList())
-                ));
+  public static List<ExpectationResultsByType> computeGlobalExpectationResults(@NotNull final List<Inject> injects) {
+    List<InjectExpectation> expectations = injects
+        .stream()
+        .flatMap(inject -> inject.getExpectations().stream())
+        .toList();
+    return AtomicTestingUtils.getExpectationResultByTypes(expectations);
+  }
 
-        return groupedByAttackPattern.entrySet()
-                .stream()
-                .map(entry -> new InjectExpectationResultsByAttackPattern(entry.getKey(), entry.getValue()))
-                .toList();
-    }
+  public static List<InjectExpectationResultsByAttackPattern> computeInjectExpectationResults(
+      @NotNull final List<Inject> injects) {
+    Map<AttackPattern, List<Inject>> groupedByAttackPattern = injects.stream()
+        .flatMap(inject -> inject.getInjectorContract()
+            .getAttackPatterns()
+            .stream()
+            .map(attackPattern -> Map.entry(attackPattern, inject))
+        )
+        .collect(Collectors.groupingBy(
+            java.util.Map.Entry::getKey,
+            Collectors.mapping(java.util.Map.Entry::getValue, Collectors.toList())
+        ));
 
-    // -- TARGET --
+    return groupedByAttackPattern.entrySet()
+        .stream()
+        .map(entry -> new InjectExpectationResultsByAttackPattern(entry.getKey(), entry.getValue()))
+        .toList();
+  }
 
-    public static List<InjectTargetWithResult> computeTargetResults(@NotNull final List<Inject> injects) {
-        return injects.stream()
-                .flatMap((inject) -> getTargetsWithResults(inject).stream())
-                .distinct()
-                .toList();
-    }
+  // -- TARGET --
+
+  public static List<InjectTargetWithResult> computeTargetResults(@NotNull final List<Inject> injects) {
+    return injects.stream()
+        .flatMap(inject -> getTargetsWithResults(inject).stream())
+        .distinct()
+        .toList();
+  }
 
 }

--- a/openbas-model/src/main/java/io/openbas/database/repository/ScenarioRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/ScenarioRepository.java
@@ -22,7 +22,7 @@ public interface ScenarioRepository extends CrudRepository<Scenario, String>,
     JpaSpecificationExecutor<Scenario> {
 
   @NotNull
-  List<Scenario> findByExternalReference(@Param("externalReference") String externalReference);
+  List<Scenario> findByExternalReference(@Param("externalReference") final String externalReference);
 
   @Query("select distinct s from Scenario s " +
       "join s.grants as grant " +


### PR DESCRIPTION
### Proposed changes

OpenCTI should get the latest ended simulation based on scenarios instead of the latest simulation based on the first scenario.

### Related issues

* https://github.com/OpenBAS-Platform/openbas/issues/1047
*

### Testing

- Generate a scenario from OpenCTI to OpenBAS
- Launch a simulation with some expectations
- Wait for the end of this simulation
- Go to opencti and checked that the security posture is the same as that on OpenBAS
- Re launch the simulation, change the expectation result and verify the new posture in both platform

OpenCTI PR -> https://github.com/OpenCTI-Platform/opencti/pull/7233