### PR TITLE
[frontend] Fix missing filter on dynamic asset group

### DIFF
--- a/openbas-front/src/admin/components/assets/asset_groups/DynamicAssetField.tsx
+++ b/openbas-front/src/admin/components/assets/asset_groups/DynamicAssetField.tsx
@@ -21,6 +21,14 @@ const DynamicAssetField: FunctionComponent<Props> = ({
 
   const [filterGroup, helpers] = useFiltersState(value ?? emptyFilterGroup, undefined, onChange);
 
+  const availableFilterNames = [
+    'endpoint_agent_version',
+    'endpoint_arch',
+    'endpoint_hostname',
+    'endpoint_ips',
+    'endpoint_platform',
+  ];
+
   return (
     <div style={{ marginTop: 20 }}>
       <div style={{ display: 'flex', alignItems: 'end', gap: 10 }}>
@@ -35,6 +43,7 @@ const DynamicAssetField: FunctionComponent<Props> = ({
       </div>
       <FilterField
         entityPrefix="endpoint"
+        availableFilterNames={availableFilterNames}
         filterGroup={filterGroup}
         helpers={helpers}
         style={{ marginTop: 20 }}


### PR DESCRIPTION
Asset group Bug - Dynamic asset filter empty, i see ‘no option’ in the dropdown when creating a new asset group
![image](https://github.com/user-attachments/assets/17fd3f9f-f8e5-4eda-8d5f-7ba2e24841e7)
