### PR TITLE
[frontend] Fix Mitre Att&ck Coverage display on Firefox

### DIFF
--- a/openbas-front/src/admin/components/common/matrix/MitreMatrix.tsx
+++ b/openbas-front/src/admin/components/common/matrix/MitreMatrix.tsx
@@ -19,8 +19,6 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     gap: 20,
     overflowX: 'auto',
-    '--start-if-can-scroll': 'var(--can-scroll) start',
-    justifyContent: 'var(--start-if-can-scroll, center)',
     animation: 'detect-scroll linear',
     animationTimeline: 'scroll(self inline)',
   },

--- a/openbas-front/src/admin/components/common/matrix/MitreMatrixDummy.tsx
+++ b/openbas-front/src/admin/components/common/matrix/MitreMatrixDummy.tsx
@@ -19,8 +19,7 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     gap: 20,
     overflowX: 'auto',
-    '--start-if-can-scroll': 'var(--can-scroll) start',
-    justifyContent: 'var(--start-if-can-scroll, space-evenly)',
+    // test
     animation: 'detect-scroll linear',
     animationTimeline: 'scroll(self inline)',
   },


### PR DESCRIPTION
Close #1435 

### Proposed changes

- Remove experimental attributes since non compatible with Firefox

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality


Before (Firefox):
![Screenshot from 2024-09-19 16-51-11](https://github.com/user-attachments/assets/e5905831-6c4e-4c6c-97b2-e769ea3615de)

After (Firefox):
![Screenshot from 2024-09-19 16-51-41](https://github.com/user-attachments/assets/4b434f54-8b01-46cf-a296-02372a078892)
