### PR TITLE
[frontend] Added space to avoid banner goes over the drawer title

### DIFF
--- a/openbas-front/src/components/common/Drawer.tsx
+++ b/openbas-front/src/components/common/Drawer.tsx
@@ -3,6 +3,8 @@ import React, { CSSProperties, FunctionComponent } from 'react';
 import { Close } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import type { Theme } from '../Theme';
+import useAuth from '../../utils/hooks/useAuth';
+import { computeBannerSettings } from '../../public/components/systembanners/SystemBanners';
 
 const useStyles = makeStyles<Theme>((theme: Theme) => ({
   drawerPaperHalf: {
@@ -65,6 +67,9 @@ const Drawer: FunctionComponent<DrawerProps> = ({
   disableEnforceFocus = false,
   containerStyle = {},
 }) => {
+  const { settings } = useAuth();
+  const { bannerHeightNumber } = computeBannerSettings(settings);
+
   const classes = useStyles({ variant });
   let component;
   if (children) {
@@ -87,7 +92,7 @@ const Drawer: FunctionComponent<DrawerProps> = ({
         disableEnforceFocus,
       }}
     >
-      <div className={variant === 'full' ? classes.headerFull : classes.header}>
+      <div className={variant === 'full' ? classes.headerFull : classes.header} style={{ marginTop: bannerHeightNumber }}>
         <IconButton
           aria-label="Close"
           onClick={handleClose}


### PR DESCRIPTION
### Proposed changes

* Just add space logic in Drawer like we do on leftbar, topbar, ect
Before
![image](https://github.com/user-attachments/assets/c91dcb49-49cf-409c-b77f-c5c5c4e1773d)

After
![image](https://github.com/user-attachments/assets/00dc31c9-cb45-439b-8aa7-83f927fae1e9)
