### PR TITLE
[frontend] Keep commands lines shown if another element is updated in atomic testing page

### DIFF
--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/Index.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/Index.tsx
@@ -41,8 +41,10 @@ const Index = () => {
   const { injectId } = useParams() as { injectId: InjectResultDTO['inject_id'] };
   const [injectResultDto, setInjectResultDto] = useState<InjectResultDTO>();
 
-  const updateInjectResultDto = (newData: InjectResultDTO) => {
-    setInjectResultDto(newData);
+  const updateInjectResultDto = () => {
+    fetchInjectResultDto(injectId).then((result: { data: InjectResultDTO }) => {
+      setInjectResultDto(result.data);
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Proposed changes

* When we update an element of an atomic testing, the commands lines disappear. The update object is not the same object as the get object so we re-fetch again the object to fix the bug. This page will be improved in the future.
