### PR TITLE
[backend] Fix inject status delete cascading

### DIFF
--- a/openbas-api/src/main/java/io/openbas/migration/V3_35__Modify_Injects_tests_statuses_status_inject_on_delete.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_35__Modify_Injects_tests_statuses_status_inject_on_delete.java
@@ -1,0 +1,36 @@
+package io.openbas.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+@Component
+public class V3_35__Modify_Injects_tests_statuses_status_inject_on_delete extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Connection connection = context.getConnection();
+    Statement select = connection.createStatement();
+    // Drop the old foreign key constraint
+    select.execute("""
+            ALTER TABLE injects_tests_statuses
+            DROP CONSTRAINT inject_test_status_inject_id_fkey;
+        """);
+
+    // Add the new foreign key constraint with ON DELETE CASCADE
+    select.execute("""
+            ALTER TABLE injects_tests_statuses
+            ADD CONSTRAINT inject_test_status_inject_id_fkey 
+            FOREIGN KEY (status_inject) REFERENCES injects(inject_id) ON DELETE CASCADE;
+        """);
+
+    // Optionally, you can reindex if necessary (usually not required just for FK changes)
+    select.execute("""
+            CREATE INDEX IF NOT EXISTS idx_inject_test_inject ON injects_tests_statuses(status_inject);
+        """);
+  }
+
+}


### PR DESCRIPTION
- When I remove a simulation, some time I have this

![image](https://github.com/user-attachments/assets/3f0159cb-d023-4cfa-9d11-480bfa6c4d0a)

```json
error
: 
"could not execute statement [ERROR: null value in column \"status_inject\" of relation \"injects_tests_statuses\" violates not-null constraint\n  Detail: Failing row contains (6c732625-161b-4f47-b065-4988c22bb961, SUCCESS, [{\"execution_time\":\"2024-09-13T13:53:25.610690185Z\",\"execution_d..., 2024-09-13 13:53:25.618166, null, 2024-09-13 13:53:25.618205, 0, 1, 0, 1, null, 2024-09-13 13:44:23.053403, 2024-09-13 13:53:26.36281).\n  Where: SQL statement \"UPDATE ONLY \"public\".\"injects_tests_statuses\" SET \"status_inject\" = NULL WHERE $1::pg_catalog.text OPERATOR(pg_catalog.=) \"status_inject\"::pg_catalog.text\"] [delete from exercises where exercise_id=?]"
message
: 
"Error applying constraint status_inject\" of relation \"injects_tests_statuses"
type
: 
"ConstraintViolationException"
```