### PR TITLE
[frontend/backend] In XLS mapper, having a way to map "All teams" as targets of injects

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractApi.java
@@ -39,6 +39,7 @@ public class InjectorContractApi extends RestBehavior {
     private final InjectorRepository injectorRepository;
 
     private final InjectorContractRepository injectorContractRepository;
+
     private final InjectorContractService injectorContractService;
 
     @GetMapping("/api/injector_contracts")

--- a/openbas-api/src/main/java/io/openbas/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectService.java
@@ -300,7 +300,7 @@ public class InjectService {
             Map<String, Pattern> mapPatternByInjectImport = importMapper
                 .getInjectImporters().stream().collect(
                     Collectors.toMap(InjectImporter::getId,
-                            injectImporter -> Pattern.compile(injectImporter.getImportTypeValue())
+                        injectImporter -> Pattern.compile(injectImporter.getImportTypeValue())
                     ));
 
             Map<String, Pattern> mapPatternByAllTeams = importMapper.getInjectImporters().stream()

--- a/openbas-api/src/main/java/io/openbas/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectService.java
@@ -287,7 +287,7 @@ public class InjectService {
         try {
             // We open the previously saved file
             String tmpdir = System.getProperty("java.io.tmpdir");
-            java.nio.file.Path file = Files.list(Path.of(tmpdir, pathSeparator, importId, pathSeparator)).findFirst().orElseThrow();
+            Path file = Files.list(Path.of(tmpdir, pathSeparator, importId, pathSeparator)).findFirst().orElseThrow();
 
             // We open the file and convert it to an apache POI object
             InputStream xlsFile = Files.newInputStream(file);
@@ -301,6 +301,16 @@ public class InjectService {
                 .getInjectImporters().stream().collect(
                     Collectors.toMap(InjectImporter::getId,
                             injectImporter -> Pattern.compile(injectImporter.getImportTypeValue())
+                    ));
+
+            Map<String, Pattern> mapPatternByAllTeams = importMapper.getInjectImporters().stream()
+                    .flatMap(injectImporter -> injectImporter.getRuleAttributes().stream())
+                    .filter(ruleAttribute -> Objects.equals(ruleAttribute.getName(), "teams"))
+                    .filter(ruleAttribute ->  !Strings.isBlank(ruleAttribute.getAdditionalConfig().get("allTeamsValue")))
+                    .collect(
+                            Collectors.toMap(ruleAttribute -> ruleAttribute.getAdditionalConfig().get("allTeamsValue"),
+                                    ruleAttribute -> Pattern.compile(ruleAttribute.getAdditionalConfig().get("allTeamsValue")),
+                                    (first, second) -> first
                     ));
 
             // We also get the list of teams into a map to be able to get them easily later on
@@ -321,7 +331,7 @@ public class InjectService {
 
             // For each rows of the selected sheet
             selectedSheet.rowIterator().forEachRemaining(row -> {
-                ImportRow rowSummary = importRow(row, importMapper, scenario, mapPatternByInjectImport, mapTeamByName,
+                ImportRow rowSummary = importRow(row, importMapper, scenario, mapPatternByInjectImport, mapTeamByName, mapPatternByAllTeams,
                         zoneOffset);
                 importTestSummary.getImportMessage().addAll(rowSummary.getImportMessages());
                 if(rowSummary.getInject() != null) {
@@ -366,7 +376,7 @@ public class InjectService {
 
     private ImportRow importRow(Row row, ImportMapper importMapper, Scenario scenario,
                                 Map<String, Pattern> mapPatternByInjectImport, Map<String, Team> mapTeamByName,
-                                ZoneOffset timezoneOffset) {
+                                Map<String, Pattern> mapPatternByAllTeams, ZoneOffset timezoneOffset) {
         ImportRow importTestSummary = new ImportRow();
         // The column that differenciate the importer is the same for all so we get it right now
         int colTypeIdx = CellReference.convertColStringToIndex(importMapper.getInjectTypeColumn());
@@ -574,10 +584,8 @@ public class InjectService {
         matchingInjectImporter.getRuleAttributes().forEach(ruleAttribute -> {
             importTestSummary.getImportMessages().addAll(
                     addFields(inject, ruleAttribute,
-                            row, mapTeamByName, expectation, importMapper));
+                            row, mapTeamByName, expectation, importMapper, mapPatternByAllTeams));
         });
-        // This is by default at false
-        inject.setAllTeams(false);
         // The user is the one doing the import
         inject.setUser(userRepository.findById(currentUser().getId()).orElseThrow());
         // No exercise yet
@@ -630,7 +638,8 @@ public class InjectService {
     private List<ImportMessage> addFields(Inject inject, RuleAttribute ruleAttribute,
                                           Row row, Map<String, Team> mapTeamByName,
                                           AtomicReference<InjectExpectation> expectation,
-                                          ImportMapper importMapper) {
+                                          ImportMapper importMapper,
+                                          Map<String, Pattern> mapPatternByAllTeams) {
         // If it's a reserved field, it's already taken care of
         if(importReservedField.contains(ruleAttribute.getName())) {
             return Collections.emptyList();
@@ -668,8 +677,8 @@ public class InjectService {
             case "team":
                 // If the rule type is on a team field, we split by "+" if there is a concatenation of columns
                 // and then joins the result, split again by "," and use the list of results to get the teams by their name
-
                 List<String> columnValues = new ArrayList<>();
+                String allTeamsValue = ruleAttribute.getAdditionalConfig().get("allTeamsValue");
                 if(ruleAttribute.getColumns() != null) {
                     columnValues = Arrays.stream(Arrays.stream(ruleAttribute.getColumns().split("\\+"))
                                     .map(column -> getValueAsString(row, column))
@@ -687,7 +696,14 @@ public class InjectService {
                 } else {
                     List<ImportMessage> importMessages = new ArrayList<>();
                     columnValues.forEach(teamName -> {
-                        if(mapTeamByName.containsKey(teamName)) {
+                        inject.setAllTeams(false);
+                        Matcher allTeamsMatcher = null;
+                        if(mapPatternByAllTeams.get(allTeamsValue) != null) {
+                            allTeamsMatcher = mapPatternByAllTeams.get(allTeamsValue).matcher(teamName);
+                        }
+                        if (allTeamsValue != null && allTeamsMatcher != null && allTeamsMatcher.find()) {
+                            inject.setAllTeams(true);
+                        } else if(mapTeamByName.containsKey(teamName)) {
                             inject.getTeams().add(mapTeamByName.get(teamName));
                         } else {
                             // The team does not exist, we create a new one

--- a/openbas-api/src/main/java/io/openbas/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectService.java
@@ -306,7 +306,7 @@ public class InjectService {
             Map<String, Pattern> mapPatternByAllTeams = importMapper.getInjectImporters().stream()
                     .flatMap(injectImporter -> injectImporter.getRuleAttributes().stream())
                     .filter(ruleAttribute -> Objects.equals(ruleAttribute.getName(), "teams"))
-                    .filter(ruleAttribute ->  !Strings.isBlank(ruleAttribute.getAdditionalConfig().get("allTeamsValue")))
+                    .filter(ruleAttribute ->  ruleAttribute.getAdditionalConfig() != null && !Strings.isBlank(ruleAttribute.getAdditionalConfig().get("allTeamsValue")))
                     .collect(
                             Collectors.toMap(ruleAttribute -> ruleAttribute.getAdditionalConfig().get("allTeamsValue"),
                                     ruleAttribute -> Pattern.compile(ruleAttribute.getAdditionalConfig().get("allTeamsValue")),
@@ -678,7 +678,7 @@ public class InjectService {
                 // If the rule type is on a team field, we split by "+" if there is a concatenation of columns
                 // and then joins the result, split again by "," and use the list of results to get the teams by their name
                 List<String> columnValues = new ArrayList<>();
-                String allTeamsValue = ruleAttribute.getAdditionalConfig().get("allTeamsValue");
+                String allTeamsValue = ruleAttribute.getAdditionalConfig() != null ? ruleAttribute.getAdditionalConfig().get("allTeamsValue") : null;
                 if(ruleAttribute.getColumns() != null) {
                     columnValues = Arrays.stream(Arrays.stream(ruleAttribute.getColumns().split("\\+"))
                                     .map(column -> getValueAsString(row, column))

--- a/openbas-api/src/main/resources/application.properties
+++ b/openbas-api/src/main/resources/application.properties
@@ -194,6 +194,9 @@ openbas.mail.imap.starttls.enable=false
 openbas.xtm.opencti.enable=false
 openbas.xtm.opencti.url=<opencti-url>
 openbas.xtm.opencti.token=<opencti-token>
+# XLS Import
+openbas.xls.import.mail.enable=true
+openbas.xls.import.sms.enable=true
 
 # Injector Caldera config
 injector.caldera.enable=true

--- a/openbas-api/src/test/resources/application.properties
+++ b/openbas-api/src/test/resources/application.properties
@@ -76,6 +76,10 @@ http.enable=false
 # Injector Caldera config
 injector.caldera.enable=false
 
+# XLS Import
+openbas.xls.import.mail.enable=true
+openbas.xls.import.sms.enable=true
+
 #############
 # COLLECTORS #
 #############

--- a/openbas-front/src/admin/components/settings/data_ingestion/xls_mapper/RulesContractContent.tsx
+++ b/openbas-front/src/admin/components/settings/data_ingestion/xls_mapper/RulesContractContent.tsx
@@ -233,6 +233,36 @@ const RulesContractContent: React.FC<Props> = ({
             )}
           />
           {rulesFields.map((ruleField, rulesIndex) => {
+            let cogIcon;
+            if (ruleField.rule_attribute_name === 'trigger_time') {
+              cogIcon = <Badge
+                color="secondary" variant="dot"
+                invisible={(!methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)
+                          || methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)?.length === 0)
+                      && (!methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_additional_config.timePattern`)
+                          || methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_additional_config`)?.timePattern?.length === 0)}
+                        >
+                <CogOutline />
+              </Badge>;
+            } else if (ruleField.rule_attribute_name === 'teams') {
+              cogIcon = <Badge
+                color="secondary" variant="dot"
+                invisible={(!methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)
+                          || methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)?.length === 0)
+                      && (!methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_additional_config.allTeamsValue`)
+                          || methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_additional_config`)?.allTeamsValue?.length === 0)}
+                        >
+                <CogOutline />
+              </Badge>;
+            } else {
+              cogIcon = <Badge
+                color="secondary" variant="dot"
+                invisible={!methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)
+                        || methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)?.length === 0}
+                        >
+                <CogOutline />
+              </Badge>;
+            }
             return (
               <div key={ruleField.id} style={{ marginTop: 20 }}>
                 <div className={classes.rulesArray}>
@@ -261,26 +291,7 @@ const RulesContractContent: React.FC<Props> = ({
                     color="primary"
                     onClick={() => handleDefaultValueOpen(rulesIndex)}
                   >
-                    {(ruleField.rule_attribute_name === 'trigger_time')
-                      ? (
-                        <Badge
-                          color="secondary" variant="dot"
-                          invisible={(!methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)
-                            || methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)?.length === 0)
-                            && (!methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_additional_config.timePattern`)
-                            || methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_additional_config`)?.timePattern?.length === 0)}
-                        >
-                          <CogOutline />
-                        </Badge>
-                      ) : (
-                        <Badge
-                          color="secondary" variant="dot"
-                          invisible={!methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)
-                              || methods.getValues(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${rulesIndex}.rule_attribute_default_value`)?.length === 0}
-                        >
-                          <CogOutline />
-                        </Badge>)
-                    }
+                    {cogIcon}
                   </IconButton>
                 </div>
                 {currentRuleIndex !== null
@@ -319,6 +330,27 @@ const RulesContractContent: React.FC<Props> = ({
                             />
                           </Tooltip>
                         </div>
+                      }
+                      {currentRuleIndex === rulesFields.findIndex((r) => r.rule_attribute_name === 'teams')
+                          && <div style={{ display: 'flex', alignItems: 'end', gap: '8px' }}>
+                            <TextField
+                              label={t('All teams value')}
+                              fullWidth
+                              style={{ marginTop: 10 }}
+                              inputProps={methods.register(`import_mapper_inject_importers.${index}.inject_importer_rule_attributes.${currentRuleIndex}.rule_attribute_additional_config.allTeamsValue`)}
+                            />
+                            <Tooltip
+                              title={t(
+                                'Value that signifies all teams are targeted. A regex can be used.',
+                              )}
+                            >
+                              <InformationOutline
+                                fontSize="medium"
+                                color="primary"
+                                style={{ cursor: 'default' }}
+                              />
+                            </Tooltip>
+                          </div>
                       }
                     </DialogContent>
                     <DialogActions>

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -1271,6 +1271,7 @@ const i18n = {
       // Inject test
       'Inject test has been sent, you can view test logs details on ': 'Le test de l\'inject a été envoyé, vous pouvez visualiser les logs de test sur  ',
       'its dedicated page.': 'sa page dédiée',
+      'Value that signifies that all teams are targeted. A regex can be used.': 'Valeur indiquant que l\'injecteur s\'applique à toutes les équipes. Il est possible d\'utiliser une expression régulière.',
     },
     zh: {
       'Email address': 'email地址',
@@ -2487,6 +2488,7 @@ const i18n = {
       // Platform Banner
       'IMAP service is not responding, your injectors may be impacted.': 'IMAP service is not responding, your injectors may be impacted.',
       'Executor Caldera is not responding, your exercises may be impacted.': 'Executor Caldera is not responding, your exercises may be impacted.',
+      'Value that signifies that all teams are targeted. A regex can be used.': 'Value that signifies that all teams are targeted. A regex can be used.',
     },
     en: {
       openbas_email: 'Email',
@@ -2594,6 +2596,7 @@ const i18n = {
       // Platform Banner
       'IMAP service is not responding, your injectors may be impacted.': 'IMAP service is not responding, your injectors may be impacted.',
       'Executor Caldera is not responding, your exercises may be impacted.': 'Executor Caldera is not responding, your exercises may be impacted.',
+      'Value that signifies that all teams are targeted. A regex can be used.': 'Value that signifies that all teams are targeted. A regex can be used.',
     },
   },
 };


### PR DESCRIPTION
In XLS mapper, having a way to map "All teams" as targets of injects

<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* In XLS mapper, having a way to map "All teams" as targets of injects
* Make sure we have the import available on startup using a failsafe

### Related issues

* #1248 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
