### PR TITLE
In atomic testing, update the manual set expectation, the security platform is not filled after full reload (and crashes if removed)

### DIFF
--- a/openbas-front/src/admin/components/simulations/simulation/validation/expectations/DetectionPreventionExpectationsValidationForm.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/validation/expectations/DetectionPreventionExpectationsValidationForm.tsx
@@ -34,10 +34,11 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface FormProps {
   expectation: InjectExpectationsStore;
   result?: InjectExpectationResult;
+  sourceIds?: string[];
   onUpdate?: () => void;
 }
 
-const DetectionPreventionExpectationsValidationForm: FunctionComponent<FormProps> = ({ expectation, result, onUpdate }) => {
+const DetectionPreventionExpectationsValidationForm: FunctionComponent<FormProps> = ({ expectation, result, sourceIds = [], onUpdate }) => {
   const classes = useStyles();
   const { t } = useFormatter();
   const dispatch = useAppDispatch();
@@ -69,10 +70,14 @@ const DetectionPreventionExpectationsValidationForm: FunctionComponent<FormProps
       security_platform: z.string().min(1, { message: t('Should not be empty') }),
     })),
     defaultValues: {
-      expectation_score: result?.score ?? expectation.inject_expectation_score ?? expectation.inject_expectation_expected_score ?? 0,
+      expectation_score: result?.score ?? expectation.inject_expectation_expected_score ?? 0,
       security_platform: result?.sourceId ?? '',
     },
   });
+
+  // Security Platform Options
+  const filterOptions = (n: SecurityPlatform) => (n.asset_external_reference === null && !sourceIds.includes(n.asset_id));
+
   return (
     <form id="expectationForm" onSubmit={handleSubmit(onSubmit)}>
       {result && (
@@ -96,8 +101,9 @@ const DetectionPreventionExpectationsValidationForm: FunctionComponent<FormProps
             fieldValue={value ?? ''}
             fieldOnChange={onChange}
             errors={errors}
+            filterOptions={filterOptions}
             style={{ marginTop: 20 }}
-            onlyManual={true}
+            editing={!!result}
           />
         )}
       />


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove security platform already set in expectation creation
* Disable edition of security platform in expectation edition

### Related issues

* https://github.com/OpenBAS-Platform/openbas/issues/1181
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
