### PR TITLE
[backend] Change trace level when store message in imap

### DIFF
--- a/openbas-api/src/main/java/io/openbas/injectors/email/service/EmailService.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/email/service/EmailService.java
@@ -20,8 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.openbas.database.model.InjectStatusExecution.traceError;
-import static io.openbas.database.model.InjectStatusExecution.traceSuccess;
+import static io.openbas.database.model.InjectStatusExecution.*;
 import static io.openbas.helper.TemplateHelper.buildContextualContent;
 import static java.util.stream.Collectors.joining;
 
@@ -106,7 +105,7 @@ public class EmailService {
                     execution.addTrace(traceSuccess("Mail successfully stored in IMAP"));
                     return;
                 } catch (Exception e) {
-                    execution.addTrace(traceError("Fail to store mail in IMAP" + e.getMessage()));
+                    execution.addTrace(traceInfo("Fail to store mail in IMAP" + e.getMessage()));
                     Thread.sleep(2000);
                 }
             }


### PR DESCRIPTION
The current mechanism allows us to make three attempts to store messages in the imap.

But by setting the traces to error, the status changes to partial, even if after the third attempt the storage is done.
By passing the trace into info, we make sure to keep the status close to reality.