### PR TITLE
[frontend] Add validation mode to manual expectations

### DIFF
--- a/openbas-api/src/main/java/io/openbas/helper/InjectHelper.java
+++ b/openbas-api/src/main/java/io/openbas/helper/InjectHelper.java
@@ -41,7 +41,7 @@ public class InjectHelper {
 
   private List<Team> getInjectTeams(@NotNull final Inject inject) {
     Exercise exercise = inject.getExercise();
-    if(inject.isAllTeams()) {
+    if(inject.isAllTeams()) { // In order to process expectations from players, we also need to load players into teams
       exercise.getTeams().forEach(team -> Hibernate.initialize(team.getUsers()));
       return exercise.getTeams();
     } else {

--- a/openbas-api/src/main/java/io/openbas/helper/InjectHelper.java
+++ b/openbas-api/src/main/java/io/openbas/helper/InjectHelper.java
@@ -41,7 +41,13 @@ public class InjectHelper {
 
   private List<Team> getInjectTeams(@NotNull final Inject inject) {
     Exercise exercise = inject.getExercise();
-    return inject.isAllTeams() ? exercise.getTeams() : inject.getTeams();
+    if(inject.isAllTeams()) {
+      exercise.getTeams().forEach(team -> Hibernate.initialize(team.getUsers()));
+      return exercise.getTeams();
+    } else {
+      inject.getTeams().forEach(team -> Hibernate.initialize(team.getUsers()));
+      return inject.getTeams();
+    }
   }
 
   // -- INJECTION --

--- a/openbas-api/src/main/java/io/openbas/importer/V1_DataImporter.java
+++ b/openbas-api/src/main/java/io/openbas/importer/V1_DataImporter.java
@@ -558,7 +558,7 @@ public class V1_DataImporter implements Importer {
     challenge.setName(nodeChallenge.get("challenge_name").textValue());
     challenge.setCategory(nodeChallenge.get("challenge_category").textValue());
     challenge.setContent(nodeChallenge.get("challenge_content").textValue());
-    challenge.setScore(nodeChallenge.get("challenge_score").asInt(0));
+    challenge.setScore(nodeChallenge.get("challenge_score").asDouble(0.0));
     challenge.setMaxAttempts(nodeChallenge.get("challenge_max_attempts").asInt(0));
     challenge.setDocuments(
         resolveJsonIds(nodeChallenge, "challenge_documents")

--- a/openbas-api/src/main/java/io/openbas/injectors/caldera/CalderaContract.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/caldera/CalderaContract.java
@@ -87,12 +87,12 @@ public class CalderaContract extends Contractor {
         Expectation preventionExpectation = new Expectation();
         preventionExpectation.setType(PREVENTION);
         preventionExpectation.setName("Expect inject to be prevented");
-        preventionExpectation.setScore(100);
+        preventionExpectation.setScore(100.0);
         // Detection
         Expectation detectionExpectation = new Expectation();
         detectionExpectation.setType(DETECTION);
         detectionExpectation.setName("Expect inject to be detected");
-        detectionExpectation.setScore(100);
+        detectionExpectation.setScore(100.0);
         return expectationsField("expectations", "Expectations", List.of(preventionExpectation, detectionExpectation));
     }
 

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeContract.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeContract.java
@@ -65,6 +65,7 @@ public class ChallengeContract extends Contractor {
                     Kind regards,<br />
                     The animation team
                 """;
+        // We include the expectations for challenges
         Expectation expectation = new Expectation();
         expectation.setType(CHALLENGE);
         expectation.setName("Expect targets to complete the challenge(s)");

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeContract.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeContract.java
@@ -67,7 +67,7 @@ public class ChallengeContract extends Contractor {
                 """;
         Expectation expectation = new Expectation();
         expectation.setType(CHALLENGE);
-        expectation.setName("Expect teams to finish the challenge(s)");
+        expectation.setName("Expect targets to complete the challenge(s)");
         expectation.setScore(0.0);
         ContractExpectations expectationsField = expectationsField(
                 "expectations", "Expectations", List.of(expectation)

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeContract.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeContract.java
@@ -6,17 +6,21 @@ import io.openbas.injector_contract.Contractor;
 import io.openbas.injector_contract.ContractorIcon;
 import io.openbas.injector_contract.fields.ContractElement;
 import io.openbas.database.model.Endpoint;
+import io.openbas.injector_contract.fields.ContractExpectations;
+import io.openbas.model.inject.form.Expectation;
 import org.springframework.stereotype.Component;
 
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
+import static io.openbas.database.model.InjectExpectation.EXPECTATION_TYPE.CHALLENGE;
 import static io.openbas.injector_contract.Contract.executableContract;
 import static io.openbas.injector_contract.ContractCardinality.Multiple;
 import static io.openbas.injector_contract.ContractDef.contractBuilder;
 import static io.openbas.injector_contract.fields.ContractChallenge.challengeField;
 import static io.openbas.injector_contract.fields.ContractAttachment.attachmentField;
+import static io.openbas.injector_contract.fields.ContractExpectations.expectationsField;
 import static io.openbas.injector_contract.fields.ContractTeam.teamField;
 import static io.openbas.injector_contract.fields.ContractCheckbox.checkboxField;
 import static io.openbas.injector_contract.fields.ContractText.textField;
@@ -61,8 +65,17 @@ public class ChallengeContract extends Contractor {
                     Kind regards,<br />
                     The animation team
                 """;
+        Expectation expectation = new Expectation();
+        expectation.setType(CHALLENGE);
+        expectation.setName("Expect teams to finish the challenge(s)");
+        expectation.setScore(0.0);
+        ContractExpectations expectationsField = expectationsField(
+                "expectations", "Expectations", List.of(expectation)
+        );
         List<ContractElement> publishInstance = contractBuilder()
                 .mandatory(challengeField("challenges", "Challenges", Multiple))
+                // Contract specific
+                .optional(expectationsField)
                 .mandatory(textField("subject", "Subject", "New challenges published for ${user.email}"))
                 .mandatory(richTextareaField("body", "Body", messageBody))
                 .optional(checkboxField("encrypted", "Encrypted", false))

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
@@ -102,7 +102,7 @@ public class ChallengeExecutor extends Injector {
                 });
                 // Return expectations
                 List<Expectation> expectations = new ArrayList<>();
-                challenges.forEach(challenge -> expectations.add(new ChallengeExpectation(challenge.getScore(), challenge)));
+                challenges.forEach(challenge -> expectations.add(new ChallengeExpectation(challenge.getScore(), challenge, false)));
                 return new ExecutionProcess(false, expectations);
             } else {
                 throw new UnsupportedOperationException("Unknown contract " + contract);

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
@@ -12,9 +12,7 @@ import io.openbas.injectors.email.service.EmailService;
 import io.openbas.model.ExecutionProcess;
 import io.openbas.model.Expectation;
 import io.openbas.model.expectation.ChallengeExpectation;
-import io.openbas.model.expectation.ChannelExpectation;
 import io.openbas.model.expectation.ManualExpectation;
-import io.openbas.rest.exception.ElementNotFoundException;
 import jakarta.annotation.Resource;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -110,7 +108,10 @@ public class ChallengeExecutor extends Injector {
                             content.getExpectations()
                                     .stream()
                                     .flatMap((entry) -> switch (entry.getType()) {
-                                        case MANUAL -> challenges.stream()
+                                        case MANUAL -> Stream.of(
+                                                (Expectation) new ManualExpectation(entry.getScore(), entry.getName(), entry.getDescription(), entry.isExpectationGroup())
+                                        );
+                                        case CHALLENGE -> challenges.stream()
                                                 .map(challenge -> (Expectation) new ChallengeExpectation(entry.getScore(), challenge, entry.isExpectationGroup()));
                                         default -> Stream.of();
                                     })

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
@@ -12,6 +12,8 @@ import io.openbas.injectors.email.service.EmailService;
 import io.openbas.model.ExecutionProcess;
 import io.openbas.model.Expectation;
 import io.openbas.model.expectation.ChallengeExpectation;
+import io.openbas.model.expectation.ChannelExpectation;
+import io.openbas.model.expectation.ManualExpectation;
 import io.openbas.rest.exception.ElementNotFoundException;
 import jakarta.annotation.Resource;
 import jakarta.validation.constraints.NotNull;
@@ -22,6 +24,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.openbas.database.model.InjectStatusExecution.traceError;
 import static io.openbas.database.model.InjectStatusExecution.traceSuccess;
@@ -102,7 +105,18 @@ public class ChallengeExecutor extends Injector {
                 });
                 // Return expectations
                 List<Expectation> expectations = new ArrayList<>();
-                challenges.forEach(challenge -> expectations.add(new ChallengeExpectation(challenge.getScore(), challenge, false)));
+                if (!content.getExpectations().isEmpty()) {
+                    expectations.addAll(
+                            content.getExpectations()
+                                    .stream()
+                                    .flatMap((entry) -> switch (entry.getType()) {
+                                        case MANUAL -> challenges.stream()
+                                                .map(challenge -> (Expectation) new ChallengeExpectation(entry.getScore(), challenge, entry.isExpectationGroup()));
+                                        default -> Stream.of();
+                                    })
+                                    .toList()
+                    );
+                }
                 return new ExecutionProcess(false, expectations);
             } else {
                 throw new UnsupportedOperationException("Unknown contract " + contract);

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/model/ChallengeContent.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/model/ChallengeContent.java
@@ -2,6 +2,7 @@ package io.openbas.injectors.challenge.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openbas.injectors.email.model.EmailContent;
+import io.openbas.model.inject.form.Expectation;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,5 +15,8 @@ public class ChallengeContent extends EmailContent {
 
   @JsonProperty("challenges")
   private List<String> challenges = new ArrayList<>();
+
+  @JsonProperty("expectations")
+  private List<Expectation> expectations = new ArrayList<>();
 
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelContract.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelContract.java
@@ -75,7 +75,7 @@ public class ChannelContract extends Contractor {
         Expectation expectation = new Expectation();
         expectation.setType(ARTICLE);
         expectation.setName("Expect teams to read the article(s)");
-        expectation.setScore(0);
+        expectation.setScore(0.0);
         ContractExpectations expectationsField = expectationsField(
                 "expectations", "Expectations", List.of(expectation)
         );

--- a/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelContract.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelContract.java
@@ -74,7 +74,7 @@ public class ChannelContract extends Contractor {
         ContractCheckbox emailingField = checkboxField("emailing", "Send email", true);
         Expectation expectation = new Expectation();
         expectation.setType(ARTICLE);
-        expectation.setName("Expect teams to read the article(s)");
+        expectation.setName("Expect targets to read the article(s)");
         expectation.setScore(0.0);
         ContractExpectations expectationsField = expectationsField(
                 "expectations", "Expectations", List.of(expectation)

--- a/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
@@ -118,10 +118,10 @@ public class ChannelExecutor extends Injector {
                   .stream()
                   .flatMap((entry) -> switch (entry.getType()) {
                     case MANUAL -> Stream.of(
-                        (Expectation) new ManualExpectation(entry.getScore(), entry.getName(), entry.getDescription())
+                        (Expectation) new ManualExpectation(entry.getScore(), entry.getName(), entry.getDescription(), entry.isExpectationGroup())
                     );
                     case ARTICLE -> articles.stream()
-                        .map(article -> (Expectation) new ChannelExpectation(entry.getScore(), article));
+                        .map(article -> (Expectation) new ChannelExpectation(entry.getScore(), article, entry.isExpectationGroup()));
                     default -> Stream.of();
                   })
                   .toList()

--- a/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
@@ -86,7 +86,7 @@ public class EmailExecutor extends Injector {
             .stream()
             .flatMap((entry) -> switch (entry.getType()) {
               case MANUAL ->
-                      Stream.of((Expectation) new ManualExpectation(entry.getScore(), entry.getName(), entry.getDescription()));
+                      Stream.of((Expectation) new ManualExpectation(entry.getScore(), entry.getName(), entry.getDescription(), entry.isExpectationGroup()));
               default -> Stream.of();
             })
             .toList();

--- a/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
@@ -65,7 +65,7 @@ public class OpenCTIExecutor extends Injector {
             .stream()
             .flatMap((entry) -> switch (entry.getType()) {
               case MANUAL ->
-                      Stream.of((Expectation) new ManualExpectation(entry.getScore(), entry.getName(), entry.getDescription()));
+                      Stream.of((Expectation) new ManualExpectation(entry.getScore(), entry.getName(), entry.getDescription(), entry.isExpectationGroup()));
               default -> Stream.of();
             })
             .toList();

--- a/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
@@ -66,7 +66,7 @@ public class OvhSmsExecutor extends Injector {
               .stream()
               .flatMap(entry -> switch (entry.getType()) {
                 case MANUAL ->
-                        Stream.of((Expectation) new ManualExpectation(entry.getScore(), entry.getName(), entry.getDescription()));
+                        Stream.of((Expectation) new ManualExpectation(entry.getScore(), entry.getName(), entry.getDescription(), entry.isExpectationGroup()));
                 default -> Stream.of();
               })
               .toList();

--- a/openbas-api/src/main/java/io/openbas/migration/V2_63__InjectExpectation_upgrade.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V2_63__InjectExpectation_upgrade.java
@@ -72,7 +72,7 @@ public class V2_63__InjectExpectation_upgrade extends BaseJavaMigration {
 
     private String message;
     private String expectationType;
-    private Integer expectationScore;
+    private Double expectationScore;
 
     OvhSmsContentNew toNewContent() {
       OvhSmsContentNew content = new OvhSmsContentNew();
@@ -99,7 +99,7 @@ public class V2_63__InjectExpectation_upgrade extends BaseJavaMigration {
     private String inReplyTo;
     private boolean encrypted;
     private String expectationType;
-    private Integer expectationScore;
+    private Double expectationScore;
 
     EmailContent toNewContent() {
       EmailContent content = new EmailContent();
@@ -122,7 +122,7 @@ public class V2_63__InjectExpectation_upgrade extends BaseJavaMigration {
 
     private List<String> articles;
     private boolean expectation;
-    private Integer expectationScore;
+    private Double expectationScore;
     private boolean emailing;
 
     ChannelContent toNewContent() {

--- a/openbas-api/src/main/java/io/openbas/migration/V3_30__Score_type.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_30__Score_type.java
@@ -1,0 +1,19 @@
+package io.openbas.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+import java.sql.Statement;
+
+@Component
+public class V3_30__Score_type extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Statement select = context.getConnection().createStatement();
+        select.execute("ALTER TABLE challenges alter column challenge_score type DOUBLE PRECISION;");
+        select.execute("ALTER TABLE injects_expectations alter column inject_expectation_score type DOUBLE PRECISION;");
+        select.execute("ALTER TABLE injects_expectations alter column inject_expectation_expected_score type DOUBLE PRECISION;");
+    }
+}

--- a/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
@@ -76,8 +76,8 @@ public class AtomicTestingApi extends RestBehavior {
       @PathVariable String injectId,
       @PathVariable String targetId,
       @PathVariable String targetType,
-      @RequestParam(required = false) String targetParentId) {
-    return injectExpectationService.findExpectationsByInjectAndTargetAndTargetType(injectId, targetId, targetParentId, targetType);
+      @RequestParam(required = false) String parentTargetId ) {
+    return injectExpectationService.findExpectationsByInjectAndTargetAndTargetType(injectId, targetId, parentTargetId, targetType);
   }
 
   @PutMapping("/{injectId}/tags")

--- a/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
@@ -73,10 +73,11 @@ public class AtomicTestingApi extends RestBehavior {
 
   @GetMapping("/{injectId}/target_results/{targetId}/types/{targetType}")
   public List<InjectExpectation> findTargetResult(
-      @PathVariable String targetId,
       @PathVariable String injectId,
-      @PathVariable String targetType) {
-    return injectExpectationService.findExpectationsByInjectAndTargetAndTargetType(injectId, targetId, targetType);
+      @PathVariable String targetId,
+      @PathVariable String targetType,
+      @RequestParam(required = false) String targetParentId) {
+    return injectExpectationService.findExpectationsByInjectAndTargetAndTargetType(injectId, targetId, targetParentId, targetType);
   }
 
   @PutMapping("/{injectId}/tags")

--- a/openbas-api/src/main/java/io/openbas/rest/challenge/ChallengeApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/challenge/ChallengeApi.java
@@ -213,10 +213,13 @@ public class ChallengeApi extends RestBehavior {
             throw new UnsupportedOperationException("User must be logged or dynamic player is required");
         }
         ChallengeResult challengeResult = tryChallenge(challengeId, input);
-        if (challengeResult.getResult()) { //todo
+        if (challengeResult.getResult()) {
             List<String> teamIds = user.getTeams().stream().map(Team::getId).toList();
             List<InjectExpectation> challengeExpectations = injectExpectationRepository.findChallengeExpectations(exerciseId,
                     teamIds, challengeId);
+
+
+
             challengeExpectations.forEach(injectExpectationExecution -> {
                 injectExpectationExecution.setUser(user);
                 injectExpectationExecution.setResults(List.of(

--- a/openbas-api/src/main/java/io/openbas/rest/challenge/ChallengeApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/challenge/ChallengeApi.java
@@ -1,7 +1,10 @@
 package io.openbas.rest.challenge;
 
-import io.openbas.database.model.*;
+import io.openbas.database.model.Challenge;
+import io.openbas.database.model.ChallengeFlag;
 import io.openbas.database.model.ChallengeFlag.FLAG_TYPE;
+import io.openbas.database.model.Exercise;
+import io.openbas.database.model.User;
 import io.openbas.database.repository.*;
 import io.openbas.rest.challenge.form.ChallengeCreateInput;
 import io.openbas.rest.challenge.form.ChallengeTryInput;
@@ -14,16 +17,14 @@ import io.openbas.rest.helper.RestBehavior;
 import io.openbas.service.ChallengeService;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 import static io.openbas.config.OpenBASAnonymous.ANONYMOUS;
 import static io.openbas.database.model.User.ROLE_ADMIN;
@@ -31,6 +32,7 @@ import static io.openbas.helper.StreamHelper.fromIterable;
 import static io.openbas.helper.StreamHelper.iterableToSet;
 
 @RestController
+@AllArgsConstructor
 public class ChallengeApi extends RestBehavior {
 
     private ChallengeRepository challengeRepository;
@@ -38,49 +40,8 @@ public class ChallengeApi extends RestBehavior {
     private TagRepository tagRepository;
     private DocumentRepository documentRepository;
     private ExerciseRepository exerciseRepository;
-    private InjectExpectationRepository injectExpectationRepository;
     private ChallengeService challengeService;
     private UserRepository userRepository;
-
-    @Autowired
-    public void setUserRepository(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
-
-    @Autowired
-    public void setChallengeService(ChallengeService challengeService) {
-        this.challengeService = challengeService;
-    }
-
-    @Autowired
-    public void setInjectExpectationRepository(InjectExpectationRepository injectExpectationRepository) {
-        this.injectExpectationRepository = injectExpectationRepository;
-    }
-
-    @Autowired
-    public void setChallengeFlagRepository(ChallengeFlagRepository challengeFlagRepository) {
-        this.challengeFlagRepository = challengeFlagRepository;
-    }
-
-    @Autowired
-    public void setChallengeRepository(ChallengeRepository challengeRepository) {
-        this.challengeRepository = challengeRepository;
-    }
-
-    @Autowired
-    public void setTagRepository(TagRepository tagRepository) {
-        this.tagRepository = tagRepository;
-    }
-
-    @Autowired
-    public void setDocumentRepository(DocumentRepository documentRepository) {
-        this.documentRepository = documentRepository;
-    }
-
-    @Autowired
-    public void setExerciseRepository(ExerciseRepository exerciseRepository) {
-        this.exerciseRepository = exerciseRepository;
-    }
 
     @GetMapping("/api/challenges")
     public Iterable<Challenge> challenges() {
@@ -136,25 +97,11 @@ public class ChallengeApi extends RestBehavior {
 
     @GetMapping("/api/player/challenges/{exerciseId}")
     public ChallengesReader playerChallenges(@PathVariable String exerciseId, @RequestParam Optional<String> userId) {
-        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
         final User user = impersonateUser(userRepository, userId);
         if (user.getId().equals(ANONYMOUS)) {
             throw new UnsupportedOperationException("User must be logged or dynamic player is required");
         }
-        ChallengesReader reader = new ChallengesReader(exercise);
-        List<String> teamIds = user.getTeams().stream().map(Team::getId).toList();
-        List<InjectExpectation> challengeExpectations = injectExpectationRepository.findChallengeExpectations(exerciseId,
-                teamIds);
-        List<ChallengeInformation> challenges = challengeExpectations.stream()
-                .map(injectExpectation -> {
-                    Challenge challenge = injectExpectation.getChallenge();
-                    challenge.setVirtualPublication(injectExpectation.getCreatedAt());
-                    return new ChallengeInformation(challenge, injectExpectation);
-                })
-                .sorted(Comparator.comparing(o -> o.getChallenge().getVirtualPublication()))
-                .toList();
-        reader.setExerciseChallenges(challenges);
-        return reader;
+        return challengeService.playerChallenges(exerciseId, user);
     }
 
     @GetMapping("/api/observer/challenges/{exerciseId}")
@@ -174,32 +121,9 @@ public class ChallengeApi extends RestBehavior {
         challengeRepository.deleteById(challengeId);
     }
 
-    private boolean checkFlag(ChallengeFlag flag, String value) {
-        switch (flag.getType()) {
-            case VALUE -> {
-                return value.equalsIgnoreCase(flag.getValue());
-            }
-            case VALUE_CASE -> {
-                return value.equals(flag.getValue());
-            }
-            case REGEXP -> {
-                return Pattern.compile(flag.getValue()).matcher(value).matches();
-            }
-            default -> {
-                return false;
-            }
-        }
-    }
-
     @PostMapping("/api/challenges/{challengeId}/try")
     public ChallengeResult tryChallenge(@PathVariable String challengeId, @Valid @RequestBody ChallengeTryInput input) {
-        Challenge challenge = challengeRepository.findById(challengeId).orElseThrow(ElementNotFoundException::new);
-        for (ChallengeFlag flag : challenge.getFlags()) {
-            if (checkFlag(flag, input.getValue())) {
-                return new ChallengeResult(true);
-            }
-        }
-        return new ChallengeResult(false);
+        return challengeService.tryChallenge(challengeId, input);
     }
 
     @PostMapping("/api/player/challenges/{exerciseId}/{challengeId}/validate")
@@ -212,63 +136,6 @@ public class ChallengeApi extends RestBehavior {
         if (user.getId().equals(ANONYMOUS)) {
             throw new UnsupportedOperationException("User must be logged or dynamic player is required");
         }
-        ChallengeResult challengeResult = tryChallenge(challengeId, input);
-        if (challengeResult.getResult()) {
-
-            // Find and update the expectation linked to user
-            InjectExpectation playerExpectation = injectExpectationRepository.findByUserAndExerciseAndChallenge(user.getId(), exerciseId, challengeId);
-            playerExpectation.setScore(playerExpectation.getExpectedScore());
-            InjectExpectationResult expectationResult = InjectExpectationResult.builder()
-                    .sourceId("challenge")
-                    .sourceType("challenge")
-                    .sourceName("Challenge validation")
-                    .result(Instant.now().toString())
-                    .date(Instant.now().toString())
-                    .score(playerExpectation.getExpectedScore())
-                    .build();
-            playerExpectation.getResults().add(expectationResult);
-            playerExpectation.setUpdatedAt(Instant.now());
-            injectExpectationRepository.save(playerExpectation);
-
-            // Process expectation linked to teams where user if part of
-            List<String> teamIds = user.getTeams().stream().map(Team::getId).toList();
-            // Find all expectations linked to teams' user, challenge and exercise
-            List<InjectExpectation> challengeExpectations = injectExpectationRepository.findChallengeExpectations(exerciseId, teamIds, challengeId);
-
-            // Depending on type of validation, we process the parent expectations:
-            challengeExpectations.stream().findAny().ifPresentOrElse(process -> {
-                boolean validationType = process.isExpectationGroup();
-
-                challengeExpectations.forEach(parentExpectation -> {
-                    if (validationType) { // type atLeast
-                        parentExpectation.setScore(injectExpectationRepository.computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChallenge(
-                                process.getExercise().getId(),
-                                process.getChallenge().getId(),
-                                parentExpectation.getTeam().getId())
-                        );
-                    } else { // type all
-                        parentExpectation.setScore(injectExpectationRepository.computeAverageScoreWhenValidationTypeIsAllPlayersForChallenge(
-                                process.getExercise().getId(),
-                                process.getChallenge().getId(),
-                                parentExpectation.getTeam().getId())
-                        );
-                    };
-                    InjectExpectationResult result = InjectExpectationResult.builder()
-                            .sourceId("challenge")
-                            .sourceType("challenge")
-                            .sourceName("Challenge validation")
-                            .result(Instant.now().toString())
-                            .date(Instant.now().toString())
-                            .score(process.getExpectedScore())
-                            .build();
-
-                    parentExpectation.getResults().clear();
-                    parentExpectation.getResults().add(result);
-                    parentExpectation.setUpdatedAt(Instant.now());
-                    injectExpectationRepository.save(parentExpectation);
-                });
-            }, () -> new ElementNotFoundException());
-        }
-        return playerChallenges(exerciseId, userId);
+        return challengeService.validateChallenge(exerciseId, challengeId, input, user);
     }
 }

--- a/openbas-api/src/main/java/io/openbas/rest/challenge/ChallengeApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/challenge/ChallengeApi.java
@@ -213,7 +213,7 @@ public class ChallengeApi extends RestBehavior {
             throw new UnsupportedOperationException("User must be logged or dynamic player is required");
         }
         ChallengeResult challengeResult = tryChallenge(challengeId, input);
-        if (challengeResult.getResult()) {
+        if (challengeResult.getResult()) { //todo
             List<String> teamIds = user.getTeams().stream().map(Team::getId).toList();
             List<InjectExpectation> challengeExpectations = injectExpectationRepository.findChallengeExpectations(exerciseId,
                     teamIds, challengeId);

--- a/openbas-api/src/main/java/io/openbas/rest/challenge/output/ChallengeOutput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/challenge/output/ChallengeOutput.java
@@ -32,7 +32,7 @@ public class ChallengeOutput {
   private String content;
 
   @JsonProperty("challenge_score")
-  private Integer score;
+  private Double score;
 
   @JsonProperty("challenge_max_attempts")
   private Integer maxAttempts;

--- a/openbas-api/src/main/java/io/openbas/rest/challenge/response/PublicChallenge.java
+++ b/openbas-api/src/main/java/io/openbas/rest/challenge/response/PublicChallenge.java
@@ -23,7 +23,7 @@ public class PublicChallenge {
     private String content;
 
     @JsonProperty("challenge_score")
-    private Integer score;
+    private Double score;
 
     @JsonProperty("challenge_flags")
     private List<PublicChallengeFlag> flags;
@@ -85,11 +85,11 @@ public class PublicChallenge {
         this.content = content;
     }
 
-    public Integer getScore() {
+    public Double getScore() {
         return score;
     }
 
-    public void setScore(Integer score) {
+    public void setScore(Double score) {
         this.score = score;
     }
 

--- a/openbas-api/src/main/java/io/openbas/rest/channel/ChannelApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/channel/ChannelApi.java
@@ -226,6 +226,11 @@ public class ChannelApi extends RestBehavior {
                 injectExpectationExecution.setScore(injectExpectationExecution.getExpectedScore());
                 injectExpectationExecution.setUpdatedAt(Instant.now());
                 injectExpectationExecutionRepository.save(injectExpectationExecution);
+
+                //Todo after update expectation player we have to update expectation team
+
+
+
             });
         }
         return channelReader;

--- a/openbas-api/src/main/java/io/openbas/rest/exercise/form/ExpectationUpdateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/form/ExpectationUpdateInput.java
@@ -24,5 +24,5 @@ public class ExpectationUpdateInput {
 
   @JsonProperty("expectation_score")
   @NotNull
-  private Integer score;
+  private Double score;
 }

--- a/openbas-api/src/main/java/io/openbas/rest/helper/TeamHelper.java
+++ b/openbas-api/src/main/java/io/openbas/rest/helper/TeamHelper.java
@@ -10,6 +10,7 @@ import io.openbas.database.repository.ScenarioRepository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -55,19 +56,21 @@ public class TeamHelper {
                     rawTeam.getTeam_expectations().stream().map(
                             expectation -> {
                                 // We set the inject expectation using the map we generated earlier
-                                RawInjectExpectation raw = mapInjectExpectation.get(expectation);
                                 InjectExpectation injectExpectation = new InjectExpectation();
-                                injectExpectation.setScore(raw.getInject_expectation_score());
-                                injectExpectation.setExpectedScore(raw.getInject_expectation_expected_score());
-                                injectExpectation.setId(raw.getInject_expectation_id());
-                                injectExpectation.setExpectedScore(raw.getInject_expectation_expected_score());
-                                if(raw.getExercise_id() != null) {
-                                    injectExpectation.setExercise(new Exercise());
-                                    injectExpectation.getExercise().setId(raw.getExercise_id());
-                                }
-                                injectExpectation.setTeam(new Team());
-                                injectExpectation.getTeam().setId(rawTeam.getTeam_id());
-                                injectExpectation.setType(InjectExpectation.EXPECTATION_TYPE.valueOf(raw.getInject_expectation_type()));
+                                Optional<RawInjectExpectation> raw = Optional.ofNullable(mapInjectExpectation.get(expectation));
+                                raw.ifPresent(toProcess -> {
+                                    injectExpectation.setScore(toProcess.getInject_expectation_score());
+                                    injectExpectation.setExpectedScore(toProcess.getInject_expectation_expected_score());
+                                    injectExpectation.setId(toProcess.getInject_expectation_id());
+                                    injectExpectation.setExpectedScore(toProcess.getInject_expectation_expected_score());
+                                    if (toProcess.getExercise_id() != null) {
+                                        injectExpectation.setExercise(new Exercise());
+                                        injectExpectation.getExercise().setId(toProcess.getExercise_id());
+                                    }
+                                    injectExpectation.setTeam(new Team());
+                                    injectExpectation.getTeam().setId(rawTeam.getTeam_id());
+                                    injectExpectation.setType(InjectExpectation.EXPECTATION_TYPE.valueOf(toProcess.getInject_expectation_type()));
+                                });
                                 return injectExpectation;
                             }
                     ).toList()

--- a/openbas-api/src/main/java/io/openbas/service/ChallengeService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ChallengeService.java
@@ -2,91 +2,197 @@ package io.openbas.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.openbas.database.model.Challenge;
-import io.openbas.database.model.Exercise;
-import io.openbas.database.model.Inject;
-import io.openbas.database.model.Scenario;
+import io.openbas.database.model.*;
 import io.openbas.database.repository.ChallengeRepository;
 import io.openbas.database.repository.ExerciseRepository;
+import io.openbas.database.repository.InjectExpectationRepository;
 import io.openbas.database.repository.InjectRepository;
 import io.openbas.injectors.challenge.model.ChallengeContent;
+import io.openbas.rest.challenge.form.ChallengeTryInput;
+import io.openbas.rest.challenge.response.ChallengeInformation;
+import io.openbas.rest.challenge.response.ChallengeResult;
+import io.openbas.rest.challenge.response.ChallengesReader;
+import io.openbas.rest.exception.ElementNotFoundException;
 import jakarta.annotation.Resource;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static io.openbas.helper.StreamHelper.fromIterable;
 import static io.openbas.injectors.challenge.ChallengeContract.CHALLENGE_PUBLISH;
 
 @Service
+@AllArgsConstructor
 public class ChallengeService {
 
-  @Resource
-  protected ObjectMapper mapper;
+    @Resource
+    protected ObjectMapper mapper;
 
-  private ExerciseRepository exerciseRepository;
-  private ChallengeRepository challengeRepository;
-  private InjectRepository injectRepository;
+    private ExerciseRepository exerciseRepository;
+    private ChallengeRepository challengeRepository;
+    private InjectRepository injectRepository;
+    private InjectExpectationRepository injectExpectationRepository;
 
-  @Autowired
-  public void setInjectRepository(InjectRepository injectRepository) {
-    this.injectRepository = injectRepository;
-  }
+    public Challenge enrichChallengeWithExercisesOrScenarios(@NotNull Challenge challenge) {
+        List<Inject> injects = fromIterable(this.injectRepository.findAllForChallengeId("%" + challenge.getId() + "%"));
+        List<String> exerciseIds = injects.stream().filter(i -> i.getExercise() != null).map(i -> i.getExercise().getId()).distinct().toList();
+        challenge.setExerciseIds(exerciseIds);
+        List<String> scenarioIds = injects.stream().filter(i -> i.getScenario() != null).map(i -> i.getScenario().getId()).distinct().toList();
+        challenge.setScenarioIds(scenarioIds);
+        return challenge;
+    }
 
-  @Autowired
-  public void setChallengeRepository(ChallengeRepository challengeRepository) {
-    this.challengeRepository = challengeRepository;
-  }
+    public Iterable<Challenge> getExerciseChallenges(@NotBlank final String exerciseId) {
+        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+        return resolveChallenges(exercise.getInjects())
+                .map(this::enrichChallengeWithExercisesOrScenarios)
+                .toList();
+    }
 
-  @Autowired
-  public void setExerciseRepository(ExerciseRepository exerciseRepository) {
-    this.exerciseRepository = exerciseRepository;
-  }
+    public Iterable<Challenge> getScenarioChallenges(@NotNull final Scenario scenario) {
+        return resolveChallenges(scenario.getInjects())
+                .map(this::enrichChallengeWithExercisesOrScenarios)
+                .toList();
+    }
 
-  public Challenge enrichChallengeWithExercisesOrScenarios(@NotNull Challenge challenge) {
-    List<Inject> injects = fromIterable(this.injectRepository.findAllForChallengeId("%" + challenge.getId() + "%"));
-    List<String> exerciseIds = injects.stream().filter(i -> i.getExercise() != null).map(i -> i.getExercise().getId()).distinct().toList();
-    challenge.setExerciseIds(exerciseIds);
-    List<String> scenarioIds = injects.stream().filter(i -> i.getScenario() != null).map(i -> i.getScenario().getId()).distinct().toList();
-    challenge.setScenarioIds(scenarioIds);
-    return challenge;
-  }
 
-  public Iterable<Challenge> getExerciseChallenges(@NotBlank final String exerciseId) {
-    Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
-    return resolveChallenges(exercise.getInjects())
-        .map(this::enrichChallengeWithExercisesOrScenarios)
-        .toList();
-  }
+    public ChallengeResult tryChallenge(String challengeId, ChallengeTryInput input) {
+        Challenge challenge = challengeRepository.findById(challengeId).orElseThrow(ElementNotFoundException::new);
+        for (ChallengeFlag flag : challenge.getFlags()) {
+            if (checkFlag(flag, input.getValue())) {
+                return new ChallengeResult(true);
+            }
+        }
+        return new ChallengeResult(false);
+    }
 
-  public Iterable<Challenge> getScenarioChallenges(@NotNull final Scenario scenario) {
-    return resolveChallenges(scenario.getInjects())
-        .map(this::enrichChallengeWithExercisesOrScenarios)
-        .toList();
-  }
+    public ChallengesReader playerChallenges(String exerciseId, User user) {
+        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
+        ChallengesReader reader = new ChallengesReader(exercise);
+        List<String> teamIds = user.getTeams().stream().map(Team::getId).toList();
+        List<InjectExpectation> challengeExpectations = injectExpectationRepository.findChallengeExpectations(exerciseId,
+                teamIds);
+        List<ChallengeInformation> challenges = challengeExpectations.stream()
+                .map(injectExpectation -> {
+                    Challenge challenge = injectExpectation.getChallenge();
+                    challenge.setVirtualPublication(injectExpectation.getCreatedAt());
+                    return new ChallengeInformation(challenge, injectExpectation);
+                })
+                .sorted(Comparator.comparing(o -> o.getChallenge().getVirtualPublication()))
+                .toList();
+        reader.setExerciseChallenges(challenges);
+        return reader;
+    }
 
-  // -- PRIVATE --
-  private Stream<Challenge> resolveChallenges(@NotNull final List<Inject> injects) {
-    List<String> challenges = injects.stream()
-            .filter(inject -> inject.getInjectorContract()
-                    .map(contract -> contract.getId().equals(CHALLENGE_PUBLISH))
-                    .orElse(false))
-            .filter(inject -> inject.getContent() != null)
-            .flatMap(inject -> {
-              try {
-                ChallengeContent content = mapper.treeToValue(inject.getContent(), ChallengeContent.class);
-                return content.getChallenges().stream();
-              } catch (JsonProcessingException e) {
-                return Stream.empty();
-              }
-            })
-            .distinct()
-            .toList();
+    public ChallengesReader validateChallenge(String exerciseId,
+                                              String challengeId,
+                                              ChallengeTryInput input,
+                                              User user) {
+        ChallengeResult challengeResult = tryChallenge(challengeId, input);
+        if (challengeResult.getResult()) {
 
-    return fromIterable(this.challengeRepository.findAllById(challenges)).stream();
-  }
+            // Find and update the expectations linked to user
+            List<InjectExpectation> playerExpectations = injectExpectationRepository.findByUserAndExerciseAndChallenge(user.getId(), exerciseId, challengeId);
+            playerExpectations.forEach(playerExpectation -> {
+                playerExpectation.setScore(playerExpectation.getExpectedScore());
+                InjectExpectationResult expectationResult = InjectExpectationResult.builder()
+                        .sourceId("challenge")
+                        .sourceType("challenge")
+                        .sourceName("Challenge validation")
+                        .result(Instant.now().toString())
+                        .date(Instant.now().toString())
+                        .score(playerExpectation.getExpectedScore())
+                        .build();
+                playerExpectation.getResults().add(expectationResult);
+                playerExpectation.setUpdatedAt(Instant.now());
+                injectExpectationRepository.save(playerExpectation);
+            });
+
+            // Process expectation linked to teams where user if part of
+            List<String> teamIds = user.getTeams().stream().map(Team::getId).toList();
+            // Find all expectations linked to teams' user, challenge and exercise
+            List<InjectExpectation> challengeExpectations = injectExpectationRepository.findChallengeExpectations(exerciseId, teamIds, challengeId);
+
+            // Depending on type of validation, we process the parent expectations:
+            challengeExpectations.stream().findAny().ifPresentOrElse(process -> {
+                boolean validationType = process.isExpectationGroup();
+
+                challengeExpectations.forEach(parentExpectation -> {
+                    if (validationType) { // type atLeast
+                        parentExpectation.setScore(injectExpectationRepository.computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChallenge(
+                                process.getExercise().getId(),
+                                process.getChallenge().getId(),
+                                parentExpectation.getTeam().getId())
+                        );
+                    } else { // type all
+                        parentExpectation.setScore(injectExpectationRepository.computeAverageScoreWhenValidationTypeIsAllPlayersForChallenge(
+                                process.getExercise().getId(),
+                                process.getChallenge().getId(),
+                                parentExpectation.getTeam().getId())
+                        );
+                    }
+                    ;
+                    InjectExpectationResult result = InjectExpectationResult.builder()
+                            .sourceId("challenge")
+                            .sourceType("challenge")
+                            .sourceName("Challenge validation")
+                            .result(Instant.now().toString())
+                            .date(Instant.now().toString())
+                            .score(process.getExpectedScore())
+                            .build();
+
+                    parentExpectation.getResults().clear();
+                    parentExpectation.getResults().add(result);
+                    parentExpectation.setUpdatedAt(Instant.now());
+                    injectExpectationRepository.save(parentExpectation);
+                });
+            }, ElementNotFoundException::new);
+        }
+        return playerChallenges(exerciseId, user);
+    }
+
+    // -- PRIVATE --
+    private Stream<Challenge> resolveChallenges(@NotNull final List<Inject> injects) {
+        List<String> challenges = injects.stream()
+                .filter(inject -> inject.getInjectorContract()
+                        .map(contract -> contract.getId().equals(CHALLENGE_PUBLISH))
+                        .orElse(false))
+                .filter(inject -> inject.getContent() != null)
+                .flatMap(inject -> {
+                    try {
+                        ChallengeContent content = mapper.treeToValue(inject.getContent(), ChallengeContent.class);
+                        return content.getChallenges().stream();
+                    } catch (JsonProcessingException e) {
+                        return Stream.empty();
+                    }
+                })
+                .distinct()
+                .toList();
+
+        return fromIterable(this.challengeRepository.findAllById(challenges)).stream();
+    }
+
+    private boolean checkFlag(ChallengeFlag flag, String value) {
+        switch (flag.getType()) {
+            case VALUE -> {
+                return value.equalsIgnoreCase(flag.getValue());
+            }
+            case VALUE_CASE -> {
+                return value.equals(flag.getValue());
+            }
+            case REGEXP -> {
+                return Pattern.compile(flag.getValue()).matcher(value).matches();
+            }
+            default -> {
+                return false;
+            }
+        }
+    }
 }

--- a/openbas-api/src/main/java/io/openbas/service/ChallengeService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ChallengeService.java
@@ -148,7 +148,6 @@ public class ChallengeService {
                             .score(process.getExpectedScore())
                             .build();
 
-                    parentExpectation.getResults().clear();
                     parentExpectation.getResults().add(result);
                     parentExpectation.setUpdatedAt(Instant.now());
                     injectExpectationRepository.save(parentExpectation);

--- a/openbas-api/src/main/java/io/openbas/service/ChannelService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ChannelService.java
@@ -126,8 +126,7 @@ public class ChannelService {
                     long zeroPlayerResponses = toProcess.stream().filter(exp -> exp.getScore() != null).filter(exp -> exp.getScore() == 0.0).count();
                     long nullPlayerResponses = toProcess.stream().filter(exp -> exp.getScore() == null).count();
 
-                    if (isValidationAtLeastOneTarget) { // type atLeast
-                        //If true is at least one
+                    if (isValidationAtLeastOneTarget) { // Type atLeast
                         OptionalDouble avgAtLeastOnePlayer = toProcess.stream().filter(exp -> exp.getScore() != null).filter(exp -> exp.getScore() > 0.0).mapToDouble(InjectExpectation::getScore).average();
                         if (avgAtLeastOnePlayer.isPresent()) { //Any response is positive
                             parentExpectation.setScore(avgAtLeastOnePlayer.getAsDouble());

--- a/openbas-api/src/main/java/io/openbas/service/ChannelService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ChannelService.java
@@ -1,0 +1,152 @@
+package io.openbas.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openbas.database.model.*;
+import io.openbas.database.repository.ArticleRepository;
+import io.openbas.database.repository.ChannelRepository;
+import io.openbas.database.repository.ExerciseRepository;
+import io.openbas.database.repository.InjectExpectationRepository;
+import io.openbas.injectors.channel.model.ChannelContent;
+import io.openbas.rest.channel.model.VirtualArticle;
+import io.openbas.rest.channel.response.ChannelReader;
+import io.openbas.rest.exception.ElementNotFoundException;
+import jakarta.annotation.Resource;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static io.openbas.helper.StreamHelper.fromIterable;
+import static io.openbas.injectors.channel.ChannelContract.CHANNEL_PUBLISH;
+
+@Service
+@AllArgsConstructor
+public class ChannelService {
+
+    @Resource
+    protected ObjectMapper mapper;
+
+    private InjectExpectationRepository injectExpectationExecutionRepository;
+    private ExerciseRepository exerciseRepository;
+    private ScenarioService scenarioService;
+    private ArticleRepository articleRepository;
+    private ChannelRepository channelRepository;
+
+
+    public ChannelReader validateArticles(String exerciseId, String channelId, User user) {
+        ChannelReader channelReader;
+        Channel channel = channelRepository.findById(channelId).orElseThrow(ElementNotFoundException::new);
+        List<Inject> injects;
+
+        Optional<Exercise> exerciseOpt = exerciseRepository.findById(exerciseId);
+        if (exerciseOpt.isPresent()) {
+            Exercise exercise = exerciseOpt.get();
+            channelReader = new ChannelReader(channel, exercise);
+            injects = exercise.getInjects();
+        } else {
+            Scenario scenario = this.scenarioService.scenario(exerciseId);
+            channelReader = new ChannelReader(channel, scenario);
+            injects = scenario.getInjects();
+        }
+
+        Map<String, Instant> toPublishArticleIdsMap = injects.stream()
+                .filter(inject -> inject.getInjectorContract()
+                        .map(contract -> contract.getId().equals(CHANNEL_PUBLISH))
+                        .orElse(false))
+                .filter(inject -> inject.getStatus().isPresent())
+                .sorted(Comparator.comparing(inject -> inject.getStatus().get().getTrackingSentDate()))
+                .flatMap(inject -> {
+                    Instant virtualInjectDate = inject.getStatus().get().getTrackingSentDate();
+                    try {
+                        ChannelContent content = mapper.treeToValue(inject.getContent(), ChannelContent.class);
+                        if (content.getArticles() != null) {
+                            return content.getArticles().stream().map(article -> new VirtualArticle(virtualInjectDate, article));
+                        }
+                        return null;
+                    } catch (JsonProcessingException e) {
+                        // Invalid channel content.
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toMap(VirtualArticle::id, VirtualArticle::date));
+        if (!toPublishArticleIdsMap.isEmpty()) {
+            List<Article> publishedArticles = fromIterable(articleRepository.findAllById(toPublishArticleIdsMap.keySet()))
+                    .stream().filter(article -> article.getChannel().equals(channel))
+                    .peek(article -> article.setVirtualPublication(toPublishArticleIdsMap.get(article.getId())))
+                    .sorted(Comparator.comparing(Article::getVirtualPublication).reversed())
+                    .toList();
+            channelReader.setChannelArticles(publishedArticles);
+            // Fulfill article expectations
+            List<Inject> finalInjects = injects;
+            List<InjectExpectation> expectationExecutions = publishedArticles.stream()
+                    .flatMap(article -> finalInjects.stream()
+                            .flatMap(inject -> inject.getUserExpectationsForArticle(user, article).stream()))
+                    .filter(exec -> exec.getResults().isEmpty()).toList();
+
+            // Update all expectations linked to player
+            expectationExecutions.forEach(injectExpectationExecution -> {
+                injectExpectationExecution.setUser(user);
+                injectExpectationExecution.setResults(List.of(
+                        InjectExpectationResult.builder()
+                                .sourceId("media-pressure")
+                                .sourceType("media-pressure")
+                                .sourceName("Media pressure read")
+                                .result(Instant.now().toString())
+                                .date(Instant.now().toString())
+                                .score(injectExpectationExecution.getExpectedScore())
+                                .build()
+                ));
+                injectExpectationExecution.setScore(injectExpectationExecution.getExpectedScore());
+                injectExpectationExecution.setUpdatedAt(Instant.now());
+                injectExpectationExecutionRepository.save(injectExpectationExecution);
+            });
+
+            // Process expectation linked to teams where user if part of
+            List<String> injectIds = injects.stream().map(Inject::getId).toList();
+            List<String> teamIds = user.getTeams().stream().map(Team::getId).toList();
+            // Find all expectations linked to teams' user, channel and exercise
+            List<InjectExpectation> channelExpectations = injectExpectationExecutionRepository.findChannelExpectations(injectIds, teamIds, channelId);
+
+            // Depending on type of validation, we process the parent expectations:
+            channelExpectations.stream().findAny().ifPresentOrElse(process -> {
+                boolean validationType = process.isExpectationGroup();
+
+                channelExpectations.forEach(parentExpectation -> {
+                    if (validationType) { // type atLeast
+                        parentExpectation.setScore(injectExpectationExecutionRepository.computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChannel(
+                                injectIds,
+                                process.getArticle().getId(),
+                                parentExpectation.getTeam().getId())
+                        );
+                    } else { // type all
+                        parentExpectation.setScore(injectExpectationExecutionRepository.computeAverageScoreWhenValidationTypeIsAllPlayersForChannel(
+                                injectIds,
+                                process.getArticle().getId(),
+                                parentExpectation.getTeam().getId())
+                        );
+                    }
+                    ;
+                    InjectExpectationResult result = InjectExpectationResult.builder()
+                            .sourceId("media-pressure")
+                            .sourceType("media-pressure")
+                            .sourceName("Media pressure read")
+                            .result(Instant.now().toString())
+                            .date(Instant.now().toString())
+                            .score(process.getExpectedScore())
+                            .build();
+
+                    parentExpectation.getResults().clear();
+                    parentExpectation.getResults().add(result);
+                    parentExpectation.setUpdatedAt(Instant.now());
+                    injectExpectationExecutionRepository.save(parentExpectation);
+                });
+            }, ElementNotFoundException::new);
+        }
+        return channelReader;
+    }
+}

--- a/openbas-api/src/main/java/io/openbas/service/ChannelService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ChannelService.java
@@ -117,16 +117,16 @@ public class ChannelService {
                 boolean validationType = process.isExpectationGroup();
 
                 channelExpectations.forEach(parentExpectation -> {
-                    if (validationType) { // Validation type atleast one target
+                    if (validationType) { // Validation type at least one target
                         parentExpectation.setScore(injectExpectationExecutionRepository.computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChannel(
                                 injectIds,
-                                process.getArticle().getId(),
+                                articleIds,
                                 parentExpectation.getTeam().getId())
                         );
                     } else { // Validation type all
                         parentExpectation.setScore(injectExpectationExecutionRepository.computeAverageScoreWhenValidationTypeIsAllPlayersForChannel(
                                 injectIds,
-                                process.getArticle().getId(),
+                                articleIds,
                                 parentExpectation.getTeam().getId())
                         );
                     }
@@ -139,7 +139,6 @@ public class ChannelService {
                             .score(process.getExpectedScore())
                             .build();
 
-                    parentExpectation.getResults().clear();
                     parentExpectation.getResults().add(result);
                     parentExpectation.setUpdatedAt(Instant.now());
                     injectExpectationExecutionRepository.save(parentExpectation);

--- a/openbas-api/src/main/java/io/openbas/service/ChannelService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ChannelService.java
@@ -90,7 +90,6 @@ public class ChannelService {
 
             // Update all expectations linked to player
             expectationExecutions.forEach(injectExpectationExecution -> {
-                injectExpectationExecution.setUser(user);
                 injectExpectationExecution.setResults(List.of(
                         InjectExpectationResult.builder()
                                 .sourceId("media-pressure")
@@ -109,28 +108,28 @@ public class ChannelService {
             // Process expectation linked to teams where user if part of
             List<String> injectIds = injects.stream().map(Inject::getId).toList();
             List<String> teamIds = user.getTeams().stream().map(Team::getId).toList();
+            List<String> articleIds = publishedArticles.stream().map(Article::getId).toList();
             // Find all expectations linked to teams' user, channel and exercise
-            List<InjectExpectation> channelExpectations = injectExpectationExecutionRepository.findChannelExpectations(injectIds, teamIds, channelId);
+            List<InjectExpectation> channelExpectations = injectExpectationExecutionRepository.findChannelExpectations(injectIds, teamIds, articleIds);
 
             // Depending on type of validation, we process the parent expectations:
             channelExpectations.stream().findAny().ifPresentOrElse(process -> {
                 boolean validationType = process.isExpectationGroup();
 
                 channelExpectations.forEach(parentExpectation -> {
-                    if (validationType) { // type atLeast
+                    if (validationType) { // Validation type atleast one target
                         parentExpectation.setScore(injectExpectationExecutionRepository.computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChannel(
                                 injectIds,
                                 process.getArticle().getId(),
                                 parentExpectation.getTeam().getId())
                         );
-                    } else { // type all
+                    } else { // Validation type all
                         parentExpectation.setScore(injectExpectationExecutionRepository.computeAverageScoreWhenValidationTypeIsAllPlayersForChannel(
                                 injectIds,
                                 process.getArticle().getId(),
                                 parentExpectation.getTeam().getId())
                         );
                     }
-                    ;
                     InjectExpectationResult result = InjectExpectationResult.builder()
                             .sourceId("media-pressure")
                             .sourceType("media-pressure")

--- a/openbas-api/src/main/java/io/openbas/service/ExerciseExpectationService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ExerciseExpectationService.java
@@ -43,8 +43,6 @@ public class ExerciseExpectationService {
         if (injectExpectation.getType() == EXPECTATION_TYPE.MANUAL) {
             if (injectExpectation.getTeam() != null && injectExpectation.getUser() == null) { //If it is a team expectation
                 result = input.getScore() > 0 ? "Success" : "Failed";
-                injectExpectation.getResults().clear();
-                exists = Optional.empty();
             } else {
                 if (input.getScore() >= injectExpectation.getExpectedScore()) {
                     result = "Success";
@@ -54,6 +52,8 @@ public class ExerciseExpectationService {
                     result = "Failed";
                 }
             }
+            injectExpectation.getResults().clear();
+            exists = Optional.empty();
         } else if (injectExpectation.getType() == EXPECTATION_TYPE.DETECTION) {
             if (input.getScore() >= injectExpectation.getExpectedScore()) {
                 result = "Detected";

--- a/openbas-api/src/main/java/io/openbas/service/ExerciseExpectationService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ExerciseExpectationService.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -123,6 +124,7 @@ public class ExerciseExpectationService {
                     .build();
             parentExpectation.getResults().clear();
             parentExpectation.getResults().add(expectationResult);
+            parentExpectation.setUpdatedAt(Instant.now());
             injectExpectationRepository.save(parentExpectation);
         } else {
             // If I update the expectation team: What happens with children? -> update expectation score for all children -> set score from InjectExpectation
@@ -139,6 +141,7 @@ public class ExerciseExpectationService {
                 expectation.getResults().clear();
                 expectation.getResults().add(expectationResult);
                 expectation.setScore(updated.getScore());
+                expectation.setUpdatedAt(Instant.now());
                 injectExpectationRepository.save(expectation);
             }
         }

--- a/openbas-api/src/main/java/io/openbas/service/ExerciseExpectationService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ExerciseExpectationService.java
@@ -136,6 +136,7 @@ public class ExerciseExpectationService {
     }
 
     // -- VALIDATION TYPE --
+
     private void computeExpectationsForTeamsAndPlayer(InjectExpectation updated, String result) {
         //If the updated expectation was a player expectation, We have to update the team expectation using player expectations (based on validation type)
         if (updated.getUser() != null) {

--- a/openbas-api/src/main/java/io/openbas/service/ExerciseExpectationService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ExerciseExpectationService.java
@@ -43,6 +43,8 @@ public class ExerciseExpectationService {
         if (injectExpectation.getType() == EXPECTATION_TYPE.MANUAL) {
             if (injectExpectation.getTeam() != null && injectExpectation.getUser() == null) { //If it is a team expectation
                 result = input.getScore() > 0 ? "Success" : "Failed";
+                injectExpectation.getResults().clear();
+                exists = Optional.empty();
             } else {
                 if (input.getScore() >= injectExpectation.getExpectedScore()) {
                     result = "Success";
@@ -52,8 +54,6 @@ public class ExerciseExpectationService {
                     result = "Failed";
                 }
             }
-            injectExpectation.getResults().clear();
-            exists = Optional.empty();
         } else if (injectExpectation.getType() == EXPECTATION_TYPE.DETECTION) {
             if (input.getScore() >= injectExpectation.getExpectedScore()) {
                 result = "Detected";

--- a/openbas-api/src/main/java/io/openbas/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectService.java
@@ -728,10 +728,10 @@ public class InjectService {
                                 Double columnValueExpectation = columns.stream()
                                         .map(column -> getValueAsDouble(row, column))
                                         .reduce(0.0, Double::sum);
-                                expectation.get().setExpectedScore(columnValueExpectation.intValue());
+                                expectation.get().setExpectedScore(columnValueExpectation.doubleValue());
                             } else {
                                 try {
-                                    expectation.get().setExpectedScore(Integer.parseInt(ruleAttribute.getDefaultValue()));
+                                    expectation.get().setExpectedScore(Double.parseDouble(ruleAttribute.getDefaultValue()));
                                 } catch (NumberFormatException exception) {
                                     List<ImportMessage> importMessages = new ArrayList<>();
                                     importMessages.add(new ImportMessage(ImportMessage.MessageLevel.WARN,
@@ -743,7 +743,7 @@ public class InjectService {
                                 }
                             }
                         } else {
-                            expectation.get().setExpectedScore(Integer.parseInt(ruleAttribute.getDefaultValue()));
+                            expectation.get().setExpectedScore(Double.parseDouble(ruleAttribute.getDefaultValue()));
                         }
                     } else if ("name".equals(ruleAttribute.getName().split("_")[1])) {
                         if(ruleAttribute.getColumns() != null) {

--- a/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
@@ -351,7 +351,7 @@ public class AtomicTestingUtils {
                 .getExpectations()
                 .stream()
                 .filter(expectation -> targetIds.contains(expectation.getTargetId()))
-                .filter(expectation -> expectation.getUser() == null) // Filter expectations linked to players
+                .filter(expectation -> expectation.getUser() == null) // Filter expectations linked to players. For global results, We use Team expectations
                 .toList();
     }
 
@@ -412,13 +412,29 @@ public class AtomicTestingUtils {
                     if( rawInjectExpectation.getInject_expectation_score() == null ) {
                         return null;
                     }
-                    if( rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score() ) {
-                        return 1.0;
+                    if(rawInjectExpectation.getTeam_id() != null) {
+                        if (rawInjectExpectation.getInject_expectation_group()) {
+                            if (rawInjectExpectation.getInject_expectation_score() > 0) {
+                                return 1.0;
+                            } else {
+                                return 0.0;
+                            }
+                        } else {
+                            if (rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score()) {
+                                return 1.0;
+                            } else {
+                                return 0.0;
+                            }
+                        }
+                    }else{
+                        if( rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score() ) {
+                            return 1.0;
+                        }
+                        if( rawInjectExpectation.getInject_expectation_score() == 0 ) {
+                            return 0.0;
+                        }
+                        return 0.5;
                     }
-                    if( rawInjectExpectation.getInject_expectation_score() == 0 ) {
-                        return 0.0;
-                    }
-                    return 0.5;
                 })
                 .toList();
     }

--- a/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
@@ -412,29 +412,13 @@ public class AtomicTestingUtils {
                     if( rawInjectExpectation.getInject_expectation_score() == null ) {
                         return null;
                     }
-                    if(rawInjectExpectation.getTeam_id() != null) {
-                        if (true) {
-                            if (rawInjectExpectation.getInject_expectation_score() > 0) {
-                                return 1.0;
-                            } else {
-                                return 0.0;
-                            }
-                        } else {
-                            if (rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score()) {
-                                return 1.0;
-                            } else {
-                                return 0.0;
-                            }
-                        }
-                    }else{
-                        if( rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score() ) {
-                            return 1.0;
-                        }
-                        if( rawInjectExpectation.getInject_expectation_score() == 0 ) {
-                            return 0.0;
-                        }
-                        return 0.5;
+                    if( rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score() ) {
+                        return 1.0;
                     }
+                    if( rawInjectExpectation.getInject_expectation_score() == 0 ) {
+                        return 0.0;
+                    }
+                    return 0.5;
                 })
                 .toList();
     }

--- a/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
@@ -20,9 +20,9 @@ import java.util.stream.Collectors;
 public class AtomicTestingUtils {
 
     public static List<InjectTargetWithResult> getTargets(
-        final List<Team> teams,
-        final List<Asset> assets,
-        final List<AssetGroup> assetGroups) {
+            final List<Team> teams,
+            final List<Asset> assets,
+            final List<AssetGroup> assetGroups) {
         List<InjectTargetWithResult> targets = new ArrayList<>();
         targets.addAll(teams
                 .stream()
@@ -30,7 +30,7 @@ public class AtomicTestingUtils {
                 .toList());
         targets.addAll(assets
                 .stream()
-                .map(t -> new InjectTargetWithResult(TargetType.ASSETS, t.getId(), t.getName(), List.of(), Objects.equals(t.getType(), "Endpoint") ? ((Endpoint) Hibernate.unproxy(t)).getPlatform(): null))
+                .map(t -> new InjectTargetWithResult(TargetType.ASSETS, t.getId(), t.getName(), List.of(), Objects.equals(t.getType(), "Endpoint") ? ((Endpoint) Hibernate.unproxy(t)).getPlatform() : null))
                 .toList());
         targets.addAll(assetGroups
                 .stream()
@@ -41,22 +41,22 @@ public class AtomicTestingUtils {
     }
 
     public static List<InjectTargetWithResult> getTargetsFromRaw(
-        final List<RawTeam> teams,
-        final List<RawAsset> assets,
-        final List<RawAssetGroup> assetGroups) {
+            final List<RawTeam> teams,
+            final List<RawAsset> assets,
+            final List<RawAssetGroup> assetGroups) {
         List<InjectTargetWithResult> targets = new ArrayList<>();
         targets.addAll(teams
-            .stream()
-            .map(t -> new InjectTargetWithResult(TargetType.TEAMS, t.getTeam_id(), t.getTeam_name(), List.of(), null))
-            .toList());
+                .stream()
+                .map(t -> new InjectTargetWithResult(TargetType.TEAMS, t.getTeam_id(), t.getTeam_name(), List.of(), null))
+                .toList());
         targets.addAll(assets
-            .stream()
-            .map(t -> new InjectTargetWithResult(TargetType.ASSETS, t.getAsset_id(), t.getAsset_name(), List.of(), Objects.equals(t.getAsset_type(), "Endpoint") ? Endpoint.PLATFORM_TYPE.valueOf(t.getEndpoint_platform()): null))
-            .toList());
+                .stream()
+                .map(t -> new InjectTargetWithResult(TargetType.ASSETS, t.getAsset_id(), t.getAsset_name(), List.of(), Objects.equals(t.getAsset_type(), "Endpoint") ? Endpoint.PLATFORM_TYPE.valueOf(t.getEndpoint_platform()) : null))
+                .toList());
         targets.addAll(assetGroups
-            .stream()
-            .map(t -> new InjectTargetWithResult(TargetType.ASSETS_GROUPS, t.getAsset_group_id(), t.getAsset_group_name(), List.of(), null))
-            .toList());
+                .stream()
+                .map(t -> new InjectTargetWithResult(TargetType.ASSETS_GROUPS, t.getAsset_group_id(), t.getAsset_group_name(), List.of(), null))
+                .toList());
 
         return targets;
     }
@@ -72,9 +72,9 @@ public class AtomicTestingUtils {
 
         expectations.forEach(expectation -> {
             if (expectation.getTeam() != null) {
-                if(expectation.getUser() != null) {
+                if (expectation.getUser() != null) {
                     playerExpectations.add(expectation);
-                }else{
+                } else {
                     teamExpectations.add(expectation);
                 }
             }
@@ -109,7 +109,7 @@ public class AtomicTestingUtils {
                         team.getName(),
                         defaultExpectationResultsByTypes,
                         null
-                        );
+                );
                 targets.add(target);
             }
         });
@@ -183,7 +183,7 @@ public class AtomicTestingUtils {
                                     )
                             )
                             .entrySet().stream()
-                            .map(entry -> new InjectTargetWithResult(TargetType.TEAMS, entry.getKey().getId(), entry.getKey().getName(), entry.getValue(), playerExpectations.isEmpty()? List.of() : calculateResultsforPlayers(groupedByTeamAndUser.get(entry.getKey())), null))
+                            .map(entry -> new InjectTargetWithResult(TargetType.TEAMS, entry.getKey().getId(), entry.getKey().getName(), entry.getValue(), playerExpectations.isEmpty() ? List.of() : calculateResultsforPlayers(groupedByTeamAndUser.get(entry.getKey())), null))
                             .toList()
             );
         }
@@ -374,10 +374,10 @@ public class AtomicTestingUtils {
                 .stream()
                 .filter(e -> types.contains(e.getType()))
                 .map(injectExpectation -> {
-                    if( injectExpectation.getScore() == null ) {
+                    if (injectExpectation.getScore() == null) {
                         return null;
                     }
-                    if(injectExpectation.getTeam() != null) {
+                    if (injectExpectation.getTeam() != null) {
                         if (injectExpectation.isExpectationGroup()) {
                             if (injectExpectation.getScore() > 0) {
                                 return 1.0;
@@ -391,11 +391,11 @@ public class AtomicTestingUtils {
                                 return 0.0;
                             }
                         }
-                    }else{
-                        if( injectExpectation.getScore() >= injectExpectation.getExpectedScore() ) {
+                    } else {
+                        if (injectExpectation.getScore() >= injectExpectation.getExpectedScore()) {
                             return 1.0;
                         }
-                        if( injectExpectation.getScore() == 0 ) {
+                        if (injectExpectation.getScore() == 0) {
                             return 0.0;
                         }
                         return 0.5;
@@ -409,10 +409,10 @@ public class AtomicTestingUtils {
                 .stream()
                 .filter(e -> types.contains(EXPECTATION_TYPE.valueOf(e.getInject_expectation_type())))
                 .map(rawInjectExpectation -> {
-                    if( rawInjectExpectation.getInject_expectation_score() == null ) {
+                    if (rawInjectExpectation.getInject_expectation_score() == null) {
                         return null;
                     }
-                    if(rawInjectExpectation.getTeam_id() != null) {
+                    if (rawInjectExpectation.getTeam_id() != null) {
                         if (rawInjectExpectation.getInject_expectation_group()) {
                             if (rawInjectExpectation.getInject_expectation_score() > 0) {
                                 return 1.0;
@@ -426,11 +426,11 @@ public class AtomicTestingUtils {
                                 return 0.0;
                             }
                         }
-                    }else{
-                        if( rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score() ) {
+                    } else {
+                        if (rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score()) {
                             return 1.0;
                         }
-                        if( rawInjectExpectation.getInject_expectation_score() == 0 ) {
+                        if (rawInjectExpectation.getInject_expectation_score() == 0) {
                             return 0.0;
                         }
                         return 0.5;

--- a/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
@@ -183,7 +183,7 @@ public class AtomicTestingUtils {
                                     )
                             )
                             .entrySet().stream()
-                            .map(entry -> new InjectTargetWithResult(TargetType.TEAMS, entry.getKey().getId(), entry.getKey().getName(), entry.getValue(), playerExpectations.isEmpty()? List.of() : calculateChildren(groupedByTeamAndUser.get(entry.getKey())), null))
+                            .map(entry -> new InjectTargetWithResult(TargetType.TEAMS, entry.getKey().getId(), entry.getKey().getName(), entry.getValue(), playerExpectations.isEmpty()? List.of() : calculateResultsforPlayers(groupedByTeamAndUser.get(entry.getKey())), null))
                             .toList()
             );
         }
@@ -279,7 +279,7 @@ public class AtomicTestingUtils {
         return sortResults(targets);
     }
 
-    private static List<InjectTargetWithResult> calculateChildren(Map<User, List<InjectExpectation>> expectationsByUser) {
+    private static List<InjectTargetWithResult> calculateResultsforPlayers(Map<User, List<InjectExpectation>> expectationsByUser) {
         return expectationsByUser.entrySet().stream()
                 .map(userEntry -> new InjectTargetWithResult(
                         TargetType.PLAYER,
@@ -377,13 +377,29 @@ public class AtomicTestingUtils {
                     if( injectExpectation.getScore() == null ) {
                         return null;
                     }
-                    if( injectExpectation.getScore() >= injectExpectation.getExpectedScore() ) {
-                        return 1.0;
+                    if(injectExpectation.getTeam() != null) {
+                        if (injectExpectation.isExpectationGroup()) {
+                            if (injectExpectation.getScore() > 0) {
+                                return 1.0;
+                            } else {
+                                return 0.0;
+                            }
+                        } else {
+                            if (injectExpectation.getScore() >= injectExpectation.getExpectedScore()) {
+                                return 1.0;
+                            } else {
+                                return 0.0;
+                            }
+                        }
+                    }else{
+                        if( injectExpectation.getScore() >= injectExpectation.getExpectedScore() ) {
+                            return 1.0;
+                        }
+                        if( injectExpectation.getScore() == 0 ) {
+                            return 0.0;
+                        }
+                        return 0.5;
                     }
-                    if( injectExpectation.getScore() == 0 ) {
-                        return 0.0;
-                    }
-                    return 0.5;
                 })
                 .toList();
     }
@@ -396,13 +412,29 @@ public class AtomicTestingUtils {
                     if( rawInjectExpectation.getInject_expectation_score() == null ) {
                         return null;
                     }
-                    if( rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score() ) {
-                        return 1.0;
+                    if(rawInjectExpectation.getTeam_id() != null) {
+                        if (true) {
+                            if (rawInjectExpectation.getInject_expectation_score() > 0) {
+                                return 1.0;
+                            } else {
+                                return 0.0;
+                            }
+                        } else {
+                            if (rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score()) {
+                                return 1.0;
+                            } else {
+                                return 0.0;
+                            }
+                        }
+                    }else{
+                        if( rawInjectExpectation.getInject_expectation_score() >= rawInjectExpectation.getInject_expectation_expected_score() ) {
+                            return 1.0;
+                        }
+                        if( rawInjectExpectation.getInject_expectation_score() == 0 ) {
+                            return 0.0;
+                        }
+                        return 0.5;
                     }
-                    if( rawInjectExpectation.getInject_expectation_score() == 0 ) {
-                        return 0.0;
-                    }
-                    return 0.5;
                 })
                 .toList();
     }

--- a/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
@@ -183,7 +183,7 @@ public class AtomicTestingUtils {
                                     )
                             )
                             .entrySet().stream()
-                            .map(entry -> new InjectTargetWithResult(TargetType.TEAMS, entry.getKey().getId(), entry.getKey().getName(), entry.getValue(), calculateChildren(groupedByTeamAndUser.get(entry.getKey())), null))
+                            .map(entry -> new InjectTargetWithResult(TargetType.TEAMS, entry.getKey().getId(), entry.getKey().getName(), entry.getValue(), playerExpectations.isEmpty()? List.of() : calculateChildren(groupedByTeamAndUser.get(entry.getKey())), null))
                             .toList()
             );
         }
@@ -351,6 +351,7 @@ public class AtomicTestingUtils {
                 .getExpectations()
                 .stream()
                 .filter(expectation -> targetIds.contains(expectation.getTargetId()))
+                .filter(expectation -> expectation.getUser() == null) // Filter expectations linked to players
                 .toList();
     }
 

--- a/openbas-api/src/main/java/io/openbas/utils/ExpectationUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/ExpectationUtils.java
@@ -1,0 +1,74 @@
+package io.openbas.utils;
+
+import io.openbas.database.model.InjectExpectation;
+import io.openbas.database.model.InjectExpectationResult;
+import io.openbas.database.model.Team;
+import io.openbas.rest.exception.ElementNotFoundException;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalDouble;
+
+public class ExpectationUtils {
+
+
+    public static List<InjectExpectation> processByValidationType(boolean isaNewExpectationResult, List<InjectExpectation> childrenExpectations, List<InjectExpectation> parentExpectations, Map<Team, List<InjectExpectation>> playerByTeam) {
+        List<InjectExpectation> updatedExpectations = new ArrayList<>();
+
+        childrenExpectations.stream().findAny().ifPresentOrElse(process -> {
+            boolean isValidationAtLeastOneTarget = process.isExpectationGroup();
+
+            parentExpectations.forEach(parentExpectation -> {
+                List<InjectExpectation> toProcess = playerByTeam.get(parentExpectation.getTeam());
+                int playersSize = toProcess.size(); // Without Parent expectation
+                long zeroPlayerResponses = toProcess.stream().filter(exp -> exp.getScore() != null).filter(exp -> exp.getScore() == 0.0).count();
+                long nullPlayerResponses = toProcess.stream().filter(exp -> exp.getScore() == null).count();
+
+                if (isValidationAtLeastOneTarget) { // Type atLeast
+                    OptionalDouble avgAtLeastOnePlayer = toProcess.stream().filter(exp -> exp.getScore() != null).filter(exp -> exp.getScore() > 0.0).mapToDouble(InjectExpectation::getScore).average();
+                    if (avgAtLeastOnePlayer.isPresent()) { //Any response is positive
+                        parentExpectation.setScore(avgAtLeastOnePlayer.getAsDouble());
+                    } else {
+                        if (zeroPlayerResponses == playersSize) { //All players had failed
+                            parentExpectation.setScore(0.0);
+                        } else {
+                            parentExpectation.setScore(null);
+                        }
+                    }
+                } else { // type all
+                    if(nullPlayerResponses == 0){
+                        OptionalDouble avgAllPlayer = toProcess.stream().mapToDouble(InjectExpectation::getScore).average();
+                        parentExpectation.setScore(avgAllPlayer.getAsDouble());
+                    }else{
+                        if(zeroPlayerResponses == 0) {
+                            parentExpectation.setScore(null);
+                        }else{
+                            double sumAllPlayer = toProcess.stream().filter(exp->exp.getScore() != null).mapToDouble(InjectExpectation::getScore).sum();
+                            parentExpectation.setScore(sumAllPlayer/playersSize);
+                        }
+                    }
+                }
+
+                if(isaNewExpectationResult) {
+                    InjectExpectationResult result = InjectExpectationResult.builder()
+                            .sourceId("media-pressure")
+                            .sourceType("media-pressure")
+                            .sourceName("Media pressure read")
+                            .result(Instant.now().toString())
+                            .date(Instant.now().toString())
+                            .score(process.getExpectedScore())
+                            .build();
+                    parentExpectation.getResults().add(result);
+                }
+
+                parentExpectation.setUpdatedAt(Instant.now());
+                updatedExpectations.add(parentExpectation);
+            });
+        }, ElementNotFoundException::new);
+
+        return updatedExpectations;
+    }
+
+}

--- a/openbas-api/src/main/java/io/openbas/utils/ResultUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/ResultUtils.java
@@ -26,6 +26,7 @@ public class ResultUtils {
         List<InjectExpectation> expectations = injects
                 .stream()
                 .flatMap(inject -> inject.getExpectations().stream())
+                .filter(expectation -> expectation.getUser() == null) // Filter expectations linked to players
                 .toList();
         return AtomicTestingUtils.getExpectationResultByTypes(expectations);
     }

--- a/openbas-api/src/test/java/io/openbas/injects/email/EmailExecutorTest.java
+++ b/openbas-api/src/test/java/io/openbas/injects/email/EmailExecutorTest.java
@@ -49,7 +49,7 @@ public class EmailExecutorTest {
     content.setBody("A body");
     Expectation expectation = new Expectation();
     expectation.setName("The animation team can validate the audience reaction");
-    expectation.setScore(10);
+    expectation.setScore(10.0);
     expectation.setType(InjectExpectation.EXPECTATION_TYPE.MANUAL);
     content.setExpectations(List.of(expectation));
     Inject inject = new Inject();

--- a/openbas-api/src/test/java/io/openbas/service/ExerciseExpectationServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/service/ExerciseExpectationServiceTest.java
@@ -75,7 +75,7 @@ public class ExerciseExpectationServiceTest {
 
         // -- EXECUTE --
         ExpectationUpdateInput input = new ExpectationUpdateInput();
-        input.setScore(7);
+        input.setScore(7.0);
         InjectExpectation expectation = this.exerciseExpectationService.updateInjectExpectation(id, input);
 
         // -- ASSERT --
@@ -114,7 +114,7 @@ public class ExerciseExpectationServiceTest {
         expectation.setTeam(teamCreated);
         expectation.setType(MANUAL);
         expectation.setName(EXPECTATION_NAME);
-        expectation.setExpectedScore(10);
+        expectation.setExpectedScore(10.0);
         expectation.setExercise(exerciseCreated);
         this.injectExpectationRepository.save(expectation);
     }

--- a/openbas-api/src/test/java/io/openbas/service/InjectServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/service/InjectServiceTest.java
@@ -159,10 +159,10 @@ class InjectServiceTest {
             verify(teamRepository, times(1)).save(any());
             assertEquals(30 * 24 * 60 * 60, importTestSummary.getInjects().getLast().getDependsDuration());
 
-            ObjectNode jsonNodeMail = (ObjectNode) mapper.readTree("{\"message\":\"message1\",\"expectations\":[{\"expectation_description\":\"expectation\",\"expectation_name\":\"expectation done\",\"expectation_score\":100,\"expectation_type\":\"MANUAL\",\"expectation_expectation_group\":false}]}");
+            ObjectNode jsonNodeMail = (ObjectNode) mapper.readTree("{\"message\":\"message1\",\"expectations\":[{\"expectation_description\":\"expectation\",\"expectation_name\":\"expectation done\",\"expectation_score\":100.0,\"expectation_type\":\"MANUAL\",\"expectation_expectation_group\":false}]}");
             assertEquals(jsonNodeMail, importTestSummary.getInjects().getFirst().getContent());
 
-            ObjectNode jsonNodeSms = (ObjectNode) mapper.readTree("{\"subject\":\"subject\",\"body\":\"message2\",\"expectations\":[{\"expectation_description\":\"expectation\",\"expectation_name\":\"expectation done\",\"expectation_score\":100,\"expectation_type\":\"MANUAL\",\"expectation_expectation_group\":false}]}");
+            ObjectNode jsonNodeSms = (ObjectNode) mapper.readTree("{\"subject\":\"subject\",\"body\":\"message2\",\"expectations\":[{\"expectation_description\":\"expectation\",\"expectation_name\":\"expectation done\",\"expectation_score\":100.0,\"expectation_type\":\"MANUAL\",\"expectation_expectation_group\":false}]}");
             assertEquals(jsonNodeSms, importTestSummary.getInjects().getLast().getContent());
         }
     }
@@ -577,7 +577,7 @@ class InjectServiceTest {
         RuleAttribute ruleAttributeExpectationScore = new RuleAttribute();
         ruleAttributeExpectationScore.setName("expectation_score");
         ruleAttributeExpectationScore.setColumns("J");
-        ruleAttributeExpectationScore.setDefaultValue("500");
+        ruleAttributeExpectationScore.setDefaultValue("500.0");
 
         RuleAttribute ruleAttributeExpectationName = new RuleAttribute();
         ruleAttributeExpectationName.setName("expectation_name");
@@ -637,7 +637,7 @@ class InjectServiceTest {
         RuleAttribute ruleAttributeExpectationScore = new RuleAttribute();
         ruleAttributeExpectationScore.setName("expectation_score");
         ruleAttributeExpectationScore.setColumns("J");
-        ruleAttributeExpectationScore.setDefaultValue("500");
+        ruleAttributeExpectationScore.setDefaultValue("500.0");
 
         RuleAttribute ruleAttributeExpectationName = new RuleAttribute();
         ruleAttributeExpectationName.setName("expectation_name");

--- a/openbas-framework/src/main/java/io/openbas/asset/AssetGroupService.java
+++ b/openbas-framework/src/main/java/io/openbas/asset/AssetGroupService.java
@@ -103,7 +103,6 @@ public class AssetGroupService {
                 assetGroup.setDynamicAssets(filteredAssets);
             }
         });
-
         return assetGroups;
     }
 

--- a/openbas-framework/src/main/java/io/openbas/atomic_testing/TargetType.java
+++ b/openbas-framework/src/main/java/io/openbas/atomic_testing/TargetType.java
@@ -3,5 +3,6 @@ package io.openbas.atomic_testing;
 public enum TargetType {
   ASSETS,
   ASSETS_GROUPS,
+  PLAYER,
   TEAMS
 }

--- a/openbas-framework/src/main/java/io/openbas/execution/Injector.java
+++ b/openbas-framework/src/main/java/io/openbas/execution/Injector.java
@@ -87,8 +87,14 @@ public abstract class Injector {
         expectationExecution.setExpectedScore(expectation.getScore());
         expectationExecution.setExpectationGroup(expectation.isExpectationGroup());
         switch (expectation.type()) {
-            case ARTICLE -> expectationExecution.setArticle(((ChannelExpectation) expectation).getArticle());
-            case CHALLENGE -> expectationExecution.setChallenge(((ChallengeExpectation) expectation).getChallenge());
+            case ARTICLE -> {
+                expectationExecution.setName(expectation.getName());
+                expectationExecution.setArticle(((ChannelExpectation) expectation).getArticle());
+            }
+            case CHALLENGE -> {
+                expectationExecution.setName(expectation.getName());
+                expectationExecution.setChallenge(((ChallengeExpectation) expectation).getChallenge());
+            }
             case DOCUMENT -> expectationExecution.setType(EXPECTATION_TYPE.DOCUMENT);
             case TEXT -> expectationExecution.setType(EXPECTATION_TYPE.TEXT);
             case DETECTION -> {

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
@@ -176,11 +176,13 @@ public class InjectExpectationService {
     public List<InjectExpectation> findExpectationsByInjectAndTargetAndTargetType(
             @NotBlank final String injectId,
             @NotBlank final String targetId,
+            @NotBlank final String targetParentId,
             @NotBlank final String targetType) {
         try {
             TargetType targetTypeEnum = TargetType.valueOf(targetType);
             return switch (targetTypeEnum) {
                 case TEAMS -> injectExpectationRepository.findAllByInjectAndTeam(injectId, targetId);
+                case PLAYER -> injectExpectationRepository.findAllByInjectAndTeamAndPlayer(injectId, targetParentId, targetId);
                 case ASSETS -> injectExpectationRepository.findAllByInjectAndAsset(injectId, targetId);
                 case ASSETS_GROUPS -> injectExpectationRepository.findAllByInjectAndAssetGroup(injectId, targetId);
             };

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
@@ -51,8 +51,8 @@ public class InjectExpectationService {
             computeResult(expectation, sourceId, sourceType, sourceName, result, expectation.getExpectedScore());
             expectation.setScore(expectation.getExpectedScore());
         } else if (expectation.getScore() == null) {
-            computeResult(expectation, sourceId, sourceType, sourceName, result, 0);
-            expectation.setScore(0);
+            computeResult(expectation, sourceId, sourceType, sourceName, result, 0.0);
+            expectation.setScore(0.0);
         }
         return this.update(expectation);
     }
@@ -71,7 +71,7 @@ public class InjectExpectationService {
             success = expectationAssets.stream().allMatch((e) -> e.getExpectedScore().equals(e.getScore()));
         }
         computeResult(expectationAssetGroup, sourceId, sourceType, sourceName, success ? "SUCCESS" : "FAILED", success ? expectationAssetGroup.getExpectedScore() : 0);
-        expectationAssetGroup.setScore(success ? expectationAssetGroup.getExpectedScore() : 0);
+        expectationAssetGroup.setScore(success ? expectationAssetGroup.getExpectedScore() : 0.0);
         this.update(expectationAssetGroup);
     }
 

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
@@ -176,13 +176,13 @@ public class InjectExpectationService {
     public List<InjectExpectation> findExpectationsByInjectAndTargetAndTargetType(
             @NotBlank final String injectId,
             @NotBlank final String targetId,
-            @NotBlank final String targetParentId,
+            @NotBlank final String parentTargetId,
             @NotBlank final String targetType) {
         try {
             TargetType targetTypeEnum = TargetType.valueOf(targetType);
             return switch (targetTypeEnum) {
                 case TEAMS -> injectExpectationRepository.findAllByInjectAndTeam(injectId, targetId);
-                case PLAYER -> injectExpectationRepository.findAllByInjectAndTeamAndPlayer(injectId, targetParentId, targetId);
+                case PLAYER -> injectExpectationRepository.findAllByInjectAndTeamAndPlayer(injectId, parentTargetId, targetId);
                 case ASSETS -> injectExpectationRepository.findAllByInjectAndAsset(injectId, targetId);
                 case ASSETS_GROUPS -> injectExpectationRepository.findAllByInjectAndAssetGroup(injectId, targetId);
             };

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
@@ -29,7 +29,7 @@ public class InjectExpectationUtils {
             @NotBlank final String sourceType,
             @NotBlank final String sourceName,
             @NotBlank final String result,
-            @NotBlank final Integer score
+            @NotBlank final Double score
     ) {
         Optional<InjectExpectationResult> exists = expectation.getResults()
                 .stream()

--- a/openbas-framework/src/main/java/io/openbas/integrations/PayloadService.java
+++ b/openbas-framework/src/main/java/io/openbas/integrations/PayloadService.java
@@ -130,12 +130,12 @@ public class PayloadService {
         Expectation preventionExpectation = new Expectation();
         preventionExpectation.setType(PREVENTION);
         preventionExpectation.setName("Expect inject to be prevented");
-        preventionExpectation.setScore(100);
+        preventionExpectation.setScore(100.0);
         // Detection
         Expectation detectionExpectation = new Expectation();
         detectionExpectation.setType(DETECTION);
         detectionExpectation.setName("Expect inject to be detected");
-        detectionExpectation.setScore(100);
+        detectionExpectation.setScore(100.0);
         return expectationsField("expectations", "Expectations", List.of(preventionExpectation, detectionExpectation));
     }
 

--- a/openbas-framework/src/main/java/io/openbas/model/Expectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/Expectation.java
@@ -9,4 +9,5 @@ public interface Expectation {
     default boolean isExpectationGroup() {
         return false;
     }
+    String getName();
 }

--- a/openbas-framework/src/main/java/io/openbas/model/Expectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/Expectation.java
@@ -5,7 +5,7 @@ import io.openbas.database.model.InjectExpectation.EXPECTATION_TYPE;
 public interface Expectation {
 
     EXPECTATION_TYPE type();
-    Integer getScore();
+    Double getScore();
     default boolean isExpectationGroup() {
         return false;
     }

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/ChallengeExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/ChallengeExpectation.java
@@ -12,17 +12,17 @@ import java.util.Objects;
 @Setter
 public class ChallengeExpectation implements Expectation {
 
-  private Integer score;
+  private Double score;
   private Challenge challenge;
   private boolean expectationGroup;
 
-  public ChallengeExpectation(Integer score, Challenge challenge) {
-    setScore(Objects.requireNonNullElse(score, 100));
+  public ChallengeExpectation(Double score, Challenge challenge) {
+    setScore(Objects.requireNonNullElse(score, 100.0));
     setChallenge(challenge);
   }
 
-  public ChallengeExpectation(Integer score, Challenge challenge, boolean expectationGroup) {
-    setScore(Objects.requireNonNullElse(score, 100));
+  public ChallengeExpectation(Double score, Challenge challenge, boolean expectationGroup) {
+    setScore(Objects.requireNonNullElse(score, 100.0));
     setChallenge(challenge);
     setExpectationGroup(expectationGroup);
   }

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/ChallengeExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/ChallengeExpectation.java
@@ -15,6 +15,7 @@ public class ChallengeExpectation implements Expectation {
   private Double score;
   private Challenge challenge;
   private boolean expectationGroup;
+  private String name;
 
   public ChallengeExpectation(Double score, Challenge challenge) {
     setScore(Objects.requireNonNullElse(score, 100.0));
@@ -24,6 +25,7 @@ public class ChallengeExpectation implements Expectation {
   public ChallengeExpectation(Double score, Challenge challenge, boolean expectationGroup) {
     setScore(Objects.requireNonNullElse(score, 100.0));
     setChallenge(challenge);
+    setName(challenge.getName());
     setExpectationGroup(expectationGroup);
   }
 

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/ChallengeExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/ChallengeExpectation.java
@@ -14,10 +14,17 @@ public class ChallengeExpectation implements Expectation {
 
   private Integer score;
   private Challenge challenge;
+  private boolean expectationGroup;
 
   public ChallengeExpectation(Integer score, Challenge challenge) {
     setScore(Objects.requireNonNullElse(score, 100));
     setChallenge(challenge);
+  }
+
+  public ChallengeExpectation(Integer score, Challenge challenge, boolean expectationGroup) {
+    setScore(Objects.requireNonNullElse(score, 100));
+    setChallenge(challenge);
+    setExpectationGroup(expectationGroup);
   }
 
   @Override

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/ChannelExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/ChannelExpectation.java
@@ -12,17 +12,17 @@ import java.util.Objects;
 @Setter
 public class ChannelExpectation implements Expectation {
 
-  private Integer score;
+  private Double score;
   private Article article;
   private boolean expectationGroup;
 
-  public ChannelExpectation(Integer score, Article article) {
-    setScore(Objects.requireNonNullElse(score, 100));
+  public ChannelExpectation(Double score, Article article) {
+    setScore(Objects.requireNonNullElse(score, 100.0));
     setArticle(article);
   }
 
-  public ChannelExpectation(Integer score, Article article, boolean expectationGroup) {
-    setScore(Objects.requireNonNullElse(score, 100));
+  public ChannelExpectation(Double score, Article article, boolean expectationGroup) {
+    setScore(Objects.requireNonNullElse(score, 100.0));
     setArticle(article);
     setExpectationGroup(expectationGroup);
   }

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/ChannelExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/ChannelExpectation.java
@@ -15,6 +15,7 @@ public class ChannelExpectation implements Expectation {
   private Double score;
   private Article article;
   private boolean expectationGroup;
+  private String name;
 
   public ChannelExpectation(Double score, Article article) {
     setScore(Objects.requireNonNullElse(score, 100.0));
@@ -24,6 +25,7 @@ public class ChannelExpectation implements Expectation {
   public ChannelExpectation(Double score, Article article, boolean expectationGroup) {
     setScore(Objects.requireNonNullElse(score, 100.0));
     setArticle(article);
+    setName(article.getName());
     setExpectationGroup(expectationGroup);
   }
 

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/ChannelExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/ChannelExpectation.java
@@ -14,10 +14,17 @@ public class ChannelExpectation implements Expectation {
 
   private Integer score;
   private Article article;
+  private boolean expectationGroup;
 
   public ChannelExpectation(Integer score, Article article) {
     setScore(Objects.requireNonNullElse(score, 100));
     setArticle(article);
+  }
+
+  public ChannelExpectation(Integer score, Article article, boolean expectationGroup) {
+    setScore(Objects.requireNonNullElse(score, 100));
+    setArticle(article);
+    setExpectationGroup(expectationGroup);
   }
 
   @Override

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/DetectionExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/DetectionExpectation.java
@@ -20,7 +20,7 @@ import static io.openbas.database.model.InjectExpectation.EXPECTATION_TYPE.DETEC
 @Setter
 public class DetectionExpectation implements Expectation {
 
-    private Integer score;
+    private Double score;
     private String name;
     private String description;
     private Asset asset;
@@ -37,7 +37,7 @@ public class DetectionExpectation implements Expectation {
     }
 
     public static DetectionExpectation detectionExpectationForAsset(
-            @Nullable final Integer score,
+            @Nullable final Double score,
             @NotBlank final String name,
             final String description,
             @NotNull final Asset asset,
@@ -45,7 +45,7 @@ public class DetectionExpectation implements Expectation {
             final List<InjectExpectationSignature> expectationSignatures
     ) {
         DetectionExpectation detectionExpectation = new DetectionExpectation();
-        detectionExpectation.setScore(Objects.requireNonNullElse(score, 100));
+        detectionExpectation.setScore(Objects.requireNonNullElse(score, 100.0));
         detectionExpectation.setName(name);
         detectionExpectation.setDescription(description);
         detectionExpectation.setAsset(asset);
@@ -55,7 +55,7 @@ public class DetectionExpectation implements Expectation {
     }
 
     public static DetectionExpectation detectionExpectationForAssetGroup(
-            @Nullable final Integer score,
+            @Nullable final Double score,
             @NotBlank final String name,
             final String description,
             @NotNull final AssetGroup assetGroup,
@@ -63,7 +63,7 @@ public class DetectionExpectation implements Expectation {
             final List<InjectExpectationSignature> expectationSignatures
     ) {
         DetectionExpectation detectionExpectation = new DetectionExpectation();
-        detectionExpectation.setScore(Objects.requireNonNullElse(score, 100));
+        detectionExpectation.setScore(Objects.requireNonNullElse(score, 100.0));
         detectionExpectation.setName(name);
         detectionExpectation.setDescription(description);
         detectionExpectation.setAssetGroup(assetGroup);

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/ManualExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/ManualExpectation.java
@@ -39,6 +39,13 @@ public class ManualExpectation implements Expectation {
     this.description = description;
   }
 
+  public ManualExpectation(final Integer score, @NotBlank final String name, final String description, final boolean expectationGroup) {
+    this(score);
+    this.name = name;
+    this.description = description;
+    this.expectationGroup = expectationGroup;
+  }
+
   public static ManualExpectation manualExpectationForAsset(
           @Nullable final Integer score,
           @NotBlank final String name,

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/ManualExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/ManualExpectation.java
@@ -19,7 +19,7 @@ import static io.openbas.database.model.InjectExpectation.EXPECTATION_TYPE;
 @Setter
 public class ManualExpectation implements Expectation {
 
-  private Integer score;
+  private Double score;
   private String name;
   private String description;
   private Asset asset;
@@ -29,17 +29,17 @@ public class ManualExpectation implements Expectation {
   public ManualExpectation() {
   }
 
-  public ManualExpectation(final Integer score) {
-    this.score = Objects.requireNonNullElse(score, 100);
+  public ManualExpectation(final Double score) {
+    this.score = Objects.requireNonNullElse(score, 100.0);
   }
 
-  public ManualExpectation(final Integer score, @NotBlank final String name, final String description) {
+  public ManualExpectation(final Double score, @NotBlank final String name, final String description) {
     this(score);
     this.name = name;
     this.description = description;
   }
 
-  public ManualExpectation(final Integer score, @NotBlank final String name, final String description, final boolean expectationGroup) {
+  public ManualExpectation(final Double score, @NotBlank final String name, final String description, final boolean expectationGroup) {
     this(score);
     this.name = name;
     this.description = description;
@@ -47,14 +47,14 @@ public class ManualExpectation implements Expectation {
   }
 
   public static ManualExpectation manualExpectationForAsset(
-          @Nullable final Integer score,
+          @Nullable final Double score,
           @NotBlank final String name,
           final String description,
           @NotNull final Asset asset,
           final boolean expectationGroup
   ) {
     ManualExpectation manualExpectation = new ManualExpectation();
-    manualExpectation.setScore(Objects.requireNonNullElse(score, 100));
+    manualExpectation.setScore(Objects.requireNonNullElse(score, 100.0));
     manualExpectation.setName(name);
     manualExpectation.setDescription(description);
     manualExpectation.setAsset(asset);
@@ -63,14 +63,14 @@ public class ManualExpectation implements Expectation {
   }
 
   public static ManualExpectation manualExpectationForAssetGroup(
-          @Nullable final Integer score,
+          @Nullable final Double score,
           @NotBlank final String name,
           final String description,
           @NotNull final AssetGroup assetGroup,
           final boolean expectationGroup
   ) {
     ManualExpectation manualExpectation = new ManualExpectation();
-    manualExpectation.setScore(Objects.requireNonNullElse(score, 100));
+    manualExpectation.setScore(Objects.requireNonNullElse(score, 100.0));
     manualExpectation.setName(name);
     manualExpectation.setDescription(description);
     manualExpectation.setAssetGroup(assetGroup);

--- a/openbas-framework/src/main/java/io/openbas/model/expectation/PreventionExpectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/expectation/PreventionExpectation.java
@@ -20,7 +20,7 @@ import static io.openbas.database.model.InjectExpectation.EXPECTATION_TYPE.PREVE
 @Setter
 public class PreventionExpectation implements Expectation {
 
-    private Integer score;
+    private Double score;
     private String name;
     private String description;
     private Asset asset;
@@ -37,7 +37,7 @@ public class PreventionExpectation implements Expectation {
     }
 
     public static PreventionExpectation preventionExpectationForAsset(
-            @Nullable final Integer score,
+            @Nullable final Double score,
             @NotBlank final String name,
             final String description,
             @NotNull final Asset asset,
@@ -45,7 +45,7 @@ public class PreventionExpectation implements Expectation {
             final List<InjectExpectationSignature> expectationSignatures
     ) {
         PreventionExpectation preventionExpectation = new PreventionExpectation();
-        preventionExpectation.setScore(Objects.requireNonNullElse(score, 100));
+        preventionExpectation.setScore(Objects.requireNonNullElse(score, 100.0));
         preventionExpectation.setName(name);
         preventionExpectation.setDescription(description);
         preventionExpectation.setAsset(asset);
@@ -55,7 +55,7 @@ public class PreventionExpectation implements Expectation {
     }
 
     public static PreventionExpectation preventionExpectationForAssetGroup(
-            @Nullable final Integer score,
+            @Nullable final Double score,
             @NotBlank final String name,
             final String description,
             @NotNull final AssetGroup assetGroup,
@@ -63,7 +63,7 @@ public class PreventionExpectation implements Expectation {
             final List<InjectExpectationSignature> expectationSignatures
     ) {
         PreventionExpectation preventionExpectation = new PreventionExpectation();
-        preventionExpectation.setScore(Objects.requireNonNullElse(score, 100));
+        preventionExpectation.setScore(Objects.requireNonNullElse(score, 100.0));
         preventionExpectation.setName(name);
         preventionExpectation.setDescription(description);
         preventionExpectation.setAssetGroup(assetGroup);

--- a/openbas-framework/src/main/java/io/openbas/model/inject/form/Expectation.java
+++ b/openbas-framework/src/main/java/io/openbas/model/inject/form/Expectation.java
@@ -17,7 +17,7 @@ public class Expectation {
   private String description;
 
   @JsonProperty("expectation_score")
-  private Integer score;
+  private Double score;
 
   @JsonProperty("expectation_expectation_group")
   private boolean expectationGroup;

--- a/openbas-front/src/actions/atomic_testings/atomic-testing-actions.ts
+++ b/openbas-front/src/actions/atomic_testings/atomic-testing-actions.ts
@@ -29,8 +29,11 @@ export const tryAtomicTesting = (injectId: string) => {
   return simpleCall(uri);
 };
 
-export const fetchTargetResult = (injectId: string, targetId: string, targetType: string) => {
-  const uri = `${ATOMIC_TESTING_URI}/${injectId}/target_results/${targetId}/types/${targetType}`;
+export const fetchTargetResult = (injectId: string, targetId: string, targetType: string, parentTargetId ?: string) => {
+  let uri = `${ATOMIC_TESTING_URI}/${injectId}/target_results/${targetId}/types/${targetType}`;
+  if (parentTargetId) {
+    uri += `?parentTargetId=${encodeURIComponent(parentTargetId)}`;
+  }
   return simpleCall(uri);
 };
 

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
@@ -43,6 +43,7 @@ const AtomicTesting = () => {
   const classes = useStyles();
   const { t, tPick, fldt } = useFormatter();
   const [selectedTarget, setSelectedTarget] = useState<InjectTargetWithResult>();
+  const [currentParentTargetId, setCurrentParentTargetId] = useState<string>();
   const filtering = useSearchAnFilter('', 'name', ['name']);
 
   // Fetching data
@@ -54,8 +55,11 @@ const AtomicTesting = () => {
   const sortedTargets: InjectTargetWithResult[] = filtering.filterAndSort(injectResultDto?.inject_targets ?? []);
 
   // Handles
-  const handleTargetClick = (target: InjectTargetWithResult) => {
+  const handleTargetClick = (target: InjectTargetWithResult, currentParentId?: string) => {
     setSelectedTarget(target);
+    if (currentParentId) {
+      setCurrentParentTargetId(currentParentId);
+    }
   };
 
   if (!injectResultDto) {
@@ -225,10 +229,10 @@ const AtomicTesting = () => {
             <List>
               {sortedTargets.map((target) => (
                 <div key={target?.id} style={{ marginBottom: 15 }}>
-                  <TargetListItem onClick={handleTargetClick} target={target} selected={selectedTarget?.id === target.id} />
+                  <TargetListItem onClick={() => handleTargetClick(target)} target={target} selected={selectedTarget?.id === target.id} />
                   <List component="div" disablePadding>
                     {target?.children?.map((child) => (
-                      <TargetListItem key={child?.id} isChild onClick={handleTargetClick} target={child} selected={selectedTarget?.id === child.id} />
+                      <TargetListItem key={child?.id} isChild onClick={() => handleTargetClick(child, target.id)} target={child} selected={selectedTarget?.id === child.id && currentParentTargetId === target.id} />
                     ))}
                   </List>
                 </div>
@@ -246,9 +250,9 @@ const AtomicTesting = () => {
         <Paper classes={{ root: classes.paper }} variant="outlined" style={{ marginTop: 18 }}>
           {selectedTarget && !!injectResultDto.inject_type && (
           <TargetResultsDetail
-            teamId={}
-            target={selectedTarget}
             inject={injectResultDto}
+            parentTargetId={currentParentTargetId}
+            target={selectedTarget}
             lastExecutionStartDate={injectResultDto.inject_status?.tracking_sent_date || ''}
             lastExecutionEndDate={injectResultDto.inject_status?.tracking_end_date || ''}
           />

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
@@ -232,7 +232,9 @@ const AtomicTesting = () => {
                   <TargetListItem onClick={() => handleTargetClick(target)} target={target} selected={selectedTarget?.id === target.id} />
                   <List component="div" disablePadding>
                     {target?.children?.map((child) => (
-                      <TargetListItem key={child?.id} isChild onClick={() => handleTargetClick(child, target)} target={child} selected={selectedTarget?.id === child.id && currentParentTarget?.id === target.id} />
+                      <TargetListItem key={child?.id} isChild onClick={() => handleTargetClick(child, target)}
+                        target={child} selected={selectedTarget?.id === child.id && currentParentTarget?.id === target.id}
+                      />
                     ))}
                   </List>
                 </div>

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
@@ -43,22 +43,22 @@ const AtomicTesting = () => {
   const classes = useStyles();
   const { t, tPick, fldt } = useFormatter();
   const [selectedTarget, setSelectedTarget] = useState<InjectTargetWithResult>();
-  const [currentParentTargetId, setCurrentParentTargetId] = useState<string>();
+  const [currentParentTarget, setCurrentParentTarget] = useState<InjectTargetWithResult>();
   const filtering = useSearchAnFilter('', 'name', ['name']);
 
   // Fetching data
   const { injectResultDto } = useContext<InjectResultDtoContextType>(InjectResultDtoContext);
   useEffect(() => {
-    setSelectedTarget(injectResultDto?.inject_targets[0]);
+    setSelectedTarget(currentParentTarget || injectResultDto?.inject_targets[0]);
   }, [injectResultDto]);
 
   const sortedTargets: InjectTargetWithResult[] = filtering.filterAndSort(injectResultDto?.inject_targets ?? []);
 
   // Handles
-  const handleTargetClick = (target: InjectTargetWithResult, currentParentId?: string) => {
+  const handleTargetClick = (target: InjectTargetWithResult, currentParent?: InjectTargetWithResult) => {
     setSelectedTarget(target);
-    if (currentParentId) {
-      setCurrentParentTargetId(currentParentId);
+    if (currentParent) {
+      setCurrentParentTarget(currentParent);
     }
   };
 
@@ -232,7 +232,7 @@ const AtomicTesting = () => {
                   <TargetListItem onClick={() => handleTargetClick(target)} target={target} selected={selectedTarget?.id === target.id} />
                   <List component="div" disablePadding>
                     {target?.children?.map((child) => (
-                      <TargetListItem key={child?.id} isChild onClick={() => handleTargetClick(child, target.id)} target={child} selected={selectedTarget?.id === child.id && currentParentTargetId === target.id} />
+                      <TargetListItem key={child?.id} isChild onClick={() => handleTargetClick(child, target)} target={child} selected={selectedTarget?.id === child.id && currentParentTarget?.id === target.id} />
                     ))}
                   </List>
                 </div>
@@ -251,7 +251,7 @@ const AtomicTesting = () => {
           {selectedTarget && !!injectResultDto.inject_type && (
           <TargetResultsDetail
             inject={injectResultDto}
-            parentTargetId={currentParentTargetId}
+            parentTargetId={currentParentTarget?.id}
             target={selectedTarget}
             lastExecutionStartDate={injectResultDto.inject_status?.tracking_sent_date || ''}
             lastExecutionEndDate={injectResultDto.inject_status?.tracking_end_date || ''}

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
@@ -246,6 +246,7 @@ const AtomicTesting = () => {
         <Paper classes={{ root: classes.paper }} variant="outlined" style={{ marginTop: 18 }}>
           {selectedTarget && !!injectResultDto.inject_type && (
           <TargetResultsDetail
+            teamId={}
             target={selectedTarget}
             inject={injectResultDto}
             lastExecutionStartDate={injectResultDto.inject_status?.tracking_sent_date || ''}

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingDetail.tsx
@@ -73,11 +73,13 @@ const AtomicTestingDetail: FunctionComponent<Props> = () => {
                 </Typography>
                 {
                   injectResultDto.inject_expectations !== undefined && injectResultDto.inject_expectations.length > 0
-                    ? injectResultDto.inject_expectations.map((expectation, index) => (
-                      <Typography key={index} variant="body1">
-                        {expectation.inject_expectation_name}
-                      </Typography>
-                    )) : <Typography variant="body1" gutterBottom>
+                    ? Array.from(new Set(injectResultDto.inject_expectations.map((expectation) => expectation.inject_expectation_name)))
+                      .map((name, index) => (
+                        <Typography key={index} variant="body1">
+                          {name}
+                        </Typography>
+                      ))
+                    : <Typography variant="body1" gutterBottom>
                       {'-'}
                     </Typography>
                 }

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -88,6 +88,7 @@ interface Props {
   lastExecutionStartDate: string,
   lastExecutionEndDate: string,
   target: InjectTargetWithResult,
+  teamId: string,
 }
 
 const TargetResultsDetailFlow: FunctionComponent<Props> = ({
@@ -95,6 +96,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
   lastExecutionStartDate,
   lastExecutionEndDate,
   target,
+  teamId,
 }) => {
   const classes = useStyles();
   const dispatch = useAppDispatch();
@@ -213,9 +215,15 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
         labelShowBg: false,
         labelStyle: { fill: theme.palette.text?.primary, fontSize: 9 },
       })));
-      fetchTargetResult(inject.inject_id, target.id!, target.targetType!).then(
-        (result: { data: InjectExpectationsStore[] }) => setTargetResults(result.data ?? []),
-      );
+      if (target.targetType === 'PLAYER') {
+        fetchTargetResult(inject.inject_id, target.id!, target.targetType!, teamId).then(
+          (result: { data: InjectExpectationsStore[] }) => setTargetResults(result.data ?? []),
+        );
+      } else {
+        fetchTargetResult(inject.inject_id, target.id!, target.targetType!).then(
+          (result: { data: InjectExpectationsStore[] }) => setTargetResults(result.data ?? []),
+        );
+      }
       setActiveTab(0);
       setTimeout(() => setInitialized(true), 1000);
     }

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -216,15 +216,9 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
         labelShowBg: false,
         labelStyle: { fill: theme.palette.text?.primary, fontSize: 9 },
       })));
-      if (target.targetType === 'PLAYER') {
-        fetchTargetResult(inject.inject_id, target.id!, target.targetType!, parentTargetId).then(
-          (result: { data: InjectExpectationsStore[] }) => setTargetResults(result.data ?? []),
-        );
-      } else {
-        fetchTargetResult(inject.inject_id, target.id!, target.targetType!).then(
-          (result: { data: InjectExpectationsStore[] }) => setTargetResults(result.data ?? []),
-        );
-      }
+      fetchTargetResult(inject.inject_id, target.id!, target.targetType!, parentTargetId).then(
+        (result: { data: InjectExpectationsStore[] }) => setTargetResults(result.data ?? []),
+      );
       setActiveTab(0);
       setTimeout(() => setInitialized(true), 1000);
     }

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -348,8 +348,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
         label: (
           <span>
             {getStatusLabel(targetType, [expectation.inject_expectation_status])}
-            <br/>
-            ({expectation.inject_expectation_name ? truncate(expectation.inject_expectation_name, 20) : expectation.inject_expectation_type})
+            <br/>{truncate(expectation.inject_expectation_name, 20)}
           </span>
         ),
         type: targetType,
@@ -375,6 +374,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
           background: getColor(step.status).background,
         },
         position: { x: 0, y: 0 },
+
       })));
       setEdges([...Array(mergedSteps.length - 1)].map((_, i) => ({
         id: `result-${i}->result-${i + 1}`,

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -18,6 +18,7 @@ import {
   MenuItem,
   Tab,
   Tabs,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { makeStyles, useTheme } from '@mui/styles';
@@ -562,7 +563,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
                         />
                         <CardContent>
                           <ItemResult label={expectationResult.result} status={expectationResult.result} />
-                          <Chip classes={{ root: classes.score }} label={expectationResult.score}/>
+                          <Tooltip title={t('Score')}><Chip classes={{ root: classes.score }} label={expectationResult.score}/></Tooltip>
                         </CardContent>
                       </Card>
                     </Grid>

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -562,15 +562,20 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
                   ))}
                   {(['DETECTION', 'PREVENTION'].includes(injectExpectation.inject_expectation_type) || (injectExpectation.inject_expectation_type === 'MANUAL' && injectExpectation.inject_expectation_results && injectExpectation.inject_expectation_results.length === 0))
                     && (
-                  <Grid item xs={4}>
+                    <Grid item xs={4}>
                       <Card classes={{ root: classes.resultCardDummy }}>
-                        <CardActionArea classes={{ root: classes.area }} onClick={() => setSelectedExpectationForCreation({ injectExpectation, sourceIds: computeExistingSourceIds(injectExpectation.inject_expectation_results ?? []) },
-                        )}>
+                        <CardActionArea classes={{ root: classes.area }}
+                          onClick={() => setSelectedExpectationForCreation({
+                            injectExpectation,
+                            sourceIds: computeExistingSourceIds(injectExpectation.inject_expectation_results ?? []),
+                          })
+                        }
+                        >
                           <AddBoxOutlined />
                         </CardActionArea>
                       </Card>
                     </Grid>
-                  )}
+                    )}
                 </Grid>
                 <Divider style={{ marginTop: 20 }} />
               </div>

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -398,11 +398,11 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
     // eslint-disable-next-line no-nested-ternary
     return isTechnicalExpectation(injectExpectation.inject_expectation_type)
       ? injectExpectation.inject_expectation_group
-        ? 'At least one asset'
-        : 'All assets'
+        ? 'At least one asset (per group) must validate the expectation'
+        : 'All assets (per group) must validate the expectation'
       : injectExpectation.inject_expectation_group
-        ? 'At least one player'
-        : 'All players';
+        ? 'At least one player (per team) must validate the expectation'
+        : 'All players (per team) must validate the expectation';
   };
 
   return (
@@ -464,88 +464,90 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
       )}
       {Object.keys(sortedGroupedResults).map((targetResult, targetResultIndex) => (
         <div key={targetResultIndex} hidden={activeTab !== targetResultIndex}>
-          {sortedGroupedResults[targetResult].map((injectExpectation) => (
-            <div key={injectExpectation.inject_expectation_id} style={{ marginTop: 20 }}>
-              <Grid container={true} spacing={2}>
-                <Grid item={true} xs={4}>
-                  <Typography variant="h4">
-                    {t('Name')}
-                  </Typography>
-                  {injectExpectation.inject_expectation_name}
+          {sortedGroupedResults[targetResult].sort((a, b) => { return a.inject_expectation_name.localeCompare(b.inject_expectation_name); })
+            .map((injectExpectation) => (
+              <div key={injectExpectation.inject_expectation_id} style={{ marginTop: 20 }}>
+                <Grid container={true} spacing={2}>
+                  <Grid item={true} xs={4}>
+                    <Typography variant="h4">
+                      {t('Name')}
+                    </Typography>
+                    {injectExpectation.inject_expectation_name}
+                  </Grid>
+                  <Grid item={true} xs={4}>
+                    <Typography variant="h4">
+                      {t('Validation type')}
+                    </Typography>
+                    {emptyFilled(getLabelOfValidationType(injectExpectation))}
+                  </Grid>
+                  <Grid item={true} xs={4}>
+                    <Typography variant="h4">
+                      {t('Description')}
+                    </Typography>
+                    {emptyFilled(injectExpectation.inject_expectation_description)}
+                  </Grid>
                 </Grid>
-                <Grid item={true} xs={8}>
-                  <Typography variant="h4">
-                    {t('Validation type')}
-                  </Typography>
-                  {emptyFilled(getLabelOfValidationType(injectExpectation))}
-                </Grid>
-              </Grid>
-              <Typography variant="h4" style={{ marginTop: 20 }}>
-                {t('Results')}
-              </Typography>
-              <Grid container={true} spacing={2}>
-                {injectExpectation.inject_expectation_results && injectExpectation.inject_expectation_results.map((expectationResult, index) => (
-                  <Grid key={index} item xs={4}>
-                    <Card key={injectExpectation.inject_expectation_id} classes={{ root: classes.resultCard }}>
-                      <CardHeader
-                        avatar={getAvatar(injectExpectation, expectationResult)}
-                        action={
-                          <>
-                            <IconButton
-                              color="primary"
-                              onClick={(ev) => {
-                                ev.stopPropagation();
-                                setAnchorEls({ ...anchorEls, [`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]: ev.currentTarget });
-                              }}
-                              aria-haspopup="true"
-                              size="large"
-                              disabled={['collector', 'media-pressure', 'challenge'].includes(expectationResult.sourceType ?? 'unknown')}
-                            >
-                              <MoreVertOutlined />
-                            </IconButton>
-                            <Menu
-                              anchorEl={anchorEls[`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]}
-                              open={Boolean(anchorEls[`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`])}
-                              onClose={() => setAnchorEls({ ...anchorEls, [`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]: null })}
-                            >
-                              <MenuItem onClick={() => handleOpenResultEdition(injectExpectation, expectationResult)}>
-                                {t('Update')}
-                              </MenuItem>
-                              <MenuItem onClick={() => handleOpenResultDeletion(injectExpectation, expectationResult)}>
-                                {t('Delete')}
-                              </MenuItem>
-                            </Menu>
-                          </>
+                <Typography variant="h4" style={{ marginTop: 20 }}>
+                  {t('Results')}
+                </Typography>
+                <Grid container={true} spacing={2}>
+                  {injectExpectation.inject_expectation_results && injectExpectation.inject_expectation_results.map((expectationResult, index) => (
+                    <Grid key={index} item xs={4}>
+                      <Card key={injectExpectation.inject_expectation_id} classes={{ root: classes.resultCard }}>
+                        <CardHeader
+                          avatar={getAvatar(injectExpectation, expectationResult)}
+                          action={
+                            <>
+                              <IconButton
+                                color="primary"
+                                onClick={(ev) => {
+                                  ev.stopPropagation();
+                                  setAnchorEls({ ...anchorEls, [`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]: ev.currentTarget });
+                                }}
+                                aria-haspopup="true"
+                                size="large"
+                                disabled={['collector', 'media-pressure', 'challenge'].includes(expectationResult.sourceType ?? 'unknown')}
+                              >
+                                <MoreVertOutlined />
+                              </IconButton>
+                              <Menu
+                                anchorEl={anchorEls[`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]}
+                                open={Boolean(anchorEls[`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`])}
+                                onClose={() => setAnchorEls({ ...anchorEls, [`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]: null })}
+                              >
+                                <MenuItem onClick={() => handleOpenResultEdition(injectExpectation, expectationResult)}>
+                                  {t('Update')}
+                                </MenuItem>
+                                <MenuItem onClick={() => handleOpenResultDeletion(injectExpectation, expectationResult)}>
+                                  {t('Delete')}
+                                </MenuItem>
+                              </Menu>
+                            </>
                         }
-                        title={expectationResult.sourceName ?? t('Unknown')}
-                        subheader={nsdt(expectationResult.date)}
-                      />
-                      <CardContent>
-                        <ItemResult label={expectationResult.result} status={expectationResult.result} />
-                      </CardContent>
-                    </Card>
-                  </Grid>
-                ))}
-                {(['DETECTION', 'PREVENTION'].includes(injectExpectation.inject_expectation_type)
-                  || (injectExpectation.inject_expectation_type === 'MANUAL' && injectExpectation.inject_expectation_results && injectExpectation.inject_expectation_results.length === 0))
-                  && (
+                          title={expectationResult.sourceName ?? t('Unknown')}
+                          subheader={nsdt(expectationResult.date)}
+                        />
+                        <CardContent>
+                          <ItemResult label={expectationResult.result} status={expectationResult.result} />
+                        </CardContent>
+                      </Card>
+                    </Grid>
+                  ))}
+                  {(['DETECTION', 'PREVENTION'].includes(injectExpectation.inject_expectation_type) || (injectExpectation.inject_expectation_type === 'MANUAL' && injectExpectation.inject_expectation_results && injectExpectation.inject_expectation_results.length === 0))
+                    && (
                   <Grid item xs={4}>
-                    <Card classes={{ root: classes.resultCardDummy }}>
-                      <CardActionArea
-                        classes={{ root: classes.area }}
-                        onClick={() => setSelectedExpectationForCreation(
-                          { injectExpectation, sourceIds: computeExistingSourceIds(injectExpectation.inject_expectation_results ?? []) },
-                        )}
-                      >
-                        <AddBoxOutlined />
-                      </CardActionArea>
-                    </Card>
-                  </Grid>
+                      <Card classes={{ root: classes.resultCardDummy }}>
+                        <CardActionArea classes={{ root: classes.area }} onClick={() => setSelectedExpectationForCreation({ injectExpectation, sourceIds: computeExistingSourceIds(injectExpectation.inject_expectation_results ?? []) },
+                        )}>
+                          <AddBoxOutlined />
+                        </CardActionArea>
+                      </Card>
+                    </Grid>
                   )}
-              </Grid>
-              <Divider style={{ marginTop: 20 }} />
-            </div>
-          ))}
+                </Grid>
+                <Divider style={{ marginTop: 20 }} />
+              </div>
+            ))}
           <Dialog
             open={selectedExpectationForCreation !== null}
             TransitionComponent={Transition}

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -36,7 +36,7 @@ import ItemResult from '../../../../components/ItemResult';
 import InjectIcon from '../../common/injects/InjectIcon';
 import { isNotEmptyField } from '../../../../utils/utils';
 import Transition from '../../../../components/common/Transition';
-import { emptyFilled } from '../../../../utils/String';
+import { emptyFilled, truncate } from '../../../../utils/String';
 import DetectionPreventionExpectationsValidationForm from '../../simulations/simulation/validation/expectations/DetectionPreventionExpectationsValidationForm';
 import { deleteInjectExpectationResult } from '../../../../actions/Exercise';
 import { useAppDispatch } from '../../../../utils/hooks';
@@ -345,7 +345,13 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
         return a.inject_expectation_id.localeCompare(b.inject_expectation_id);
       }).map((expectation: InjectExpectationStore) => ({
         key: 'result',
-        label: getStatusLabel(targetType, [expectation.inject_expectation_status]),
+        label: (
+          <span>
+            {getStatusLabel(targetType, [expectation.inject_expectation_status])}
+            <br/>
+            ({expectation.inject_expectation_name ? truncate(expectation.inject_expectation_name, 20) : expectation.inject_expectation_type})
+          </span>
+        ),
         type: targetType,
         status: getStatus([expectation.inject_expectation_status]),
       })));
@@ -450,10 +456,10 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
           nodesFocusable={false}
           elementsSelectable={false}
           maxZoom={1}
-          zoomOnScroll={false}
+          zoomOnScroll
           zoomOnPinch={false}
           zoomOnDoubleClick={false}
-          panOnDrag={false}
+          panOnDrag
           defaultEdgeOptions={defaultEdgeOptions}
           proOptions={proOptions}
         />

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -6,6 +6,7 @@ import {
   CardActionArea,
   CardContent,
   CardHeader,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -81,6 +82,11 @@ const useStyles = makeStyles<Theme>((theme) => ({
   area: {
     width: '100%',
     height: '100%',
+  },
+  score: {
+    fontSize: '0.75rem',
+    height: '20px',
+    padding: '0 4px',
   },
 }));
 
@@ -556,6 +562,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
                         />
                         <CardContent>
                           <ItemResult label={expectationResult.result} status={expectationResult.result} />
+                          <Chip classes={{ root: classes.score }} label={expectationResult.score}/>
                         </CardContent>
                       </Card>
                     </Grid>

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -415,11 +415,11 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
     // eslint-disable-next-line no-nested-ternary
     return isTechnicalExpectation(injectExpectation.inject_expectation_type)
       ? injectExpectation.inject_expectation_group
-        ? 'At least one asset (per group) must validate the expectation'
-        : 'All assets (per group) must validate the expectation'
+        ? t('At least one asset (per group) must validate the expectation')
+        : t('All assets (per group) must validate the expectation')
       : injectExpectation.inject_expectation_group
-        ? 'At least one player (per team) must validate the expectation'
-        : 'All players (per team) must validate the expectation';
+        ? t('At least one player (per team) must validate the expectation')
+        : t('All players (per team) must validate the expectation');
   };
 
   return (

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -551,7 +551,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
                               </Menu>
                             </>
                         }
-                          title={expectationResult.sourceName ?? t('Unknown')}
+                          title={expectationResult.sourceName ? t(expectationResult.sourceName) : t('Unknown')}
                           subheader={nsdt(expectationResult.date)}
                         />
                         <CardContent>

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -41,6 +41,7 @@ import DetectionPreventionExpectationsValidationForm from '../../simulations/sim
 import { deleteInjectExpectationResult } from '../../../../actions/Exercise';
 import { useAppDispatch } from '../../../../utils/hooks';
 import type { InjectExpectationStore } from '../../../../actions/injects/Inject';
+import { isTechnicalExpectation } from '../../common/injects/expectations/ExpectationUtils';
 
 interface Steptarget {
   label: string;
@@ -88,7 +89,7 @@ interface Props {
   lastExecutionStartDate: string,
   lastExecutionEndDate: string,
   target: InjectTargetWithResult,
-  teamId: string,
+  parentTargetId?: string,
 }
 
 const TargetResultsDetailFlow: FunctionComponent<Props> = ({
@@ -96,7 +97,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
   lastExecutionStartDate,
   lastExecutionEndDate,
   target,
-  teamId,
+  parentTargetId,
 }) => {
   const classes = useStyles();
   const dispatch = useAppDispatch();
@@ -216,7 +217,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
         labelStyle: { fill: theme.palette.text?.primary, fontSize: 9 },
       })));
       if (target.targetType === 'PLAYER') {
-        fetchTargetResult(inject.inject_id, target.id!, target.targetType!, teamId).then(
+        fetchTargetResult(inject.inject_id, target.id!, target.targetType!, parentTargetId).then(
           (result: { data: InjectExpectationsStore[] }) => setTargetResults(result.data ?? []),
         );
       } else {
@@ -274,7 +275,6 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
         return '';
     }
   };
-
   const getAvatar = (injectExpectation: InjectExpectationStore, expectationResult: InjectExpectationResult) => {
     if (expectationResult.sourceType === 'collector') {
       return (
@@ -400,6 +400,17 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
     type: 'straight',
     markerEnd: { type: MarkerType.ArrowClosed },
   };
+  const getLabelOfValidationType = (injectExpectation: InjectExpectationsStore): string => {
+    // eslint-disable-next-line no-nested-ternary
+    return isTechnicalExpectation(injectExpectation.inject_expectation_type)
+      ? injectExpectation.inject_expectation_group
+        ? 'At least one asset'
+        : 'All assets'
+      : injectExpectation.inject_expectation_group
+        ? 'At least one player'
+        : 'All players';
+  };
+
   return (
     <>
       <div className={classes.target}>
@@ -470,9 +481,9 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
                 </Grid>
                 <Grid item={true} xs={8}>
                   <Typography variant="h4">
-                    {t('Description')}
+                    {t('Validation type')}
                   </Typography>
-                  {emptyFilled(injectExpectation.inject_expectation_description)}
+                  {emptyFilled(getLabelOfValidationType(injectExpectation))}
                 </Grid>
               </Grid>
               <Typography variant="h4" style={{ marginTop: 20 }}>

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -334,7 +334,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
   useEffect(() => {
     if (initialized && targetResults && targetResults.length > 0) {
       const groupedBy = groupedByExpectationType(targetResults);
-      const newSteps = Array.from(groupedBy).flatMap(([targetType, results]) => results.sort((a, b) => {
+      const newSteps = Array.from(groupedBy).flatMap(([targetType, results]) => results.sort((a: InjectExpectationsStore, b: InjectExpectationsStore) => {
         if (a.inject_expectation_name && b.inject_expectation_name) {
           return a.inject_expectation_name.localeCompare(b.inject_expectation_name);
         } if (a.inject_expectation_name && !b.inject_expectation_name) {

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/types/nodes/NodeResultStep.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/types/nodes/NodeResultStep.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
         : '1px solid rgba(0, 0, 0, 0.12)',
     borderRadius: 4,
     width: 200,
-    height: 100,
+    height: 110,
     padding: '8px 5px 5px 5px',
   },
   icon: {

--- a/openbas-front/src/admin/components/common/injects/ResponsePie.tsx
+++ b/openbas-front/src/admin/components/common/injects/ResponsePie.tsx
@@ -133,6 +133,7 @@ const ResponsePie: FunctionComponent<Props> = ({
       </div>
     );
   };
+
   return (
     <Grid container={true} spacing={3}>
       <Grid item={true} xs={4}>

--- a/openbas-front/src/admin/components/common/injects/ResponsePie.tsx
+++ b/openbas-front/src/admin/components/common/injects/ResponsePie.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   iconOverlay: {
     position: 'absolute',
-    top: '43%',
+    top: '37%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
     fontSize: 35,

--- a/openbas-front/src/admin/components/common/injects/expectations/Expectation.ts
+++ b/openbas-front/src/admin/components/common/injects/expectations/Expectation.ts
@@ -1,7 +1,8 @@
 import type { InjectExpectation } from '../../../../../utils/api-types';
 
-export interface InjectExpectationsStore extends Omit<InjectExpectation, 'inject_expectation_team' | 'inject_expectation_article' | 'inject_expectation_challenge' | 'inject_expectation_asset'> {
+export interface InjectExpectationsStore extends Omit<InjectExpectation, 'inject_expectation_team' | 'inject_expectation_user' | 'inject_expectation_article' | 'inject_expectation_challenge' | 'inject_expectation_asset'> {
   inject_expectation_team: string | undefined;
+  inject_expectation_user: string | undefined;
   inject_expectation_article: string | undefined;
   inject_expectation_challenge: string | undefined;
   inject_expectation_asset: string | undefined;

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormCreate.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormCreate.tsx
@@ -6,7 +6,6 @@ import type { ExpectationInput } from './Expectation';
 import { formProps, infoMessage } from './ExpectationFormUtils';
 import { useFormatter } from '../../../../../components/i18n';
 import type { Theme } from '../../../../../components/Theme';
-import { hasExpectationByGroup } from './ExpectationUtils';
 import ExpectationGroupField from './field/ExpectationGroupField';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -138,11 +137,7 @@ const ExpectationFormCreate: FunctionComponent<Props> = ({
         }
         inputProps={register('expectation_score')}
       />
-
-      {hasExpectationByGroup(watchType)
-        && <ExpectationGroupField control={control} />
-      }
-
+      <ExpectationGroupField control={control} />
       <div className={classes.buttons}>
         <Button
           onClick={handleClose}

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormCreate.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormCreate.tsx
@@ -7,6 +7,7 @@ import { formProps, infoMessage } from './ExpectationFormUtils';
 import { useFormatter } from '../../../../../components/i18n';
 import type { Theme } from '../../../../../components/Theme';
 import ExpectationGroupField from './field/ExpectationGroupField';
+import { isTechnicalExpectation } from './ExpectationUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   marginTop_2: {
@@ -137,7 +138,7 @@ const ExpectationFormCreate: FunctionComponent<Props> = ({
         }
         inputProps={register('expectation_score')}
       />
-      <ExpectationGroupField control={control} />
+      <ExpectationGroupField isTechnicalExpectation={isTechnicalExpectation(watchType)} control={control} />
       <div className={classes.buttons}>
         <Button
           onClick={handleClose}

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormCreate.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormCreate.tsx
@@ -95,7 +95,7 @@ const ExpectationFormCreate: FunctionComponent<Props> = ({
           <MenuItem key={'MANUAL'} value={'MANUAL'}>{t('MANUAL')}</MenuItem>
         </MUISelect>
       </div>
-      {watchType === 'ARTICLE'
+      {(watchType === 'ARTICLE' || watchType === 'CHALLENGE')
         && <Alert
           severity="info"
           className={classes.marginTop_2}

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUpdate.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUpdate.tsx
@@ -7,7 +7,6 @@ import type { ExpectationInput } from './Expectation';
 import { useFormatter } from '../../../../../components/i18n';
 import type { Theme } from '../../../../../components/Theme';
 import ExpectationGroupField from './field/ExpectationGroupField';
-import { hasExpectationByGroup } from './ExpectationUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   marginTop_2: {
@@ -108,11 +107,7 @@ const ExpectationFormUpdate: FunctionComponent<Props> = ({
         }
         inputProps={register('expectation_score')}
       />
-
-      {hasExpectationByGroup(initialValues.expectation_type)
-        && <ExpectationGroupField control={control} />
-      }
-
+      <ExpectationGroupField control={control} />
       <div className={classes.buttons}>
         <Button
           onClick={handleClose}

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUpdate.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUpdate.tsx
@@ -65,7 +65,7 @@ const ExpectationFormUpdate: FunctionComponent<Props> = ({
           <MenuItem value={getValues().expectation_type}>{t(getValues().expectation_type)}</MenuItem>
         </MUISelect>
       </div>
-      {getValues().expectation_type === 'ARTICLE'
+      {(getValues().expectation_type === 'ARTICLE' || getValues().expectation_type === 'CHALLENGE')
         && <Alert
           severity="info"
           className={classes.marginTop_2}

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUpdate.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUpdate.tsx
@@ -7,6 +7,7 @@ import type { ExpectationInput } from './Expectation';
 import { useFormatter } from '../../../../../components/i18n';
 import type { Theme } from '../../../../../components/Theme';
 import ExpectationGroupField from './field/ExpectationGroupField';
+import { isTechnicalExpectation } from './ExpectationUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   marginTop_2: {
@@ -107,7 +108,7 @@ const ExpectationFormUpdate: FunctionComponent<Props> = ({
         }
         inputProps={register('expectation_score')}
       />
-      <ExpectationGroupField control={control} />
+      <ExpectationGroupField isTechnicalExpectation={isTechnicalExpectation(getValues().expectation_type)} control={control} />
       <div className={classes.buttons}>
         <Button
           onClick={handleClose}

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUtils.ts
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUtils.ts
@@ -8,6 +8,9 @@ export const infoMessage = (type: string, t: (key: string) => string) => {
   if (type === 'ARTICLE') {
     return t('This expectation is handled automatically by the platform and triggered when target reads the articles');
   }
+  if (type === 'CHALLENGE') {
+    return t('This expectation is handled automatically by the platform and triggered when the target completes the challenges');
+  }
   return '';
 };
 

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUtils.ts
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationFormUtils.ts
@@ -6,7 +6,7 @@ import type { ExpectationInput } from './Expectation';
 
 export const infoMessage = (type: string, t: (key: string) => string) => {
   if (type === 'ARTICLE') {
-    return t('This expectation is handled automatically by the platform and triggered when team reads articles');
+    return t('This expectation is handled automatically by the platform and triggered when target reads the articles');
   }
   return '';
 };

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationUtils.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationUtils.tsx
@@ -19,3 +19,7 @@ export const typeIcon = (type: string) => {
   }
   return <AssignmentTurnedIn />;
 };
+
+export const isTechnicalExpectation = (type: string) => {
+  return [ExpectationType.PREVENTION.toString(), ExpectationType.DETECTION.toString()].includes(type);
+};

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationUtils.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationUtils.tsx
@@ -19,7 +19,3 @@ export const typeIcon = (type: string) => {
   }
   return <AssignmentTurnedIn />;
 };
-
-export const hasExpectationByGroup = (type: string) => {
-  return [ExpectationType.PREVENTION.toString(), ExpectationType.DETECTION.toString()].includes(type);
-};

--- a/openbas-front/src/admin/components/common/injects/expectations/field/ExpectationGroupField.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/field/ExpectationGroupField.tsx
@@ -20,13 +20,17 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props {
   control: Control<ExpectationInput>;
+  isTechnicalExpectation: boolean;
 }
 
 const ExpectationGroupField: FunctionComponent<Props> = ({
   control,
+  isTechnicalExpectation,
 }) => {
   const { t } = useFormatter();
   const classes = useStyles();
+
+  const singleTargetType = isTechnicalExpectation ? 'asset' : 'player';
 
   return (
     <Controller
@@ -37,9 +41,7 @@ const ExpectationGroupField: FunctionComponent<Props> = ({
           <FormLabel className={classes.container}>
             {t('Validation mode')}
             <Tooltip
-              title={t(
-                'An isolated asset is considered as a group of one asset',
-              )}
+              title={t(`An isolated ${singleTargetType} is considered as a group of one asset`)}
             >
               <InfoOutlined
                 fontSize="small"
@@ -55,8 +57,8 @@ const ExpectationGroupField: FunctionComponent<Props> = ({
               onChange((event.target as HTMLInputElement).value === 'true');
             }}
           >
-            <FormControlLabel value={false} control={<Radio />} label={t('All assets (per group) must validate the expectation')} />
-            <FormControlLabel value={true} control={<Radio />} label={t('At least one asset (per group) must validate the expectation')} />
+            <FormControlLabel value={false} control={<Radio />} label={t(`All ${singleTargetType}s (per group) must validate the expectation`)} />
+            <FormControlLabel value={true} control={<Radio />} label={t(`At least one ${singleTargetType} (per group) must validate the expectation`)} />
           </RadioGroup>
         </div>
       )}

--- a/openbas-front/src/admin/components/common/injects/expectations/field/ExpectationGroupField.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/field/ExpectationGroupField.tsx
@@ -30,8 +30,6 @@ const ExpectationGroupField: FunctionComponent<Props> = ({
   const { t } = useFormatter();
   const classes = useStyles();
 
-  const singleTargetType = isTechnicalExpectation ? 'asset' : 'player';
-
   return (
     <Controller
       control={control}
@@ -41,7 +39,9 @@ const ExpectationGroupField: FunctionComponent<Props> = ({
           <FormLabel className={classes.container}>
             {t('Validation mode')}
             <Tooltip
-              title={t(`An isolated ${singleTargetType} is considered as a group of one asset`)}
+              title={isTechnicalExpectation
+                ? t('An isolated asset is considered as a group of one asset')
+                : t('An isolated player is considered as a group of one player')}
             >
               <InfoOutlined
                 fontSize="small"
@@ -57,8 +57,12 @@ const ExpectationGroupField: FunctionComponent<Props> = ({
               onChange((event.target as HTMLInputElement).value === 'true');
             }}
           >
-            <FormControlLabel value={false} control={<Radio />} label={t(`All ${singleTargetType}s (per group) must validate the expectation`)} />
-            <FormControlLabel value={true} control={<Radio />} label={t(`At least one ${singleTargetType} (per group) must validate the expectation`)} />
+            <FormControlLabel value={false} control={<Radio />} label={isTechnicalExpectation ? t('All assets (per group) must validate the expectation')
+              : t('All players (per team) must validate the expectation')}
+            />
+            <FormControlLabel value={true} control={<Radio />} label={isTechnicalExpectation ? t('At least one asset (per group) must validate the expectation')
+              : t('At least one player (per team) must validate the expectation')}
+            />
           </RadioGroup>
         </div>
       )}

--- a/openbas-front/src/admin/components/simulations/simulation/validation/common/TeamOrAssetLine.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/common/TeamOrAssetLine.tsx
@@ -168,7 +168,7 @@ const TeamOrAssetLine: FunctionComponent<Props> = ({
             return (<div key={expectationName}></div>);
           }
           return (
-            <ManualExpectations key={expectationName} exerciseId={exerciseId} inject={inject} expectations={es} />
+            <ManualExpectations key={expectationName} exerciseId={exerciseId} inject={inject} expectations={es}/>
           );
         })}
       </List>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/common/TeamOrAssetLine.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/common/TeamOrAssetLine.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
-import { List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
-import { CastForEducationOutlined, DnsOutlined, LanOutlined } from '@mui/icons-material';
+import { Accordion, AccordionDetails, AccordionSummary, List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
+import { CastForEducationOutlined, DnsOutlined, ExpandMore, LanOutlined } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import ChannelExpectation from '../expectations/ChannelExpectation';
 import ChallengeExpectation from '../expectations/ChallengeExpectation';
@@ -91,13 +91,13 @@ const TeamOrAssetLine: FunctionComponent<Props> = ({
   const asset: EndpointStore = assetsMap[id];
   const assetGroup: AssetGroupStore = assetGroupsMap[id];
 
-  const groupedByExpectationType = (es: InjectExpectationsStore[]) => {
+  const groupByExpectationName = (es: InjectExpectationsStore[]) => {
     return es.reduce((group, expectation) => {
-      const { inject_expectation_type } = expectation;
-      if (inject_expectation_type) {
-        const values = group.get(inject_expectation_type) ?? [];
+      const { inject_expectation_name } = expectation;
+      if (inject_expectation_name) {
+        const values = group.get(inject_expectation_name) ?? [];
         values.push(expectation);
-        group.set(inject_expectation_type, values);
+        group.set(inject_expectation_name, values);
       }
       return group;
     }, new Map());
@@ -124,28 +124,28 @@ const TeamOrAssetLine: FunctionComponent<Props> = ({
         />
       </ListItem>
       <List component="div" disablePadding>
-        {Array.from(groupedByExpectationType(expectations)).map(([expectationType, es]) => {
-          if (expectationType === 'ARTICLE') {
+        {Array.from(groupByExpectationName(expectations)).map(([expectationName, es]) => {
+          if (es === 'ARTICLE') {
             const expectation = es[0];
             const article = articlesMap[expectation.inject_expectation_article] || {};
             const channel = channelsMap[article.article_channel] || {};
             return (
-              <ChannelExpectation key={expectationType} channel={channel} article={article} expectation={expectation} />
+              <ChannelExpectation key={expectationName} channel={channel} article={article} expectation={expectation} />
             );
           }
-          if (expectationType === 'CHALLENGE') {
+          if (es === 'CHALLENGE') {
             const expectation = es[0];
             const challenge = challengesMap[expectation.inject_expectation_challenge] || {};
             return (
-              <ChallengeExpectation key={expectationType} challenge={challenge} expectation={expectation} />
+              <ChallengeExpectation key={expectationName} challenge={challenge} expectation={expectation} />
             );
           }
-          if (expectationType === 'PREVENTION' || expectationType === 'DETECTION') {
+          if (es === 'PREVENTION' || es === 'DETECTION') {
             const expectation = es[0];
             if (asset) {
               return (
                 <TechnicalExpectationAsset
-                  key={expectationType}
+                  key={expectationName}
                   expectation={expectation}
                   injectContract={injectContract}
                 />
@@ -156,7 +156,7 @@ const TeamOrAssetLine: FunctionComponent<Props> = ({
 
               return (
                 <TechnicalExpectationAssetGroup
-                  key={expectationType}
+                  key={expectationName}
                   expectation={expectation}
                   injectContract={injectContract}
                   relatedExpectations={relatedExpectations}
@@ -165,10 +165,10 @@ const TeamOrAssetLine: FunctionComponent<Props> = ({
                 />
               );
             }
-            return (<div key={expectationType}></div>);
+            return (<div key={expectationName}></div>);
           }
           return (
-            <ManualExpectations key={expectationType} exerciseId={exerciseId} inject={inject} expectations={es} />
+            <ManualExpectations key={expectationName} exerciseId={exerciseId} inject={inject} expectations={es} />
           );
         })}
       </List>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/common/TeamOrAssetLine.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/common/TeamOrAssetLine.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
-import { Accordion, AccordionDetails, AccordionSummary, List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
-import { CastForEducationOutlined, DnsOutlined, ExpandMore, LanOutlined } from '@mui/icons-material';
+import { List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
+import { CastForEducationOutlined, DnsOutlined, LanOutlined } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import ChannelExpectation from '../expectations/ChannelExpectation';
 import ChallengeExpectation from '../expectations/ChallengeExpectation';
@@ -168,7 +168,7 @@ const TeamOrAssetLine: FunctionComponent<Props> = ({
             return (<div key={expectationName}></div>);
           }
           return (
-            <ManualExpectations key={expectationName} exerciseId={exerciseId} inject={inject} expectations={es}/>
+            <ManualExpectations key={expectationName} inject={inject} expectations={es}/>
           );
         })}
       </List>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
-import { Alert, AlertTitle, Chip, Divider, List, ListItemButton, ListItemIcon, ListItemText, Typography } from '@mui/material';
+import { Alert, AlertTitle, Chip, Divider, List, ListItemButton, ListItemIcon, ListItemText, Tooltip, Typography } from '@mui/material';
 import { AssignmentTurnedIn } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import * as R from 'ramda';
@@ -46,7 +46,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  exerciseId: string;
   inject: Inject;
   expectations: InjectExpectationsStore[];
 }
@@ -58,11 +57,20 @@ const ManualExpectations: FunctionComponent<Props> = ({
   const classes = useStyles();
   const { t } = useFormatter();
 
+  const [selectedItem, setSelectedItem] = useState<string | null>(null);
   const [currentExpectations, setCurrentExpectations] = useState<InjectExpectationsStore[] | null>(null);
+
+  const handleItemClick = (expectationsToUpdate: InjectExpectationsStore[]) => {
+    setSelectedItem(expectationsToUpdate[0]?.inject_expectation_name || null);
+    setCurrentExpectations(expectationsToUpdate);
+  };
+  const handleItemClose = () => {
+    setSelectedItem(null);
+    setCurrentExpectations(null);
+  };
 
   const parentExpectation = expectations.filter((e) => !e.inject_expectation_user)[0];
   const childrenExpectations = expectations.filter((e) => e.inject_expectation_user);
-
   const validatedCount = expectations.filter((v) => !R.isEmpty(v.inject_expectation_results)).length;
   const isAllValidated = validatedCount === expectations.length;
 
@@ -81,7 +89,8 @@ const ManualExpectations: FunctionComponent<Props> = ({
           divider
           sx={{ pl: 8 }}
           classes={{ root: classes.item }}
-          onClick={() => setCurrentExpectations(expectations)}
+          onClick={() => handleItemClick(expectations)}
+          selected={selectedItem === expectations[0].inject_expectation_name}
         >
           <ListItemIcon>
             <AssignmentTurnedIn fontSize="small"/>
@@ -89,7 +98,9 @@ const ManualExpectations: FunctionComponent<Props> = ({
           <ListItemText
             primary={(
               <div className={classes.container}>
-                {expectations[0].inject_expectation_name}
+                <Tooltip title={expectations[0].inject_expectation_description}>
+                  {expectations[0].inject_expectation_name}
+                </Tooltip>
                 <div className={classes.chip}>
                   <Chip
                     classes={{ root: classes.validationType }}
@@ -113,14 +124,14 @@ const ManualExpectations: FunctionComponent<Props> = ({
       </List>
       <Drawer
         open={currentExpectations !== null}
-        handleClose={() => setCurrentExpectations(null)}
+        handleClose={() => handleItemClose()}
         title={t('Expectations of ') + inject.inject_title}
       >
         <>
           <Alert
             severity="warning"
             variant="outlined"
-            style={{ position: 'relative', marginBottom: 10 }}
+            style={{ position: 'relative', marginBottom: 20 }}
           >
             <AlertTitle>
               <ExpandableText
@@ -133,9 +144,22 @@ const ManualExpectations: FunctionComponent<Props> = ({
               />
             </AlertTitle>
           </Alert>
+          <Alert
+            severity="info"
+            variant="outlined"
+            style={{ position: 'relative', marginBottom: 20 }}
+          >
+            <AlertTitle>
+              {t('The score set for the team will also be applied to all players in the team')}
+            </AlertTitle>
+          </Alert>
+          <Typography variant="h5" style={{ fontWeight: 500, margin: '10px' }}>
+            {t('Team')}
+          </Typography>
           <Paper>
             <ManualExpectationsValidationForm key={parentExpectation} expectation={parentExpectation}/>
           </Paper>
+          <Divider style={{ margin: '20px 0' }}/>
           <Typography variant="h5" style={{ fontWeight: 500, margin: '10px' }}>
             {t('Players')}
           </Typography>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -99,7 +99,9 @@ const ManualExpectations: FunctionComponent<Props> = ({
             primary={(
               <div className={classes.container}>
                 <Tooltip title={expectations[0].inject_expectation_description}>
-                  {expectations[0].inject_expectation_name ?? 'Manual Expectation'}
+                  <span>
+                    {expectations[0].inject_expectation_name ?? 'Manual Expectation'}
+                  </span>
                 </Tooltip>
                 <div className={classes.chip}>
                   <Chip

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -157,7 +157,7 @@ const ManualExpectations: FunctionComponent<Props> = ({
             {t('Team')}
           </Typography>
           <Paper>
-            <ManualExpectationsValidationForm key={parentExpectation} expectation={parentExpectation}/>
+            <ManualExpectationsValidationForm key={parentExpectation.targetId} expectation={parentExpectation}/>
           </Paper>
           <Divider style={{ margin: '20px 0' }}/>
           <Typography variant="h5" style={{ fontWeight: 500, margin: '10px' }}>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -99,7 +99,7 @@ const ManualExpectations: FunctionComponent<Props> = ({
             primary={(
               <div className={classes.container}>
                 <Tooltip title={expectations[0].inject_expectation_description}>
-                  {expectations[0].inject_expectation_name}
+                  {expectations[0].inject_expectation_name ?? 'Manual Expectation'}
                 </Tooltip>
                 <div className={classes.chip}>
                   <Chip

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -1,17 +1,16 @@
 import React, { FunctionComponent, useState } from 'react';
-import { List, ListItemButton, ListItemIcon, ListItemText, Chip } from '@mui/material';
+import { List, ListItemButton, ListItemIcon, ListItemText, Chip, Typography, Alert, AlertTitle, Divider } from '@mui/material';
 import { AssignmentTurnedIn } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import * as R from 'ramda';
-import type { Team, Inject } from '../../../../../../utils/api-types';
-import { useHelper } from '../../../../../../store';
 import type { InjectExpectationsStore } from '../../../../common/injects/expectations/Expectation';
 import { useFormatter } from '../../../../../../components/i18n';
 import type { Theme } from '../../../../../../components/Theme';
 import colorStyles from '../../../../../../components/Color';
-import type { TeamsHelper } from '../../../../../../actions/teams/team-helper';
 import Drawer from '../../../../../../components/common/Drawer';
 import ManualExpectationsValidationForm from './ManualExpectationsValidationForm';
+import ExpandableText from '../../../../../../components/common/ExpendableText';
+import { Inject } from '../../../../../../utils/api-types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   item: {
@@ -38,6 +37,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     border: '1px solid #ec407a',
     color: '#ec407a',
   },
+  validationType: {
+    height: 20,
+    border: '1px solid',
+    borderRadius: 4,
+  },
 }));
 
 interface Props {
@@ -53,78 +57,58 @@ const ManualExpectations: FunctionComponent<Props> = ({
   const classes = useStyles();
   const { t } = useFormatter();
 
-  const { teamsMap }: { teamsMap: Record<string, Team> } = useHelper((helper: TeamsHelper) => {
-    return ({
-      teamsMap: helper.getTeamsMap(),
-    });
-  });
-
-  const groupedByTeam = expectations.reduce((group: Map<string, InjectExpectationsStore[]>, expectation) => {
-    const { inject_expectation_team } = expectation;
-    if (inject_expectation_team) {
-      const values = group.get(inject_expectation_team) ?? [];
-      values.push(expectation);
-      group.set(inject_expectation_team, values);
-    }
-    return group;
-  }, new Map());
-
   const [currentExpectations, setCurrentExpectations] = useState<InjectExpectationsStore[] | null>(null);
+
+  const parentExpectation = expectations.filter((e) => !e.inject_expectation_user)[0];
+  const childrenExpectations = expectations.filter((e) => e.inject_expectation_user);
+
+  const validatedCount = expectations.filter((v) => !R.isEmpty(v.inject_expectation_results)).length;
+  const isAllValidated = validatedCount === expectations.length;
+
+  const label = isAllValidated
+    ? `${t('Validated')} (${expectations.reduce((acc, el) => acc + el.inject_expectation_score, 0) / expectations.length})`
+    : t('Pending validation');
+
+  const style = isAllValidated ? colorStyles.green : colorStyles.orange;
 
   return (
     <>
       <List component="div" disablePadding>
-        {Array.from(groupedByTeam)
-          .map(([entry, values]) => {
-            const team = teamsMap[entry] || {};
-            const expectationValues = values
-              .reduce((acc, el) => ({
-                ...acc,
-                expected_score: acc.expected_score + (el.inject_expectation_expected_score ?? 0),
-                score: acc.score + (el.inject_expectation_score ?? 0),
-                result: acc.result + (el.inject_expectation_results ?? ''),
-              }), { expected_score: 0, score: 0, result: '' });
-            const validated = values.filter((v) => !R.isEmpty(v.inject_expectation_results)).length;
-            let label = t('Pending validation');
-            if (validated === values.length) {
-              label = `${t('Validated')} (${expectationValues.score})`;
-            }
-            return (
-              <ListItemButton
-                key={team.team_id}
-                divider
-                sx={{ pl: 8 }}
-                classes={{ root: classes.item }}
-                onClick={() => setCurrentExpectations(values)}
-              >
-                <ListItemIcon>
-                  <AssignmentTurnedIn fontSize="small" />
-                </ListItemIcon>
-                <ListItemText
-                  primary={(
-                    <div className={classes.container}>
-                      {t('Manual expectations')}
-                      <div className={classes.chip}>
-                        <Chip
-                          classes={{ root: classes.points }}
-                          label={expectationValues.expected_score}
-                        />
-                        <Chip
-                          classes={{ root: classes.chipInList }}
-                          style={
-                            validated === values.length
-                              ? colorStyles.green
-                              : colorStyles.orange
-                          }
-                          label={label}
-                        />
-                      </div>
-                    </div>
+        {expectations.length > 0 && (
+        <ListItemButton
+          key={expectations[0].inject_expectation_name}
+          divider
+          sx={{ pl: 8 }}
+          classes={{ root: classes.item }}
+          onClick={() => setCurrentExpectations(expectations)}
+        >
+          <ListItemIcon>
+            <AssignmentTurnedIn fontSize="small" />
+          </ListItemIcon>
+          <ListItemText
+            primary={(
+              <div className={classes.container}>
+                {expectations[0].inject_expectation_name}
+                <div className={classes.chip}>
+                  <Chip
+                    classes={{ root: classes.validationType }}
+                    label={expectations[0].inject_expectation_group ? 'At least one player' : 'All players'}
+                  />
+                  <Chip
+                    classes={{ root: classes.points }}
+                    label={expectations[0].inject_expectation_expected_score}
+                  />
+                  <Chip
+                    classes={{ root: classes.chipInList }}
+                    style={style}
+                    label={label}
+                  />
+                </div>
+              </div>
                   )}
-                />
-              </ListItemButton>
-            );
-          })}
+          />
+        </ListItemButton>
+        )}
       </List>
       <Drawer
         open={currentExpectations !== null}
@@ -132,10 +116,33 @@ const ManualExpectations: FunctionComponent<Props> = ({
         title={t('Expectations of ') + inject.inject_title}
       >
         <>
-          {
-            expectations
-            && expectations.map((e) => <ManualExpectationsValidationForm key={e.inject_expectation_id} expectation={e} />)
-          }
+          <Alert
+            severity="warning"
+            variant="outlined"
+            style={{ position: 'relative' }}
+          >
+            <AlertTitle>
+              <ExpandableText
+                source={
+                    expectations[0].inject_expectation_group
+                      ? t('At least one player (per team) must validate the expectation')
+                      : t('All players (per team) must validate the expectation')
+                  }
+                limit={120}
+              />
+            </AlertTitle>
+          </Alert>
+          <div style={{ paddingTop: 10 }}>
+            <ManualExpectationsValidationForm key={parentExpectation} expectation={parentExpectation}/>
+          </div>
+          <div style={{ maxHeight: '80vh', overflowY: 'auto' }}>
+            {childrenExpectations && childrenExpectations.map((e) => (
+              <ManualExpectationsValidationForm
+                key={e.inject_expectation_id}
+                expectation={e}
+              />
+            ))}
+          </div>
         </>
       </Drawer>
     </>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -246,7 +246,7 @@ const ManualExpectations: FunctionComponent<Props> = ({
                       height: '10px',
                     }}
                   >
-                    <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%', margin: 0 }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
                       <div style={{ display: 'flex', alignItems: 'center' }}>
                         <PersonOutlined color="primary"/>
                         <Typography style={{ marginLeft: 8 }}>{targetLabel(e)}</Typography>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -88,6 +88,7 @@ const ManualExpectations: FunctionComponent<Props> = ({
 
   const [selectedItem, setSelectedItem] = useState<string | null>(null);
   const [currentExpectations, setCurrentExpectations] = useState<InjectExpectationsStore[] | null>(null);
+  const [expanded, setExpanded] = useState<string | false>(false);
 
   const { teamsMap, usersMap }: {
     teamsMap: Record<string, Team>,
@@ -110,6 +111,10 @@ const ManualExpectations: FunctionComponent<Props> = ({
   const handleItemClose = () => {
     setSelectedItem(null);
     setCurrentExpectations(null);
+  };
+
+  const handleChange = (panel: string) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
+    setExpanded(isExpanded ? panel : false);
   };
 
   const parentExpectation = expectations.filter((e) => !e.inject_expectation_user)[0];
@@ -218,34 +223,50 @@ const ManualExpectations: FunctionComponent<Props> = ({
           <Typography variant="h5" style={{ fontWeight: 500, margin: '10px' }}>
             {t('Players')}
           </Typography>
-          <div style={{ maxHeight: '80vh', overflowY: 'auto', padding: 10 }}>
-            {childrenExpectations && childrenExpectations.map((e) => (
-              <Accordion key={e.inject_expectation_id}>
-                <AccordionSummary
-                  expandIcon={<ExpandMore/>}
-                  aria-controls={`panel-${e.inject_expectation_id}-content`}
-                  id={`panel-${e.inject_expectation_id}-header`}
+          <div style={{ maxHeight: '80vh', overflowY: 'auto' }}>
+            {childrenExpectations.map((e) => {
+              const panelId = `panel-${e.inject_expectation_id}`;
+
+              return (
+                <Accordion
+                  key={e.inject_expectation_id}
+                  expanded={expanded === panelId}
+                  onChange={handleChange(panelId)}
+                  style={{
+                    boxShadow: 'none', margin: 0,
+                  }}
                 >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                    <div style={{ display: 'flex' }}>
-                      <PersonOutlined color="primary" />
-                      <Typography>{targetLabel(e)}</Typography>
+                  <AccordionSummary
+                    expandIcon={<ExpandMore/>}
+                    aria-controls={`${panelId}-content`}
+                    id={`${panelId}-header`}
+                    style={{
+                      boxShadow: 'none',
+                      border: 'none',
+                      height: '10px',
+                    }}
+                  >
+                    <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%', margin: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'center' }}>
+                        <PersonOutlined color="primary"/>
+                        <Typography style={{ marginLeft: 8 }}>{targetLabel(e)}</Typography>
+                      </div>
+                      <div style={{ display: 'flex', alignItems: 'center' }}>
+                        <Chip label={e.inject_expectation_score ?? 0} style={{ marginRight: 8 }}/>
+                        <Chip
+                          classes={{ root: classes.chipStatusAcc }}
+                          style={computeColorStyle(e.inject_expectation_status)}
+                          label={t(computeLabel(e.inject_expectation_status))}
+                        />
+                      </div>
                     </div>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                      <Chip label={e.inject_expectation_score ?? 0 }/>
-                      <Chip
-                        classes={{ root: classes.chipStatusAcc }}
-                        style={computeColorStyle(e.inject_expectation_status)}
-                        label={t(computeLabel(e.inject_expectation_status))}
-                      />
-                    </div>
-                  </div>
-                </AccordionSummary>
-                <AccordionDetails style={{ margin: 0 }}>
-                  <ManualExpectationsValidationForm expectation={e} withSummary={false}/>
-                </AccordionDetails>
-              </Accordion>
-            ))}
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <ManualExpectationsValidationForm expectation={e} withSummary={false}/>
+                  </AccordionDetails>
+                </Accordion>
+              );
+            })}
           </div>
         </>
       </Drawer>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { AssignmentTurnedIn, ExpandMore } from '@mui/icons-material';
+import { AssignmentTurnedIn, ExpandMore, PersonOutlined } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import * as R from 'ramda';
 import type { InjectExpectationsStore } from '../../../../common/injects/expectations/Expectation';
@@ -227,9 +227,12 @@ const ManualExpectations: FunctionComponent<Props> = ({
                   id={`panel-${e.inject_expectation_id}-header`}
                 >
                   <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                    <Typography>{targetLabel(e)}</Typography>
+                    <div style={{ display: 'flex' }}>
+                      <PersonOutlined color="primary" />
+                      <Typography>{targetLabel(e)}</Typography>
+                    </div>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
-                      {e.inject_expectation_score && (<Chip label={e.inject_expectation_score}/>)}
+                      <Chip label={e.inject_expectation_score ?? 0 }/>
                       <Chip
                         classes={{ root: classes.chipStatusAcc }}
                         style={computeColorStyle(e.inject_expectation_status)}
@@ -238,7 +241,7 @@ const ManualExpectations: FunctionComponent<Props> = ({
                     </div>
                   </div>
                 </AccordionSummary>
-                <AccordionDetails>
+                <AccordionDetails style={{ margin: 0 }}>
                   <ManualExpectationsValidationForm expectation={e} withSummary={false}/>
                 </AccordionDetails>
               </Accordion>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
-import { List, ListItemButton, ListItemIcon, ListItemText, Chip, Typography, Alert, AlertTitle, Divider } from '@mui/material';
+import { Alert, AlertTitle, Chip, Divider, List, ListItemButton, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import { AssignmentTurnedIn } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import * as R from 'ramda';
@@ -11,6 +11,7 @@ import Drawer from '../../../../../../components/common/Drawer';
 import ManualExpectationsValidationForm from './ManualExpectationsValidationForm';
 import ExpandableText from '../../../../../../components/common/ExpendableText';
 import type { Inject } from '../../../../../../utils/api-types';
+import Paper from '../../../../../../components/common/Paper';
 
 const useStyles = makeStyles((theme: Theme) => ({
   item: {
@@ -66,7 +67,7 @@ const ManualExpectations: FunctionComponent<Props> = ({
   const isAllValidated = validatedCount === expectations.length;
 
   const label = isAllValidated
-    ? `${t('Validated')} (${expectations.reduce((acc, el) => acc + el.inject_expectation_score, 0) / expectations.length})`
+    ? `${t('Validated')} (${parentExpectation.inject_expectation_score})`
     : t('Pending validation');
 
   const style = isAllValidated ? colorStyles.green : colorStyles.orange;
@@ -83,7 +84,7 @@ const ManualExpectations: FunctionComponent<Props> = ({
           onClick={() => setCurrentExpectations(expectations)}
         >
           <ListItemIcon>
-            <AssignmentTurnedIn fontSize="small" />
+            <AssignmentTurnedIn fontSize="small"/>
           </ListItemIcon>
           <ListItemText
             primary={(
@@ -105,7 +106,7 @@ const ManualExpectations: FunctionComponent<Props> = ({
                   />
                 </div>
               </div>
-                  )}
+                            )}
           />
         </ListItemButton>
         )}
@@ -119,7 +120,7 @@ const ManualExpectations: FunctionComponent<Props> = ({
           <Alert
             severity="warning"
             variant="outlined"
-            style={{ position: 'relative' }}
+            style={{ position: 'relative', marginBottom: 10 }}
           >
             <AlertTitle>
               <ExpandableText
@@ -127,22 +128,23 @@ const ManualExpectations: FunctionComponent<Props> = ({
                     expectations[0].inject_expectation_group
                       ? t('At least one player (per team) must validate the expectation')
                       : t('All players (per team) must validate the expectation')
-                  }
+                }
                 limit={120}
               />
             </AlertTitle>
           </Alert>
-          <div style={{ padding: '10px 0' }}>
+          <Paper>
             <ManualExpectationsValidationForm key={parentExpectation} expectation={parentExpectation}/>
-          </div>
-          <Divider style={{ marginTop: 20 }}/>
-          <div style={{ maxHeight: '80vh', overflowY: 'auto', padding: '10px 0 10px 0' }}>
-            <Typography variant="h5">{t('Players')}</Typography>
+          </Paper>
+          <Typography variant="h5" style={{ fontWeight: 500, margin: '10px' }}>
+            {t('Players')}
+          </Typography>
+          <div style={{ maxHeight: '80vh', overflowY: 'auto', padding: 10 }}>
             {childrenExpectations && childrenExpectations.map((e) => (
-              <ManualExpectationsValidationForm
-                key={e.inject_expectation_id}
-                expectation={e}
-              />
+              <div key={e.inject_expectation_id}>
+                <ManualExpectationsValidationForm expectation={e}/>
+                <Divider style={{ margin: '20px 0' }}/>
+              </div>
             ))}
           </div>
         </>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -24,11 +24,10 @@ import colorStyles from '../../../../../../components/Color';
 import Drawer from '../../../../../../components/common/Drawer';
 import ManualExpectationsValidationForm from './ManualExpectationsValidationForm';
 import ExpandableText from '../../../../../../components/common/ExpendableText';
-import type { Inject, Team, User } from '../../../../../../utils/api-types';
+import type { Inject, User } from '../../../../../../utils/api-types';
 import Paper from '../../../../../../components/common/Paper';
 import { computeColorStyle, computeLabel, resolveUserName, truncate } from '../../../../../../utils/String';
 import { useHelper } from '../../../../../../store';
-import type { TeamsHelper } from '../../../../../../actions/teams/team-helper';
 import type { UserHelper } from '../../../../../../actions/helper';
 import { useAppDispatch } from '../../../../../../utils/hooks';
 import useDataLoader from '../../../../../../utils/hooks/useDataLoader';
@@ -90,12 +89,10 @@ const ManualExpectations: FunctionComponent<Props> = ({
   const [currentExpectations, setCurrentExpectations] = useState<InjectExpectationsStore[] | null>(null);
   const [expanded, setExpanded] = useState<string | false>(false);
 
-  const { teamsMap, usersMap }: {
-    teamsMap: Record<string, Team>,
+  const { usersMap }: {
     usersMap: Record<string, User>
-  } = useHelper((helper: TeamsHelper & UserHelper) => {
+  } = useHelper((helper: UserHelper) => {
     return ({
-      teamsMap: helper.getTeamsMap(),
       usersMap: helper.getUsersMap(),
     });
   });
@@ -131,9 +128,6 @@ const ManualExpectations: FunctionComponent<Props> = ({
   const targetLabel = (expectationToProcess: InjectExpectationsStore) => {
     if (expectationToProcess.inject_expectation_user && usersMap[expectationToProcess.inject_expectation_user]) {
       return truncate(resolveUserName(usersMap[expectationToProcess.inject_expectation_user]), 22);
-    }
-    if (expectationToProcess.inject_expectation_team) {
-      return teamsMap[expectationToProcess.inject_expectation_team]?.team_name;
     }
     return t('Unknown');
   };

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectations.tsx
@@ -10,7 +10,7 @@ import colorStyles from '../../../../../../components/Color';
 import Drawer from '../../../../../../components/common/Drawer';
 import ManualExpectationsValidationForm from './ManualExpectationsValidationForm';
 import ExpandableText from '../../../../../../components/common/ExpendableText';
-import { Inject } from '../../../../../../utils/api-types';
+import type { Inject } from '../../../../../../utils/api-types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   item: {
@@ -132,10 +132,12 @@ const ManualExpectations: FunctionComponent<Props> = ({
               />
             </AlertTitle>
           </Alert>
-          <div style={{ paddingTop: 10 }}>
+          <div style={{ padding: '10px 0' }}>
             <ManualExpectationsValidationForm key={parentExpectation} expectation={parentExpectation}/>
           </div>
-          <div style={{ maxHeight: '80vh', overflowY: 'auto' }}>
+          <Divider style={{ marginTop: 20 }}/>
+          <div style={{ maxHeight: '80vh', overflowY: 'auto', padding: '10px 0 10px 0' }}>
+            <Typography variant="h5">{t('Players')}</Typography>
             {childrenExpectations && childrenExpectations.map((e) => (
               <ManualExpectationsValidationForm
                 key={e.inject_expectation_id}

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import { Button, Chip, TextField as MuiTextField, Typography } from '@mui/material';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -58,6 +58,37 @@ const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({ expect
   useDataLoader(() => {
     dispatch(fetchUsers());
   });
+  const onSubmit = (data: { expectation_score: number }) => {
+    dispatch(updateInjectExpectation(expectation.inject_expectation_id, {
+      ...data,
+      source_id: 'ui',
+      source_type: 'ui',
+      source_name: 'User input',
+    })).then(() => {
+      onUpdate?.();
+    });
+  };
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<{ expectation_score: number }>({
+    mode: 'onTouched',
+    resolver: zodResolver(zodImplement<{ expectation_score: number }>().with({
+      expectation_score: z.coerce.number(),
+    })),
+    defaultValues: {
+      expectation_score: expectation.inject_expectation_score ?? expectation.inject_expectation_expected_score ?? 0,
+    },
+  });
+  useEffect(() => {
+    reset({
+      expectation_score: expectation.inject_expectation_score ?? expectation.inject_expectation_expected_score ?? 0,
+    });
+  }, [expectation, reset]);
+
   const computeLabel = (e: InjectExpectationsStore) => {
     if (e.inject_expectation_status === 'PENDING') {
       return t('Pending validation');
@@ -92,29 +123,6 @@ const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({ expect
     }
     return t('Unknown');
   };
-  const onSubmit = (data: { expectation_score: number }) => {
-    dispatch(updateInjectExpectation(expectation.inject_expectation_id, {
-      ...data,
-      source_id: 'ui',
-      source_type: 'ui',
-      source_name: 'User input',
-    })).then(() => {
-      onUpdate?.();
-    });
-  };
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isSubmitting },
-  } = useForm<{ expectation_score: number }>({
-    mode: 'onTouched',
-    resolver: zodResolver(zodImplement<{ expectation_score: number }>().with({
-      expectation_score: z.coerce.number(),
-    })),
-    defaultValues: {
-      expectation_score: expectation.inject_expectation_score ?? expectation.inject_expectation_expected_score ?? 0,
-    },
-  });
 
   return (
     <div style={{ marginTop: 10 }}>

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Button, Chip, TextField as MuiTextField, Typography } from '@mui/material';
+import { Button, Chip, Divider, TextField as MuiTextField, Typography } from '@mui/material';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -83,39 +83,39 @@ const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({ expect
       expectation_score: expectation.inject_expectation_score ?? expectation.inject_expectation_expected_score ?? 0,
     },
   });
+
   return (
-    <form id="expectationForm" onSubmit={handleSubmit(onSubmit)}>
-      <Chip
-        classes={{ root: classes.chipInList }}
-        style={computeColorStyle(expectation)}
-        label={computeLabel(expectation)}
-      />
-      <Typography variant="h3">{t('Name')}</Typography>
-      {expectation.inject_expectation_name}
-      <div className={classes.marginTop_2}>
-        <Typography variant="h3">{t('Description')}</Typography>
-        <ExpandableText source={expectation.inject_expectation_description} limit={120} />
-      </div>
-      <MuiTextField
-        className={classes.marginTop_2}
-        variant="standard"
-        fullWidth
-        label={t('Score')}
-        type="number"
-        error={!!errors.expectation_score}
-        helperText={errors.expectation_score && errors.expectation_score?.message ? errors.expectation_score?.message : `${t('Expected score:')} ${expectation.inject_expectation_expected_score}`}
-        inputProps={register('expectation_score')}
-      />
-      <div className={classes.buttons}>
-        <Button
-          type="submit"
-          disabled={isSubmitting}
-          variant="contained"
-        >
-          {t('Validate')}
-        </Button>
-      </div>
-    </form>
+    <div style={{ marginTop: 10 }}>
+      <form id="expectationForm" onSubmit={handleSubmit(onSubmit)}>
+        <Chip
+          classes={{ root: classes.chipInList }}
+          style={computeColorStyle(expectation)}
+          label={computeLabel(expectation)}
+        />
+        <Typography variant="h3">{expectation.inject_expectation_user ? t('Player') : t('Team')}</Typography>
+        {expectation.inject_expectation_user ? expectation.inject_expectation_user : expectation.inject_expectation_team}
+        <MuiTextField
+          className={classes.marginTop_2}
+          variant="standard"
+          fullWidth
+          label={t('Score')}
+          type="number"
+          error={!!errors.expectation_score}
+          helperText={errors.expectation_score && errors.expectation_score?.message ? errors.expectation_score?.message : `${t('Expected score:')} ${expectation.inject_expectation_expected_score}`}
+          inputProps={register('expectation_score')}
+        />
+        <div className={classes.buttons}>
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            variant="contained"
+          >
+            {t('Validate')}
+          </Button>
+        </div>
+        <Divider style={{ marginTop: 20 }}/>
+      </form>
+    </div>
   );
 };
 

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
@@ -23,6 +23,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   marginTop_2: {
     marginTop: theme.spacing(2),
   },
+  scoreAcc: {
+    margin: 0,
+  },
   buttons: {
     display: 'flex',
     placeContent: 'end',
@@ -112,7 +115,7 @@ const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({ expect
         {withSummary && (<Typography variant="h3">{expectation.inject_expectation_user ? t('Player') : t('Team')}</Typography>)}
         {withSummary && targetLabel(expectation)}
         <MuiTextField
-          className={classes.marginTop_2}
+          className={withSummary ? classes.marginTop_2 : classes.scoreAcc}
           variant="standard"
           fullWidth
           label={t('Score')}

--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Button, Chip, Divider, TextField as MuiTextField, Typography } from '@mui/material';
+import { Button, Chip, TextField as MuiTextField, Typography } from '@mui/material';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -8,7 +8,6 @@ import type { InjectExpectationsStore } from '../../../../common/injects/expecta
 import { useFormatter } from '../../../../../../components/i18n';
 import { updateInjectExpectation } from '../../../../../../actions/Exercise';
 import { useAppDispatch } from '../../../../../../utils/hooks';
-import ExpandableText from '../../../../../../components/common/ExpendableText';
 import type { Theme } from '../../../../../../components/Theme';
 import colorStyles from '../../../../../../components/Color';
 import { zodImplement } from '../../../../../../utils/Zod';
@@ -113,7 +112,6 @@ const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({ expect
             {t('Validate')}
           </Button>
         </div>
-        <Divider style={{ marginTop: 20 }}/>
       </form>
     </div>
   );

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -628,7 +628,7 @@ const i18n = {
       'Number of expectations': "Nombre d'attendus",
       'Inject expectations': 'Attendus du stimuli',
       'Manual expectations': 'Attendus manuels',
-      'Expectations of ': 'Attendus de',
+      'Expectations of ': 'Attendus de ',
       MANUAL: 'Manuel',
       ARTICLE: 'Automatique - Déclenché lorsque l\'équipe a lu l\'article',
       DETECTION: 'Automatique - Detection: Déclenché lorsque l\'injection est traitée',

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -1862,7 +1862,9 @@ const i18n = {
       Failed: '已失败',
       'Pending result': '待定结果',
       'Validation mode': '验证模式',
+      'All players (per team) must validate the expectation': '所有球员(每队)必须验证期望值',
       'All assets (per group) must validate the expectation': '所有资产(每组)必须验证期望值',
+      'At least one player (per team) must validate the expectation': '至少一名球员(每队)必须验证期望值',
       'At least one asset (per group) must validate the expectation': '至少一个资产(每组)必须验证期望值',
       'An isolated asset is considered as a group of one asset': '隔离的资产被视为一组资产',
       // -- Expectation end --

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -620,7 +620,7 @@ const i18n = {
       'Each team should submit a text response':
         'Chaque équipe doit soumettre une réponse texte',
       // -- Expectation start --
-      'This expectation is handled automatically by the platform and triggered when team reads articles': 'Cet attendu est géré automatiquement par la plateforme et déclenché lorsque une équipe lit les articles',
+      'This expectation is handled automatically by the platform and triggered when target reads the articles': 'Cet attendu est géré automatiquement par la plateforme et déclenché lorsque une cible lit les articles',
       'Add expectations': 'Ajouter des attendus',
       'Add expectation in this inject': 'Ajouter des attendus dans ce stimuli',
       'Update the expectation': 'Modifier l\'attendu',
@@ -2467,7 +2467,7 @@ const i18n = {
       REGEXP: 'Regular expression',
       '-': 'None',
       MANUAL: 'Manual',
-      ARTICLE: 'Automatic - Triggered when team reads articles',
+      ARTICLE: 'Automatic - Triggered when target reads the articles',
       DETECTION: 'Automatic - Detection: Triggered when inject is processed',
       PREVENTION: 'Automatic - Prevention: Triggered when inject is processed',
       TYPE_ARTICLE: 'Article',

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -646,7 +646,9 @@ const i18n = {
       Failed: 'Echoué',
       'Pending result': 'Résultat en attente',
       'Validation mode': 'Type de validation',
+      'All players (per team) must validate the expectation': 'Tous les joueurs (par équipe) doivent valider l\'attente',
       'All assets (per group) must validate the expectation': 'Tous les actifs (par groupe) doivent valider l\'attente',
+      'At least one player (per team) must validate the expectation': 'Au moins un joueur (par équipe) doit valider l\'attente',
       'At least one asset (per group) must validate the expectation': 'Au moins un actif (par groupe) doit valider l\'attente',
       'An isolated asset is considered as a group of one asset': 'Un actif isolé est considéré comme un groupe d\'un seul actif',
       // -- Expectation end --

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -346,8 +346,8 @@ const i18n = {
       'Send email': 'Envoyer le mail',
       'Add documents in this media pressure':
         'Ajouter des documents à cette pression médiatique',
-      'Expect teams to read the article(s)':
-        'Les équipes doivent lire le(s) article(s)',
+      'Expect targets to read the article(s)':
+        'Les cibles doivent lire le(s) article(s)',
       'Add media pressure': 'Ajouter de la pression médiatique',
       'Remove from the media pressure': 'Supprimer de la pression médiatique',
       'Raw request data': 'Données brutes de la requête',
@@ -1565,7 +1565,7 @@ const i18n = {
       'Send email': '发送邮件',
       'Add documents in this media pressure':
         '将文档添加到媒体',
-      'Expect teams to read the article(s)':
+      'Expect targets to read the article(s)':
         '希望团队阅读文章',
       'Add media pressure': '添加媒体',
       'Remove from the media pressure': '从媒体移除',

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -621,6 +621,7 @@ const i18n = {
         'Chaque équipe doit soumettre une réponse texte',
       // -- Expectation start --
       'This expectation is handled automatically by the platform and triggered when target reads the articles': 'Cet attendu est géré automatiquement par la plateforme et déclenché lorsque une cible lit les articles',
+      'This expectation is handled automatically by the platform and triggered when the target completes the challenges': 'Cette attente est gérée automatiquement par la plateforme et est déclenchée lorsque la cible termine les défis',
       'Add expectations': 'Ajouter des attendus',
       'Add expectation in this inject': 'Ajouter des attendus dans ce stimuli',
       'Update the expectation': 'Modifier l\'attendu',
@@ -651,6 +652,8 @@ const i18n = {
       'At least one player (per team) must validate the expectation': 'Au moins un joueur (par équipe) doit valider l\'attente',
       'At least one asset (per group) must validate the expectation': 'Au moins un actif (par groupe) doit valider l\'attente',
       'An isolated asset is considered as a group of one asset': 'Un actif isolé est considéré comme un groupe d\'un seul actif',
+      'An isolated player is considered as a group of one player': 'Un jouer isolé est considéré comme un groupe d\'un seul jouer',
+      'The score set for the team will also be applied to all players in the team': 'Le score attribué à l\'équipe sera également appliqué à tous les joueurs de l\'équipe',
       // -- Expectation end --
       'Distribution of expected total score by team':
         'Distribution du score total attendu par équipe',
@@ -738,6 +741,7 @@ const i18n = {
       'Token key': 'Token',
       Example: 'Exemple',
       Score: 'Score',
+      'Expected score': 'Score attendu',
       Message: 'Message',
       'New control': 'Nouveau contrôle',
       'Percent of reached score': 'Pourcentage du score atteint',
@@ -751,6 +755,8 @@ const i18n = {
       Order: 'Ordre',
       Details: 'Détails',
       Team: 'Equipe',
+      Player: 'Jouer',
+      player: 'jouer',
       Template: 'Modèle',
       Questionnaire: 'Questionnaire',
       User: 'Utilisateur',
@@ -776,6 +782,7 @@ const i18n = {
       'Should not be empty': 'Ne doit pas être vide',
       // Assets
       Endpoints: 'Endpoints',
+      asset: 'actif',
       'Teams of players': 'Equipes de joueurs',
       'Create a new endpoint': 'Créer un nouvel endpoint',
       'Update the endpoint': 'Modifier l\'endpoint',

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -698,6 +698,13 @@ const i18n = {
       Error: 'Erreur',
       'This page is not found on this OpenBAS application.': 'Cette page est introuvable sur l\'application OpenBAS.',
       'You must be logged to access this page': 'Vous devez être connecté pour accéder à cette page',
+      // Validation Type
+      'Validation type': 'Type de validation',
+      'User input': 'Entrée utilisateur',
+      'Player Manual Validation': 'Validation manuelle du joueur',
+      'Team Manual Validation': 'Validation manuelle de l\'équipe',
+      'Challenge validation': 'Validation du défi',
+      'Media pressure read': 'Pression médiatique',
       // Challenges
       Challenges: 'Challenges',
       // Variables

--- a/openbas-front/src/utils/String.js
+++ b/openbas-front/src/utils/String.js
@@ -1,4 +1,5 @@
 import { isNotEmptyField } from './utils';
+import colorStyles from '../components/Color';
 
 export const truncate = (str, limit) => {
   if (str === undefined || str === null || str.length <= limit) {
@@ -51,4 +52,32 @@ export const getLabelOfRemainingItems = (items, start, property) => {
 // Calculate the number of remaining items
 export const getRemainingItemsCount = (items, visibleItems) => {
   return (items && visibleItems && items.length - visibleItems.length) || null;
+};
+
+// Compute label for status
+export const computeLabel = (status) => {
+  if (status === 'PENDING') {
+    return 'Pending validation';
+  }
+  if (status === 'SUCCESS') {
+    return 'Success';
+  }
+  if (status === 'PARTIAL') {
+    return 'Partial';
+  }
+  return 'Failed';
+};
+
+// compute color for status
+export const computeColorStyle = (status) => {
+  if (status === 'PENDING') {
+    return colorStyles.blueGrey;
+  }
+  if (status === 'SUCCESS') {
+    return colorStyles.green;
+  }
+  if (status === 'PARTIAL') {
+    return colorStyles.orange;
+  }
+  return colorStyles.red;
 };

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -1347,7 +1347,7 @@ export interface InjectTargetWithResult {
   id: string;
   name?: string;
   platformType?: "Linux" | "Windows" | "MacOS" | "Container" | "Service" | "Generic" | "Internal" | "Unknown";
-  targetType?: "ASSETS" | "ASSETS_GROUPS" | "TEAMS";
+  targetType?: "ASSETS" | "ASSETS_GROUPS" | "PLAYER" | "TEAMS";
 }
 
 export interface InjectTeamsInput {

--- a/openbas-model/src/main/java/io/openbas/database/model/Challenge.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Challenge.java
@@ -57,7 +57,7 @@ public class Challenge implements Base {
 
     @Column(name = "challenge_score")
     @JsonProperty("challenge_score")
-    private Integer score;
+    private Double score;
 
     @Column(name = "challenge_max_attempts")
     @JsonProperty("challenge_max_attempts")

--- a/openbas-model/src/main/java/io/openbas/database/model/Inject.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Inject.java
@@ -310,7 +310,7 @@ public class Inject implements Base, Injection {
         return this.expectations.stream()
                 .filter(execution -> execution.getType().equals(InjectExpectation.EXPECTATION_TYPE.ARTICLE))
                 .filter(execution -> execution.getArticle().equals(article))
-                .filter(execution -> execution.getUser() != null)
+                .filter(execution -> execution.getUser() != null) //Validation automatics are from only players
                 .filter(execution -> execution.getUser().equals(user))
                 .toList();
     }

--- a/openbas-model/src/main/java/io/openbas/database/model/Inject.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Inject.java
@@ -419,6 +419,7 @@ public class Inject implements Base, Injection {
                         InjectExpectation.EXPECTATION_TYPE.valueOf(rawInjectExpectation.getInject_expectation_type()));
                 expectation.setScore(rawInjectExpectation.getInject_expectation_score());
                 expectation.setExpectedScore(rawInjectExpectation.getInject_expectation_expected_score());
+                expectation.setExpectationGroup(rawInjectExpectation.getInject_expectation_group());
 
                 // Add the team of the expectation
                 if (rawInjectExpectation.getTeam_id() != null) {

--- a/openbas-model/src/main/java/io/openbas/database/model/Inject.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Inject.java
@@ -310,7 +310,7 @@ public class Inject implements Base, Injection {
         return this.expectations.stream()
                 .filter(execution -> execution.getType().equals(InjectExpectation.EXPECTATION_TYPE.ARTICLE))
                 .filter(execution -> execution.getArticle().equals(article))
-                .filter(execution -> execution.getUser() != null) //Validation automatics are from only players
+                .filter(execution -> execution.getUser() != null) //We include only the expectations from players, because the validation link is always from a player
                 .filter(execution -> execution.getUser().equals(user))
                 .toList();
     }

--- a/openbas-model/src/main/java/io/openbas/database/model/Inject.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Inject.java
@@ -310,7 +310,8 @@ public class Inject implements Base, Injection {
         return this.expectations.stream()
                 .filter(execution -> execution.getType().equals(InjectExpectation.EXPECTATION_TYPE.ARTICLE))
                 .filter(execution -> execution.getArticle().equals(article))
-                .filter(execution -> execution.getTeam().getUsers().contains(user))
+                .filter(execution -> execution.getUser() != null)
+                .filter(execution -> execution.getUser().equals(user))
                 .toList();
     }
 

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectExpectation.java
@@ -90,16 +90,34 @@ public class InjectExpectation implements Base {
 
   @JsonProperty("inject_expectation_status")
   public EXPECTATION_STATUS getResponse() {
+
     if( this.getScore() == null ) {
       return EXPECTATION_STATUS.PENDING;
     }
-    if( this.getScore() >= this.getExpectedScore() ) {
-      return EXPECTATION_STATUS.SUCCESS;
+
+    if (team != null) {
+      if(this.isExpectationGroup()){
+        if( this.getScore() > 0) {
+          return EXPECTATION_STATUS.SUCCESS;
+        }else{
+          return EXPECTATION_STATUS.FAILED;
+        }
+      }else{
+        if( this.getScore() >= this.getExpectedScore()) {
+          return EXPECTATION_STATUS.SUCCESS;
+        }else{
+          return EXPECTATION_STATUS.FAILED;
+        }
+      }
+    }else {
+      if (this.getScore() >= this.getExpectedScore()) {
+        return EXPECTATION_STATUS.SUCCESS;
+      }
+      if (this.getScore() == 0) {
+        return EXPECTATION_STATUS.FAILED;
+      }
+      return EXPECTATION_STATUS.PARTIAL;
     }
-    if( this.getScore() == 0 ) {
-      return EXPECTATION_STATUS.FAILED;
-    }
-    return EXPECTATION_STATUS.PARTIAL;
   }
 
   @Setter

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectExpectation.java
@@ -86,7 +86,7 @@ public class InjectExpectation implements Base {
   @Setter
   @Column(name = "inject_expectation_score")
   @JsonProperty("inject_expectation_score")
-  private Integer score;
+  private Double score;
 
   @JsonProperty("inject_expectation_status")
   public EXPECTATION_STATUS getResponse() {
@@ -105,7 +105,7 @@ public class InjectExpectation implements Base {
   @Setter
   @Column(name = "inject_expectation_expected_score")
   @JsonProperty("inject_expectation_expected_score")
-  private Integer expectedScore;
+  private Double expectedScore;
 
   @Setter
   @Column(name = "inject_expectation_created_at")

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectExpectationResult.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectExpectationResult.java
@@ -16,7 +16,7 @@ public class InjectExpectationResult {
 
   private String date;
 
-  private Integer score;
+  private Double score;
 
   @NotBlank
   private String result;

--- a/openbas-model/src/main/java/io/openbas/database/model/Team.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Team.java
@@ -149,33 +149,33 @@ public class Team implements Base {
 
     @JsonProperty("team_injects_expectations_total_score")
     @NotNull
-    public long getInjectExceptationsTotalScore() {
+    public double getInjectExceptationsTotalScore() {
         return getInjectExpectations().stream()
             .filter((inject) -> inject.getScore() != null)
-            .mapToLong(InjectExpectation::getScore).sum();
+            .mapToDouble(InjectExpectation::getScore).sum();
     }
     @JsonProperty("team_injects_expectations_total_score_by_exercise")
     @NotNull
-    public Map<String, Long> getInjectExceptationsTotalScoreByExercise() {
+    public Map<String, Double> getInjectExceptationsTotalScoreByExercise() {
         return getInjectExpectations().stream()
             .filter(expectation -> Objects.nonNull(expectation.getExercise()) && Objects.nonNull(expectation.getScore()))
             .collect(Collectors.groupingBy(expectation -> expectation.getExercise().getId(),
-                Collectors.summingLong(InjectExpectation::getScore)));
+                Collectors.summingDouble(InjectExpectation::getScore)));
     }
 
     @JsonProperty("team_injects_expectations_total_expected_score")
     @NotNull
-    public long getInjectExceptationsTotalExpectedScore() {
-        return getInjectExpectations().stream().mapToLong(InjectExpectation::getExpectedScore).sum();
+    public double getInjectExceptationsTotalExpectedScore() {
+        return getInjectExpectations().stream().mapToDouble(InjectExpectation::getExpectedScore).sum();
     }
 
     @JsonProperty("team_injects_expectations_total_expected_score_by_exercise")
     @NotNull
-    public Map<String, Long> getInjectExpectationsTotalExpectedScoreByExercise() {
+    public Map<String, Double> getInjectExpectationsTotalExpectedScoreByExercise() {
         return getInjectExpectations().stream()
             .filter(expectation -> Objects.nonNull(expectation.getExercise()))
             .collect(Collectors.groupingBy(expectation -> expectation.getExercise().getId(),
-                Collectors.summingLong(InjectExpectation::getExpectedScore)));
+                Collectors.summingDouble(InjectExpectation::getExpectedScore)));
     }
     // endregion
 

--- a/openbas-model/src/main/java/io/openbas/database/model/TeamSimple.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/TeamSimple.java
@@ -111,7 +111,7 @@ public class TeamSimple {
     @JsonProperty("team_injects_expectations_total_expected_score")
     @NotNull
     public double getInjectExceptationsTotalExpectedScore() {
-        return getInjectExpectations().stream().mapToDouble(InjectExpectation::getExpectedScore).sum();
+        return getInjectExpectations().stream() .filter(expectation -> Objects.nonNull(expectation.getExpectedScore())).mapToDouble(InjectExpectation::getExpectedScore).sum();
     }
 
     @JsonProperty("team_injects_expectations_total_expected_score_by_exercise")

--- a/openbas-model/src/main/java/io/openbas/database/model/TeamSimple.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/TeamSimple.java
@@ -94,33 +94,33 @@ public class TeamSimple {
 
     @JsonProperty("team_injects_expectations_total_score")
     @NotNull
-    public long getInjectExceptationsTotalScore() {
+    public double getInjectExceptationsTotalScore() {
         return getInjectExpectations().stream()
             .filter((inject) -> inject.getScore() != null)
-            .mapToLong(InjectExpectation::getScore).sum();
+            .mapToDouble(InjectExpectation::getScore).sum();
     }
     @JsonProperty("team_injects_expectations_total_score_by_exercise")
     @NotNull
-    public Map<String, Long> getInjectExceptationsTotalScoreByExercise() {
+    public Map<String, Double> getInjectExceptationsTotalScoreByExercise() {
         return getInjectExpectations().stream()
             .filter(expectation -> Objects.nonNull(expectation.getExercise()) && Objects.nonNull(expectation.getScore()))
             .collect(Collectors.groupingBy(expectation -> expectation.getExercise().getId(),
-                Collectors.summingLong(InjectExpectation::getScore)));
+                Collectors.summingDouble(InjectExpectation::getScore)));
     }
 
     @JsonProperty("team_injects_expectations_total_expected_score")
     @NotNull
-    public long getInjectExceptationsTotalExpectedScore() {
-        return getInjectExpectations().stream().mapToLong(InjectExpectation::getExpectedScore).sum();
+    public double getInjectExceptationsTotalExpectedScore() {
+        return getInjectExpectations().stream().mapToDouble(InjectExpectation::getExpectedScore).sum();
     }
 
     @JsonProperty("team_injects_expectations_total_expected_score_by_exercise")
     @NotNull
-    public Map<String, Long> getInjectExpectationsTotalExpectedScoreByExercise() {
-        Map<String, Long> result = getInjectExpectations().stream()
+    public Map<String, Double> getInjectExpectationsTotalExpectedScoreByExercise() {
+        Map<String, Double> result = getInjectExpectations().stream()
                 .filter(expectation -> Objects.nonNull(expectation.getExercise()))
                 .collect(Collectors.groupingBy(expectation -> expectation.getExercise().getId(),
-                        Collectors.summingLong(InjectExpectation::getExpectedScore)));
+                        Collectors.summingDouble(InjectExpectation::getExpectedScore)));
         return result;
     }
     // endregion

--- a/openbas-model/src/main/java/io/openbas/database/raw/RawGlobalInjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/database/raw/RawGlobalInjectExpectation.java
@@ -4,9 +4,9 @@ public interface RawGlobalInjectExpectation {
 
     String getInject_expectation_type();
 
-    Integer getInject_expectation_score();
+    Double getInject_expectation_score();
 
-    Integer getInject_expectation_expected_score();
+    Double getInject_expectation_expected_score();
 
     String getInject_title();
 

--- a/openbas-model/src/main/java/io/openbas/database/raw/RawInjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/database/raw/RawInjectExpectation.java
@@ -17,4 +17,6 @@ public interface RawInjectExpectation {
     String getInject_expectation_id();
 
     String getExercise_id();
+
+    boolean getInject_expectation_group();
 }

--- a/openbas-model/src/main/java/io/openbas/database/raw/RawInjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/database/raw/RawInjectExpectation.java
@@ -4,9 +4,9 @@ public interface RawInjectExpectation {
 
     String getInject_expectation_type();
 
-    Integer getInject_expectation_score();
+    Double getInject_expectation_score();
 
-    Integer getInject_expectation_expected_score();
+    Double getInject_expectation_expected_score();
 
     String getTeam_id();
 

--- a/openbas-model/src/main/java/io/openbas/database/raw/RawInjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/database/raw/RawInjectExpectation.java
@@ -18,5 +18,5 @@ public interface RawInjectExpectation {
 
     String getExercise_id();
 
-    boolean getInject_expectation_group();
+    Boolean getInject_expectation_group();
 }

--- a/openbas-model/src/main/java/io/openbas/database/raw/impl/SimpleRawInjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/database/raw/impl/SimpleRawInjectExpectation.java
@@ -10,8 +10,8 @@ public class SimpleRawInjectExpectation implements RawInjectExpectation {
 
     private String inject_expectation_id;
     private String inject_expectation_type;
-    private Integer inject_expectation_score;
-    private Integer inject_expectation_expected_score;
+    private Double inject_expectation_score;
+    private Double inject_expectation_expected_score;
     private String team_id;
     private String asset_id;
     private String asset_group_id;

--- a/openbas-model/src/main/java/io/openbas/database/raw/impl/SimpleRawInjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/database/raw/impl/SimpleRawInjectExpectation.java
@@ -16,4 +16,5 @@ public class SimpleRawInjectExpectation implements RawInjectExpectation {
     private String asset_id;
     private String asset_group_id;
     private String exercise_id;
+    private Boolean inject_expectation_group;
 }

--- a/openbas-model/src/main/java/io/openbas/database/repository/ExerciseRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/ExerciseRepository.java
@@ -55,7 +55,7 @@ public interface ExerciseRepository extends CrudRepository<Exercise, String>,
      * @param from the max date of creation
      * @return the list of expectations
      */
-    @Query(value = "SELECT ie.inject_expectation_type, ie.inject_expectation_score, ie.inject_expectation_expected_score " +
+    @Query(value = "SELECT ie.inject_expectation_type, ie.inject_expectation_group, ie.inject_expectation_score, ie.inject_expectation_expected_score " +
             "FROM injects_expectations ie " +
             "INNER JOIN injects ON ie.inject_id = injects.inject_id " +
             "INNER JOIN exercises ON injects.inject_exercise = exercises.exercise_id " +
@@ -68,7 +68,7 @@ public interface ExerciseRepository extends CrudRepository<Exercise, String>,
      * @param userId the id of the user
      * @return the list of expectations
      */
-    @Query(value = "SELECT ie.inject_expectation_type, ie.inject_expectation_score, ie.inject_expectation_expected_score " +
+    @Query(value = "SELECT ie.inject_expectation_type, ie.inject_expectation_group, ie.inject_expectation_score, ie.inject_expectation_expected_score " +
             "FROM injects_expectations ie " +
             "INNER JOIN injects ON ie.inject_id = injects.inject_id " +
             "INNER JOIN exercises e ON injects.inject_exercise = e.exercise_id " +

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -34,7 +34,7 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
                                                       @Param("teamIds") List<String> teamIds);
 
     @Query(value = "select i from InjectExpectation i where i.exercise.id = :exerciseId " +
-            "and i.type = 'CHALLENGE' and i.challenge.id = :challengeId and i.team.id in (:teamIds) and i.user is null")
+            "and i.type = 'CHALLENGE' and i.challenge.id = :challengeId and i.team.id in (:teamIds)")
     List<InjectExpectation> findChallengeExpectations(@Param("exerciseId") String exerciseId,
                                                       @Param("teamIds") List<String> teamIds,
                                                       @Param("challengeId") String challengeId);

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -34,10 +34,14 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
                                                      @Param("teamIds") List<String> teamIds);
 
     @Query(value = "select i from InjectExpectation i where i.exercise.id = :exerciseId " +
-            "and i.challenge.id = :challengeId and i.team.id IN (:teamIds)")
+            "and i.type = 'CHALLENGE' and i.challenge.id = :challengeId and i.team.id IN (:teamIds) and i.user is null")
     List<InjectExpectation> findChallengeExpectations(@Param("exerciseId") String exerciseId,
                                                @Param("teamIds") List<String> teamIds,
                                                @Param("challengeId") String challengeId);
+
+    @Query(value = "select i from InjectExpectation i where i.user = : userId and i.exercise.id = :exerciseId " +
+            "and i.challenge.id = :challengeId and i.type = 'CHALLENGE' ")
+    InjectExpectation findByUserAndExerciseAndChallenge(final String userId, final String exerciseId, final String challengeId);
 
     // -- PREVENTION --
 
@@ -62,15 +66,14 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
     @Query("select AVG(ie.score) from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null and ie.score > 0")
     Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayer(final String injectId, final String teamId, final String expectationName);
 
+    @Query("select AVG(ie.score) from InjectExpectation ie where ie.exercise.id = :exerciseId and ie.challenge.id = :challengeId and ie.team.id = :teamId and ie.user is not null and ie.score > 0")
+    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChallenge(final String exerciseId, final String challengeId, final String teamId);
+
     @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null")
     Double computeAverageScoreWhenValidationTypeIsAllPlayers(final String injectId, final String teamId, final String expectationName);
 
-    @Query("select count(ie.score) from InjectExpectation ie where ie.inject.id = :injectId " +
-            "and ie.team.id = :teamId " +
-            "and ie.name = :expectationName " +
-            "and ie.user is not null " +
-            "and (ie.score is null or ie.score = 0)")
-    Integer countExpectationsWithScoreNullOrZero(final String injectId, final String teamId, final String expectationName);
+    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie where ie.exercise.id = :exerciseId and ie.challenge.id = :challengeId and ie.team.id = :teamId and ie.user is not null")
+    Double computeAverageScoreWhenValidationTypeIsAllPlayersForChallenge(final String exerciseId, final String challengeId, final String teamId);
 
     // -- RETRIEVE EXPECTATIONS FOR TEAM AND NOT FOR PLAYERS
     @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is null")

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -44,7 +44,7 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
     List<InjectExpectation> findByUserAndExerciseAndChallenge(final String userId, final String exerciseId, final String challengeId);
 
     @Query(value = "select i from InjectExpectation i where i.inject.id in (:injectIds) " +
-            "and i.article.id in (:articlesIds) and i.team.id in (:teamIds) and i.type = 'ARTICLE' and i.user is null")
+            "and i.article.id in (:articlesIds) and i.team.id in (:teamIds) and i.type = 'ARTICLE'")
     List<InjectExpectation> findChannelExpectations(@Param("injectIds") List<String> injectIds,
                                                     @Param("teamIds") List<String> teamIds,
                                                     @Param("articlesIds") List<String> articlesIds);
@@ -77,40 +77,6 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
             "and ie.name = :expectationName " +
             "and ie.user is not null")
     List<InjectExpectation> findAllByInjectAndTeamAndExpectationNameAndUserIsNotNull(final String injectId, final String teamId, final String expectationName);
-
-    @Query("select AVG(ie.score) from InjectExpectation ie " +
-            "where ie.exercise.id = :exerciseId " +
-            "and ie.challenge.id = :challengeId " +
-            "and ie.team.id = :teamId " +
-            "and ie.user is not null " +
-            "and ie.score > 0 " +
-            "and ie.type = 'CHALLENGE' ")
-    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChallenge(final String exerciseId, final String challengeId, final String teamId);
-
-    @Query("select AVG(ie.score) from InjectExpectation ie " +
-            "where ie.inject.id in (:injectIds) " +
-            "and ie.article.id in (:articleIds) " +
-            "and ie.team.id = :teamId " +
-            "and ie.user is not null " +
-            "and ie.score > 0 " +
-            "and ie.type = 'ARTICLE' ")
-    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChannel(final List<String> injectIds, final List<String> articleIds, final String teamId);
-
-    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie " +
-            "where ie.exercise.id = :exerciseId " +
-            "and ie.challenge.id = :challengeId " +
-            "and ie.team.id = :teamId " +
-            "and ie.user is not null " +
-            "and ie.type = 'CHALLENGE' ")
-    Double computeAverageScoreWhenValidationTypeIsAllPlayersForChallenge(final String exerciseId, final String challengeId, final String teamId);
-
-    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie " +
-            "where ie.inject.id in (:injectIds) " +
-            "and ie.article.id in (:articleIds) " +
-            "and ie.team.id = :teamId " +
-            "and ie.user is not null " +
-            "and ie.type = 'ARTICLE' ")
-    Double computeAverageScoreWhenValidationTypeIsAllPlayersForChannel(final List<String> injectIds, final List<String> articleIds, final String teamId);
 
     // -- RETRIEVE EXPECTATIONS FOR TEAM AND NOT FOR PLAYERS
     @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is null")

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -39,7 +39,7 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
                                                       @Param("teamIds") List<String> teamIds,
                                                       @Param("challengeId") String challengeId);
 
-    @Query(value = "select i from InjectExpectation i where i.user = :userId and i.exercise.id = :exerciseId " +
+    @Query(value = "select i from InjectExpectation i where i.user.id = :userId and i.exercise.id = :exerciseId " +
             "and i.challenge.id = :challengeId and i.type = 'CHALLENGE' ")
     List<InjectExpectation> findByUserAndExerciseAndChallenge(final String userId, final String exerciseId, final String challengeId);
 

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -49,7 +49,14 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
 
     // -- BY TARGET TYPE
 
-    @Query(value = "select i from InjectExpectation i where i.inject.id = :injectId and i.team.id = :teamId")
+    @Query(value = "select i from InjectExpectation i where i.inject.id = :injectId and i.team.id = :teamId and i.user.id = :playerId")
+    List<InjectExpectation> findAllByInjectAndTeamAndPlayer(
+        @Param("injectId") @NotBlank final String injectId,
+        @Param("teamId") @NotBlank final String teamId,
+        @Param("playerId") @NotBlank final String playerId
+    );
+
+    @Query(value = "select i from InjectExpectation i where i.inject.id = :injectId and i.team.id = :teamId and i.user is null")
     List<InjectExpectation> findAllByInjectAndTeam(
         @Param("injectId") @NotBlank final String injectId,
         @Param("teamId") @NotBlank final String teamId

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -57,14 +57,22 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
     );
 
     @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null")
-    List<InjectExpectation> findAllByInjectAndTeamAndExpectationNameAndUserIsNotNull(String injectId, String teamId, String expectationName);
+    List<InjectExpectation> findAllByInjectAndTeamAndExpectationNameAndUserIsNotNull(final String injectId, final String teamId, final String expectationName);
 
-    @Query("select AVG(ie.score) from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null")
-    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayer(String injectId, String teamId, String expectationName);
+    @Query("select AVG(ie.score) from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null and ie.score > 0")
+    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayer(final String injectId, final String teamId, final String expectationName);
 
     @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null")
-    Double computeAverageScoreWhenValidationTypeIsAllPlayers(String injectId, String teamId, String expectationName);
+    Double computeAverageScoreWhenValidationTypeIsAllPlayers(final String injectId, final String teamId, final String expectationName);
 
+    @Query("select count(ie.score) from InjectExpectation ie where ie.inject.id = :injectId " +
+            "and ie.team.id = :teamId " +
+            "and ie.name = :expectationName " +
+            "and ie.user is not null " +
+            "and (ie.score is null or ie.score = 0)")
+    Integer countExpectationsWithScoreNullOrZero(final String injectId, final String teamId, final String expectationName);
+
+    // -- RETRIEVE EXPECTATIONS FOR TEAM AND NOT FOR PLAYERS
     @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is null")
     Optional<InjectExpectation> findByInjectAndTeamAndExpectationNameAndUserIsNull(String injectId, String teamId, String expectationName);
 

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -102,7 +102,7 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
 
     @Query(value = "SELECT "
             + "team_id, asset_id, asset_group_id, inject_expectation_type, "
-            + "inject_expectation_score, inject_expectation_expected_score, inject_expectation_id, exercise_id "
+            + "inject_expectation_score, inject_expectation_group, inject_expectation_expected_score, inject_expectation_id, exercise_id "
             + "FROM injects_expectations i "
             + "where i.inject_expectation_id IN :ids",
             nativeQuery = true)

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -68,17 +68,15 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
     @Query("select ie from InjectExpectation ie " +
             "where ie.inject.id = :injectId " +
             "and ie.team.id = :teamId " +
-            "and ie.name = :expectationName " +
-            "and ie.user is not null")
-    List<InjectExpectation> findAllByInjectAndTeamAndExpectationNameAndUserIsNotNull(final String injectId, final String teamId, final String expectationName);
+            "and ie.name = :expectationName ")
+    List<InjectExpectation> findAllByInjectAndTeamAndExpectationName(final String injectId, final String teamId, final String expectationName);
 
-    @Query("select AVG(ie.score) from InjectExpectation ie " +
+    @Query("select ie from InjectExpectation ie " +
             "where ie.inject.id = :injectId " +
             "and ie.team.id = :teamId " +
             "and ie.name = :expectationName " +
-            "and ie.user is not null " +
-            "and ie.score > 0")
-    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayer(final String injectId, final String teamId, final String expectationName);
+            "and ie.user is not null")
+    List<InjectExpectation> findAllByInjectAndTeamAndExpectationNameAndUserIsNotNull(final String injectId, final String teamId, final String expectationName);
 
     @Query("select AVG(ie.score) from InjectExpectation ie " +
             "where ie.exercise.id = :exerciseId " +
@@ -99,13 +97,6 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
     Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChannel(final List<String> injectIds, final List<String> articleIds, final String teamId);
 
     @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie " +
-            "where ie.inject.id = :injectId " +
-            "and ie.team.id = :teamId " +
-            "and ie.name = :expectationName " +
-            "and ie.user is not null")
-    Double computeAverageScoreWhenValidationTypeIsAllPlayers(final String injectId, final String teamId, final String expectationName);
-
-    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie " +
             "where ie.exercise.id = :exerciseId " +
             "and ie.challenge.id = :challengeId " +
             "and ie.team.id = :teamId " +
@@ -120,13 +111,6 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
             "and ie.user is not null " +
             "and ie.type = 'ARTICLE' ")
     Double computeAverageScoreWhenValidationTypeIsAllPlayersForChannel(final List<String> injectIds, final List<String> articleIds, final String teamId);
-
-    @Query("select count(ie) from InjectExpectation ie where ie.inject.id = :injectId " +
-            "and ie.team.id = :teamId " +
-            "and ie.name = :expectationName " +
-            "and ie.user is not null " +
-            "and (ie.score is null or ie.score = 0)")
-    Integer countExpectationsWithScoreNullOrZero(final String injectId, final String teamId, final String expectationName);
 
     // -- RETRIEVE EXPECTATIONS FOR TEAM AND NOT FOR PLAYERS
     @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is null")

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -56,6 +56,18 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
         @Param("playerId") @NotBlank final String playerId
     );
 
+    @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null")
+    List<InjectExpectation> findAllByInjectAndTeamAndExpectationNameAndUserIsNotNull(String injectId, String teamId, String expectationName);
+
+    @Query("select AVG(ie.score) from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null")
+    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayer(String injectId, String teamId, String expectationName);
+
+    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null")
+    Double computeAverageScoreWhenValidationTypeIsAllPlayers(String injectId, String teamId, String expectationName);
+
+    @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is null")
+    Optional<InjectExpectation> findByInjectAndTeamAndExpectationNameAndUserIsNull(String injectId, String teamId, String expectationName);
+
     @Query(value = "select i from InjectExpectation i where i.inject.id = :injectId and i.team.id = :teamId and i.user is null")
     List<InjectExpectation> findAllByInjectAndTeam(
         @Param("injectId") @NotBlank final String injectId,

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -91,12 +91,12 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
 
     @Query("select AVG(ie.score) from InjectExpectation ie " +
             "where ie.inject.id in (:injectIds) " +
-            "and ie.article.id = :channelId " +
+            "and ie.article.id in (:articleIds) " +
             "and ie.team.id = :teamId " +
             "and ie.user is not null " +
             "and ie.score > 0 " +
             "and ie.type = 'ARTICLE' ")
-    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChannel(final List<String> injectIds, final String channelId, final String teamId);
+    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChannel(final List<String> injectIds, final List<String> articleIds, final String teamId);
 
     @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie " +
             "where ie.inject.id = :injectId " +
@@ -115,12 +115,18 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
 
     @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie " +
             "where ie.inject.id in (:injectIds) " +
-            "and ie.article.id = :channelId " +
+            "and ie.article.id in (:articleIds) " +
             "and ie.team.id = :teamId " +
             "and ie.user is not null " +
             "and ie.type = 'ARTICLE' ")
-    Double computeAverageScoreWhenValidationTypeIsAllPlayersForChannel(final List<String> injectIds, final String channelId, final String teamId);
+    Double computeAverageScoreWhenValidationTypeIsAllPlayersForChannel(final List<String> injectIds, final List<String> articleIds, final String teamId);
 
+    @Query("select count(ie) from InjectExpectation ie where ie.inject.id = :injectId " +
+            "and ie.team.id = :teamId " +
+            "and ie.name = :expectationName " +
+            "and ie.user is not null " +
+            "and (ie.score is null or ie.score = 0)")
+    Integer countExpectationsWithScoreNullOrZero(final String injectId, final String teamId, final String expectationName);
 
     // -- RETRIEVE EXPECTATIONS FOR TEAM AND NOT FOR PLAYERS
     @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is null")

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -29,9 +29,9 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
     );
 
     @Query(value = "select i from InjectExpectation i where i.exercise.id = :exerciseId " +
-            "and i.type = 'CHALLENGE' and i.team.id in (:teamIds)")
-    List<InjectExpectation> findChallengeExpectations(@Param("exerciseId") String exerciseId,
-                                                      @Param("teamIds") List<String> teamIds);
+            "and i.type = 'CHALLENGE' and i.user.id = :userId ")
+    List<InjectExpectation> findChallengeExpectationsByExerciseAndUser(@Param("exerciseId") String exerciseId,
+                                                                       @Param("userId") String userId);
 
     @Query(value = "select i from InjectExpectation i where i.exercise.id = :exerciseId " +
             "and i.type = 'CHALLENGE' and i.challenge.id = :challengeId and i.team.id in (:teamIds)")
@@ -41,7 +41,9 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
 
     @Query(value = "select i from InjectExpectation i where i.user.id = :userId and i.exercise.id = :exerciseId " +
             "and i.challenge.id = :challengeId and i.type = 'CHALLENGE' ")
-    List<InjectExpectation> findByUserAndExerciseAndChallenge(final String userId, final String exerciseId, final String challengeId);
+    List<InjectExpectation> findByUserAndExerciseAndChallenge(@Param("userId") String userId,
+                                                              @Param("exerciseId") String exerciseId,
+                                                              @Param("challengeId") String challengeId);
 
     @Query(value = "select i from InjectExpectation i where i.inject.id in (:injectIds) " +
             "and i.article.id in (:articlesIds) and i.team.id in (:teamIds) and i.type = 'ARTICLE'")

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -24,25 +24,30 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
 
     @Query(value = "select i from InjectExpectation i where i.exercise.id = :exerciseId and i.inject.id = :injectId")
     List<InjectExpectation> findAllForExerciseAndInject(
-        @Param("exerciseId") @NotBlank final String exerciseId,
-        @Param("injectId") @NotBlank final String injectId
+            @Param("exerciseId") @NotBlank final String exerciseId,
+            @Param("injectId") @NotBlank final String injectId
     );
 
     @Query(value = "select i from InjectExpectation i where i.exercise.id = :exerciseId " +
-            "and i.type = 'CHALLENGE' and i.team.id IN (:teamIds)")
+            "and i.type = 'CHALLENGE' and i.team.id in (:teamIds)")
     List<InjectExpectation> findChallengeExpectations(@Param("exerciseId") String exerciseId,
-                                                     @Param("teamIds") List<String> teamIds);
+                                                      @Param("teamIds") List<String> teamIds);
 
     @Query(value = "select i from InjectExpectation i where i.exercise.id = :exerciseId " +
-            "and i.type = 'CHALLENGE' and i.challenge.id = :challengeId and i.team.id IN (:teamIds) and i.user is null")
+            "and i.type = 'CHALLENGE' and i.challenge.id = :challengeId and i.team.id in (:teamIds) and i.user is null")
     List<InjectExpectation> findChallengeExpectations(@Param("exerciseId") String exerciseId,
-                                               @Param("teamIds") List<String> teamIds,
-                                               @Param("challengeId") String challengeId);
+                                                      @Param("teamIds") List<String> teamIds,
+                                                      @Param("challengeId") String challengeId);
 
-    @Query(value = "select i from InjectExpectation i where i.user = : userId and i.exercise.id = :exerciseId " +
+    @Query(value = "select i from InjectExpectation i where i.user = :userId and i.exercise.id = :exerciseId " +
             "and i.challenge.id = :challengeId and i.type = 'CHALLENGE' ")
-    InjectExpectation findByUserAndExerciseAndChallenge(final String userId, final String exerciseId, final String challengeId);
+    List<InjectExpectation> findByUserAndExerciseAndChallenge(final String userId, final String exerciseId, final String challengeId);
 
+    @Query(value = "select i from InjectExpectation i where i.inject.id in (:injectIds) " +
+            "and i.article.id = :channelId and i.team.id in (:teamIds) and i.type = 'ARTICLE' and i.user is null")
+    List<InjectExpectation> findChannelExpectations(@Param("injectIds") List<String> injectIds,
+                                                    @Param("teamIds") List<String> teamIds,
+                                                    @Param("channelId") String channelId);
     // -- PREVENTION --
 
     @Query(value = "select i from InjectExpectation i where i.type = 'PREVENTION' and i.inject.id = :injectId and i.asset.id = :assetId")
@@ -55,25 +60,67 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
 
     @Query(value = "select i from InjectExpectation i where i.inject.id = :injectId and i.team.id = :teamId and i.user.id = :playerId")
     List<InjectExpectation> findAllByInjectAndTeamAndPlayer(
-        @Param("injectId") @NotBlank final String injectId,
-        @Param("teamId") @NotBlank final String teamId,
-        @Param("playerId") @NotBlank final String playerId
+            @Param("injectId") @NotBlank final String injectId,
+            @Param("teamId") @NotBlank final String teamId,
+            @Param("playerId") @NotBlank final String playerId
     );
 
-    @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null")
+    @Query("select ie from InjectExpectation ie " +
+            "where ie.inject.id = :injectId " +
+            "and ie.team.id = :teamId " +
+            "and ie.name = :expectationName " +
+            "and ie.user is not null")
     List<InjectExpectation> findAllByInjectAndTeamAndExpectationNameAndUserIsNotNull(final String injectId, final String teamId, final String expectationName);
 
-    @Query("select AVG(ie.score) from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null and ie.score > 0")
+    @Query("select AVG(ie.score) from InjectExpectation ie " +
+            "where ie.inject.id = :injectId " +
+            "and ie.team.id = :teamId " +
+            "and ie.name = :expectationName " +
+            "and ie.user is not null " +
+            "and ie.score > 0")
     Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayer(final String injectId, final String teamId, final String expectationName);
 
-    @Query("select AVG(ie.score) from InjectExpectation ie where ie.exercise.id = :exerciseId and ie.challenge.id = :challengeId and ie.team.id = :teamId and ie.user is not null and ie.score > 0")
+    @Query("select AVG(ie.score) from InjectExpectation ie " +
+            "where ie.exercise.id = :exerciseId " +
+            "and ie.challenge.id = :challengeId " +
+            "and ie.team.id = :teamId " +
+            "and ie.user is not null " +
+            "and ie.score > 0 " +
+            "and ie.type = 'CHALLENGE' ")
     Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChallenge(final String exerciseId, final String challengeId, final String teamId);
 
-    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is not null")
+    @Query("select AVG(ie.score) from InjectExpectation ie " +
+            "where ie.inject.id in (:injectIds) " +
+            "and ie.article.id = :channelId " +
+            "and ie.team.id = :teamId " +
+            "and ie.user is not null " +
+            "and ie.score > 0 " +
+            "and ie.type = 'ARTICLE' ")
+    Double computeAverageScoreWhenValidationTypeIsAtLeastOnePlayerForChannel(final List<String> injectIds, final String channelId, final String teamId);
+
+    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie " +
+            "where ie.inject.id = :injectId " +
+            "and ie.team.id = :teamId " +
+            "and ie.name = :expectationName " +
+            "and ie.user is not null")
     Double computeAverageScoreWhenValidationTypeIsAllPlayers(final String injectId, final String teamId, final String expectationName);
 
-    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie where ie.exercise.id = :exerciseId and ie.challenge.id = :challengeId and ie.team.id = :teamId and ie.user is not null")
+    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie " +
+            "where ie.exercise.id = :exerciseId " +
+            "and ie.challenge.id = :challengeId " +
+            "and ie.team.id = :teamId " +
+            "and ie.user is not null " +
+            "and ie.type = 'CHALLENGE' ")
     Double computeAverageScoreWhenValidationTypeIsAllPlayersForChallenge(final String exerciseId, final String challengeId, final String teamId);
+
+    @Query("select AVG(COALESCE(ie.score, 0)) from InjectExpectation ie " +
+            "where ie.inject.id in (:injectIds) " +
+            "and ie.article.id = :channelId " +
+            "and ie.team.id = :teamId " +
+            "and ie.user is not null " +
+            "and ie.type = 'ARTICLE' ")
+    Double computeAverageScoreWhenValidationTypeIsAllPlayersForChannel(final List<String> injectIds, final String channelId, final String teamId);
+
 
     // -- RETRIEVE EXPECTATIONS FOR TEAM AND NOT FOR PLAYERS
     @Query("select ie from InjectExpectation ie where ie.inject.id = :injectId and ie.team.id = :teamId and ie.name = :expectationName and ie.user is null")
@@ -81,27 +128,27 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
 
     @Query(value = "select i from InjectExpectation i where i.inject.id = :injectId and i.team.id = :teamId and i.user is null")
     List<InjectExpectation> findAllByInjectAndTeam(
-        @Param("injectId") @NotBlank final String injectId,
-        @Param("teamId") @NotBlank final String teamId
+            @Param("injectId") @NotBlank final String injectId,
+            @Param("teamId") @NotBlank final String teamId
     );
 
     @Query(value = "select i from InjectExpectation i where i.inject.id = :injectId and i.asset.id = :assetId")
     List<InjectExpectation> findAllByInjectAndAsset(
-        @Param("injectId") @NotBlank final String injectId,
-        @Param("assetId") @NotBlank final String assetId
+            @Param("injectId") @NotBlank final String injectId,
+            @Param("assetId") @NotBlank final String assetId
     );
 
     @Query(value = "select i from InjectExpectation i where i.inject.id = :injectId and i.assetGroup.id = :assetGroupId")
     List<InjectExpectation> findAllByInjectAndAssetGroup(
-        @Param("injectId") @NotBlank final String injectId,
-        @Param("assetGroupId") @NotBlank final String assetGroupId
+            @Param("injectId") @NotBlank final String injectId,
+            @Param("assetGroupId") @NotBlank final String assetGroupId
     );
 
     @Query(value = "SELECT "
-        + "team_id, asset_id, asset_group_id, inject_expectation_type, "
-        + "inject_expectation_score, inject_expectation_expected_score, inject_expectation_id, exercise_id "
-        + "FROM injects_expectations i "
-        + "where i.inject_expectation_id IN :ids",
-        nativeQuery = true)
+            + "team_id, asset_id, asset_group_id, inject_expectation_type, "
+            + "inject_expectation_score, inject_expectation_expected_score, inject_expectation_id, exercise_id "
+            + "FROM injects_expectations i "
+            + "where i.inject_expectation_id IN :ids",
+            nativeQuery = true)
     List<RawInjectExpectation> rawByIds(@Param("ids") final List<String> ids);
 }

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -44,10 +44,10 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
     List<InjectExpectation> findByUserAndExerciseAndChallenge(final String userId, final String exerciseId, final String challengeId);
 
     @Query(value = "select i from InjectExpectation i where i.inject.id in (:injectIds) " +
-            "and i.article.id = :channelId and i.team.id in (:teamIds) and i.type = 'ARTICLE' and i.user is null")
+            "and i.article.id in (:articlesIds) and i.team.id in (:teamIds) and i.type = 'ARTICLE' and i.user is null")
     List<InjectExpectation> findChannelExpectations(@Param("injectIds") List<String> injectIds,
                                                     @Param("teamIds") List<String> teamIds,
-                                                    @Param("channelId") String channelId);
+                                                    @Param("articlesIds") List<String> articlesIds);
     // -- PREVENTION --
 
     @Query(value = "select i from InjectExpectation i where i.type = 'PREVENTION' and i.inject.id = :injectId and i.asset.id = :assetId")


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add option all target/ at least player for manual expe
* Create expectation for players
* Refact validation view
* Refact atomic overview to show manual exp by player
* Re adjust position of icons of expectation results

### Related issues

* https://github.com/OpenBAS-Platform/openbas/issues/184
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
