### PR TITLE
[backend] Add dynamic assets as children in group asset if applicable (#1055)

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
@@ -6,7 +6,6 @@ import io.openbas.inject_expectation.InjectExpectationService;
 import io.openbas.rest.atomic_testing.form.AtomicTestingInput;
 import io.openbas.rest.atomic_testing.form.AtomicTestingUpdateTagsInput;
 import io.openbas.rest.atomic_testing.form.InjectResultDTO;
-import io.openbas.rest.exception.ElementNotFoundException;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.inject.output.AtomicTestingOutput;
 import io.openbas.service.AtomicTestingService;
@@ -42,9 +41,7 @@ public class AtomicTestingApi extends RestBehavior {
 
   @GetMapping("/{injectId}")
   public InjectResultDTO findAtomicTesting(@PathVariable String injectId) {
-    return atomicTestingService.findById(injectId)
-        .map(AtomicTestingMapper::toDtoWithTargetResults)
-        .orElseThrow(ElementNotFoundException::new);
+    return atomicTestingService.findById(injectId);
   }
 
   @PostMapping()

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
@@ -229,7 +229,7 @@ const AtomicTesting = () => {
                     <TargetListItem onClick={handleTargetClick} target={target} selected={selectedTarget?.id === target.id} />
                     <List component="div" disablePadding>
                       {target?.children?.map((child) => (
-                        <TargetListItem key={child?.id} isChild onClick={handleTargetClick} target={child} selected={selectedTarget?.id === target.id} />
+                        <TargetListItem key={child?.id} isChild onClick={handleTargetClick} target={child} selected={selectedTarget?.id === child.id} />
                       ))}
                     </List>
                   </div>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Dynamic assets are added into asset group: all machine (depending on filter):
* ![image](https://github.com/OpenBAS-Platform/openbas/assets/4162296/716aca35-8fef-4c4c-8afc-ef6f7af6cd4b)
* ![image](https://github.com/OpenBAS-Platform/openbas/assets/4162296/cddb00f0-6e59-4ef4-8797-6ee3fbd059a9)

### Related issues

* https://github.com/OpenBAS-Platform/openbas/issues/1055
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
