### PR TITLE
[backend/frontend] Categorize payload by architecture

### DIFF
--- a/openbas-api/src/main/java/io/openbas/migration/V3_44__Add_column_executable_arch.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_44__Add_column_executable_arch.java
@@ -1,0 +1,20 @@
+package io.openbas.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+@Component
+public class V3_44__Add_column_executable_arch extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Connection connection = context.getConnection();
+    Statement statement = connection.createStatement();
+    statement.execute("ALTER TABLE payloads ADD executable_arch varchar(255);");
+    statement.execute("UPDATE payloads SET executable_arch = 'x86_64' WHERE payload_type ='Executable';");
+  }
+}

--- a/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/atomic_testing/AtomicTestingApi.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/atomic_testings")
+@RequestMapping("/api/atomic-testings")
 @PreAuthorize("isAdmin()")
 @RequiredArgsConstructor
 public class AtomicTestingApi extends RestBehavior {

--- a/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractService.java
@@ -122,7 +122,8 @@ public class InjectorContractService {
         injectorContractPayloadJoin.get("type").alias("payload_type"),
         payloadCollectorJoin.get("type").alias("collector_type"),
         injectorContractInjectorJoin.get("type").alias("injector_contract_injector_type"),
-        attackPatternIdsExpression.alias("injector_contract_attack_patterns")
+        attackPatternIdsExpression.alias("injector_contract_attack_patterns"),
+        injectorContractPayloadJoin.get("executableArch").alias("payload_executable_arch")
     ).distinct(true);
 
     // GROUP BY
@@ -146,7 +147,8 @@ public class InjectorContractService {
             tuple.get("payload_type", String.class),
             tuple.get("collector_type", String.class),
             tuple.get("injector_contract_injector_type", String.class),
-            tuple.get("injector_contract_attack_patterns", String[].class)
+            tuple.get("injector_contract_attack_patterns", String[].class),
+            tuple.get("payload_executable_arch", Endpoint.PLATFORM_ARCH.class)
         ))
         .toList();
   }

--- a/openbas-api/src/main/java/io/openbas/rest/injector_contract/output/InjectorContractOutput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/injector_contract/output/InjectorContractOutput.java
@@ -1,6 +1,7 @@
 package io.openbas.rest.injector_contract.output;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openbas.database.model.Endpoint;
 import io.openbas.database.model.Endpoint.PLATFORM_TYPE;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
@@ -33,6 +34,9 @@ public class InjectorContractOutput {
   @JsonProperty("injector_contract_attack_patterns")
   private List<String> attackPatterns;
 
+  @JsonProperty("injector_contract_arch")
+  private Endpoint.PLATFORM_ARCH arch;
+
   public InjectorContractOutput(
       String id,
       Map<String, String> labels,
@@ -41,7 +45,8 @@ public class InjectorContractOutput {
       String payloadType,
       String collectorType,
       String injectorType,
-      String[] attackPatterns) {
+      String[] attackPatterns,
+      Endpoint.PLATFORM_ARCH arch) {
     this.id = id;
     this.labels = labels;
     this.content = content;
@@ -50,5 +55,6 @@ public class InjectorContractOutput {
     this.injectorType = injectorType;
 
     this.attackPatterns = attackPatterns != null ? new ArrayList<>(Arrays.asList(attackPatterns)) : new ArrayList<>();
+    this.arch = arch;
   }
 }

--- a/openbas-api/src/main/java/io/openbas/rest/payload/PayloadApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/payload/PayloadApi.java
@@ -92,8 +92,8 @@ public class PayloadApi extends RestBehavior {
     @PreAuthorize("isPlanner()")
     @Transactional(rollbackOn = Exception.class)
     public Payload createPayload(@Valid @RequestBody PayloadCreateInput input) {
-        switch (input.getType()) {
-            case "Command":
+        switch (PayloadType.fromString(input.getType())) {
+            case PayloadType.COMMAND:
                 Command commandPayload = new Command();
                 commandPayload.setUpdateAttributes(input);
                 commandPayload.setAttackPatterns(fromIterable(attackPatternRepository.findAllById(input.getAttackPatternsIds())));
@@ -101,7 +101,7 @@ public class PayloadApi extends RestBehavior {
                 commandPayload = payloadRepository.save(commandPayload);
                 this.payloadService.updateInjectorContractsForPayload(commandPayload);
                 return commandPayload;
-            case "Executable":
+            case PayloadType.EXECUTABLE:
                 Executable executablePayload = new Executable();
                 PayloadCreateInput validatedInput = validateExecutableInput(input);
                 executablePayload.setUpdateAttributes(validatedInput);
@@ -111,7 +111,7 @@ public class PayloadApi extends RestBehavior {
                 executablePayload = payloadRepository.save(executablePayload);
                 this.payloadService.updateInjectorContractsForPayload(executablePayload);
                 return executablePayload;
-            case "FileDrop":
+            case PayloadType.FILE_DROP:
                 FileDrop fileDropPayload = new FileDrop();
                 fileDropPayload.setUpdateAttributes(input);
                 fileDropPayload.setAttackPatterns(fromIterable(attackPatternRepository.findAllById(input.getAttackPatternsIds())));
@@ -120,7 +120,7 @@ public class PayloadApi extends RestBehavior {
                 fileDropPayload = payloadRepository.save(fileDropPayload);
                 this.payloadService.updateInjectorContractsForPayload(fileDropPayload);
                 return fileDropPayload;
-            case "DnsResolution":
+            case PayloadType.DNS_RESOLUTION:
                 DnsResolution dnsResolutionPayload = new DnsResolution();
                 dnsResolutionPayload.setUpdateAttributes(input);
                 dnsResolutionPayload.setAttackPatterns(fromIterable(attackPatternRepository.findAllById(input.getAttackPatternsIds())));
@@ -128,7 +128,7 @@ public class PayloadApi extends RestBehavior {
                 dnsResolutionPayload = payloadRepository.save(dnsResolutionPayload);
                 this.payloadService.updateInjectorContractsForPayload(dnsResolutionPayload);
                 return dnsResolutionPayload;
-            case "NetworkTraffic":
+            case PayloadType.NETWORK_TRAFFIC:
                 NetworkTraffic networkTrafficPayload = new NetworkTraffic();
                 networkTrafficPayload.setUpdateAttributes(input);
                 networkTrafficPayload.setAttackPatterns(fromIterable(attackPatternRepository.findAllById(input.getAttackPatternsIds())));
@@ -160,34 +160,34 @@ public class PayloadApi extends RestBehavior {
         payload.setAttackPatterns(fromIterable(attackPatternRepository.findAllById(input.getAttackPatternsIds())));
         payload.setTags(iterableToSet(tagRepository.findAllById(input.getTagIds())));
         payload.setUpdatedAt(Instant.now());
-        switch (payload.getType()) {
-            case "Command":
+        switch (PayloadType.fromString(payload.getType())) {
+            case PayloadType.COMMAND:
                 Command payloadCommand = (Command) Hibernate.unproxy(payload);
                 payloadCommand.setUpdateAttributes(input);
                 payloadCommand = payloadRepository.save(payloadCommand);
                 this.payloadService.updateInjectorContractsForPayload(payloadCommand);
                 return payloadCommand;
-            case "Executable":
+            case PayloadType.EXECUTABLE:
                 Executable payloadExecutable = (Executable) Hibernate.unproxy(payload);
                 payloadExecutable.setUpdateAttributes(input);
                 payloadExecutable.setExecutableFile(documentRepository.findById(input.getExecutableFile()).orElseThrow());
                 payloadExecutable = payloadRepository.save(payloadExecutable);
                 this.payloadService.updateInjectorContractsForPayload(payloadExecutable);
                 return payloadExecutable;
-            case "FileDrop":
+            case PayloadType.FILE_DROP:
                 FileDrop payloadFileDrop = (FileDrop) Hibernate.unproxy(payload);
                 payloadFileDrop.setUpdateAttributes(input);
                 payloadFileDrop.setFileDropFile(documentRepository.findById(input.getFileDropFile()).orElseThrow());
                 payloadFileDrop = payloadRepository.save(payloadFileDrop);
                 this.payloadService.updateInjectorContractsForPayload(payloadFileDrop);
                 return payloadFileDrop;
-            case "DnsResolution":
+            case PayloadType.DNS_RESOLUTION:
                 DnsResolution payloadDnsResolution = (DnsResolution) Hibernate.unproxy(payload);
                 payloadDnsResolution.setUpdateAttributes(input);
                 payloadDnsResolution = payloadRepository.save(payloadDnsResolution);
                 this.payloadService.updateInjectorContractsForPayload(payloadDnsResolution);
                 return payloadDnsResolution;
-            case "NetworkTraffic":
+            case PayloadType.NETWORK_TRAFFIC:
                 NetworkTraffic payloadNetworkTraffic = (NetworkTraffic) Hibernate.unproxy(payload);
                 payloadNetworkTraffic.setUpdateAttributes(input);
                 payloadNetworkTraffic = payloadRepository.save(payloadNetworkTraffic);
@@ -218,34 +218,34 @@ public class PayloadApi extends RestBehavior {
             existingPayload.setAttackPatterns(fromIterable(attackPatternRepository.findAllByExternalIdInIgnoreCase(input.getAttackPatternsExternalIds())));
             existingPayload.setTags(iterableToSet(tagRepository.findAllById(input.getTagIds())));
             existingPayload.setUpdatedAt(Instant.now());
-            switch (existingPayload.getType()) {
-                case "Command":
+            switch (PayloadType.fromString(existingPayload.getType())) {
+                case PayloadType.COMMAND:
                     Command payloadCommand = (Command) Hibernate.unproxy(existingPayload);
                     payloadCommand.setUpdateAttributes(input);
                     payloadCommand = payloadRepository.save(payloadCommand);
                     this.payloadService.updateInjectorContractsForPayload(payloadCommand);
                     return payloadCommand;
-                case "Executable":
+                case PayloadType.EXECUTABLE:
                     Executable payloadExecutable = (Executable) Hibernate.unproxy(existingPayload);
                     payloadExecutable.setUpdateAttributes(input);
                     payloadExecutable.setExecutableFile(documentRepository.findById(input.getExecutableFile()).orElseThrow());
                     payloadExecutable = payloadRepository.save(payloadExecutable);
                     this.payloadService.updateInjectorContractsForPayload(payloadExecutable);
                     return payloadExecutable;
-                case "FileDrop":
+                case PayloadType.FILE_DROP:
                     FileDrop payloadFileDrop = (FileDrop) Hibernate.unproxy(existingPayload);
                     payloadFileDrop.setUpdateAttributes(input);
                     payloadFileDrop.setFileDropFile(documentRepository.findById(input.getFileDropFile()).orElseThrow());
                     payloadFileDrop = payloadRepository.save(payloadFileDrop);
                     this.payloadService.updateInjectorContractsForPayload(payloadFileDrop);
                     return payloadFileDrop;
-                case "DnsResolution":
+                case PayloadType.DNS_RESOLUTION:
                     DnsResolution payloadDnsResolution = (DnsResolution) Hibernate.unproxy(existingPayload);
                     payloadDnsResolution.setUpdateAttributes(input);
                     payloadDnsResolution = payloadRepository.save(payloadDnsResolution);
                     this.payloadService.updateInjectorContractsForPayload(payloadDnsResolution);
                     return payloadDnsResolution;
-                case "NetworkTraffic":
+                case PayloadType.NETWORK_TRAFFIC:
                     NetworkTraffic payloadNetworkTraffic = (NetworkTraffic) Hibernate.unproxy(existingPayload);
                     payloadNetworkTraffic.setUpdateAttributes(input);
                     payloadNetworkTraffic = payloadRepository.save(payloadNetworkTraffic);
@@ -255,8 +255,8 @@ public class PayloadApi extends RestBehavior {
                     throw new UnsupportedOperationException("Payload type " + existingPayload.getType() + " is not supported");
             }
         } else {
-            switch (input.getType()) {
-                case "Command":
+            switch (PayloadType.fromString(input.getType())) {
+                case PayloadType.COMMAND:
                     Command commandPayload = new Command();
                     commandPayload.setUpdateAttributes(input);
                     if( input.getCollector() != null ) {
@@ -267,7 +267,7 @@ public class PayloadApi extends RestBehavior {
                     commandPayload = payloadRepository.save(commandPayload);
                     this.payloadService.updateInjectorContractsForPayload(commandPayload);
                     return commandPayload;
-                case "Executable":
+                case PayloadType.EXECUTABLE:
                     Executable executablePayload = new Executable();
                     executablePayload.setUpdateAttributes(input);
                     if( input.getCollector() != null ) {
@@ -279,7 +279,7 @@ public class PayloadApi extends RestBehavior {
                     executablePayload = payloadRepository.save(executablePayload);
                     this.payloadService.updateInjectorContractsForPayload(executablePayload);
                     return executablePayload;
-                case "FileDrop":
+                case PayloadType.FILE_DROP:
                     FileDrop fileDropPayload = new FileDrop();
                     fileDropPayload.setUpdateAttributes(input);
                     if( input.getCollector() != null ) {
@@ -291,7 +291,7 @@ public class PayloadApi extends RestBehavior {
                     fileDropPayload = payloadRepository.save(fileDropPayload);
                     this.payloadService.updateInjectorContractsForPayload(fileDropPayload);
                     return fileDropPayload;
-                case "DnsResolution":
+                case PayloadType.DNS_RESOLUTION:
                     DnsResolution dnsResolutionPayload = new DnsResolution();
                     dnsResolutionPayload.setUpdateAttributes(input);
                     if( input.getCollector() != null ) {
@@ -302,7 +302,7 @@ public class PayloadApi extends RestBehavior {
                     dnsResolutionPayload = payloadRepository.save(dnsResolutionPayload);
                     this.payloadService.updateInjectorContractsForPayload(dnsResolutionPayload);
                     return dnsResolutionPayload;
-                case "NetworkTraffic":
+                case PayloadType.NETWORK_TRAFFIC:
                     NetworkTraffic networkTrafficPayload = new NetworkTraffic();
                     networkTrafficPayload.setUpdateAttributes(input);
                     if( input.getCollector() != null ) {

--- a/openbas-api/src/main/java/io/openbas/rest/payload/form/PayloadCreateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/payload/form/PayloadCreateInput.java
@@ -1,6 +1,7 @@
 package io.openbas.rest.payload.form;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openbas.database.model.Endpoint;
 import io.openbas.database.model.Endpoint.PLATFORM_TYPE;
 import io.openbas.database.model.Payload.PAYLOAD_SOURCE;
 import io.openbas.database.model.Payload.PAYLOAD_STATUS;
@@ -49,6 +50,9 @@ public class PayloadCreateInput {
 
   @JsonProperty("command_content")
   private String content;
+
+  @JsonProperty("executable_arch")
+  private Endpoint.PLATFORM_ARCH executableArch;
 
   @JsonProperty("executable_file")
   private String executableFile;

--- a/openbas-api/src/main/java/io/openbas/rest/payload/form/PayloadUpdateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/payload/form/PayloadUpdateInput.java
@@ -1,6 +1,7 @@
 package io.openbas.rest.payload.form;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openbas.database.model.Endpoint;
 import io.openbas.database.model.Endpoint.PLATFORM_TYPE;
 import io.openbas.database.model.PayloadArgument;
 import io.openbas.database.model.PayloadPrerequisite;
@@ -31,6 +32,9 @@ public class PayloadUpdateInput {
 
     @JsonProperty("command_content")
     private String content;
+
+    @JsonProperty("executable_arch")
+    private Endpoint.PLATFORM_ARCH executableArch;
 
     @JsonProperty("executable_file")
     private String executableFile;

--- a/openbas-api/src/main/java/io/openbas/schema/SchemaApi.java
+++ b/openbas-api/src/main/java/io/openbas/schema/SchemaApi.java
@@ -23,14 +23,14 @@ public class SchemaApi extends RestBehavior {
       @RequestBody @Valid @NotNull List<String> filterNames) throws ClassNotFoundException {
     String completeClassName = "io.openbas.database.model." + className;
     if (filterableOnly) {
-      return SchemaUtils.schema(Class.forName(completeClassName))
+      return SchemaUtils.schemaWithSubtypes(Class.forName(completeClassName))
           .stream()
           .filter(PropertySchema::isFilterable)
           .filter(p -> filterNames.isEmpty() || filterNames.contains(p.getJsonName()))
           .map(PropertySchemaDTO::new)
           .toList();
     }
-    return SchemaUtils.schema(Class.forName(completeClassName))
+    return SchemaUtils.schemaWithSubtypes(Class.forName(completeClassName))
         .stream()
         .filter(p -> filterNames.isEmpty() || filterNames.contains(p.getJsonName()))
         .map(PropertySchemaDTO::new)

--- a/openbas-api/src/test/java/io/openbas/helper/InjectHelperTest.java
+++ b/openbas-api/src/test/java/io/openbas/helper/InjectHelperTest.java
@@ -49,7 +49,7 @@ public class InjectHelperTest {
     void injectsToRunTest() {
         // -- PREPARE --
         Exercise exercise = new Exercise();
-        exercise.setName("Exercice name");
+        exercise.setName("Exercise name");
         exercise.setStart(Instant.now());
         exercise.setFrom("test@test.com");
         exercise.setReplyTos(List.of("test@test.com"));

--- a/openbas-api/src/test/java/io/openbas/injects/InjectCrudTest.java
+++ b/openbas-api/src/test/java/io/openbas/injects/InjectCrudTest.java
@@ -32,7 +32,7 @@ class InjectCrudTest {
   void createInjectSuccess() {
     // -- PREPARE --
     Exercise exercise = new Exercise();
-    exercise.setName("Exercice name");
+    exercise.setName("Exercise name");
     exercise.setFrom("test@test.com");
     exercise.setReplyTos(List.of("test@test.com"));
     Exercise exerciseCreated = this.exerciseRepository.save(exercise);

--- a/openbas-api/src/test/java/io/openbas/rest/AtomicTestingApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/AtomicTestingApiTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AtomicTestingApiTest extends IntegrationTest {
 
-    public static final String ATOMIC_TESTINGS_URI = "/api/atomic_testings";
+    public static final String ATOMIC_TESTINGS_URI = "/api/atomic-testings";
 
     static Inject INJECT_WITH_PAYLOAD;
     static Inject INJECT_WITHOUT_PAYLOAD;

--- a/openbas-api/src/test/java/io/openbas/rest/PayloadApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/PayloadApiTest.java
@@ -1,11 +1,14 @@
 package io.openbas.rest;
 
+import com.jayway.jsonpath.JsonPath;
 import io.openbas.IntegrationTest;
 import io.openbas.database.model.Document;
 import io.openbas.database.model.Endpoint;
 import io.openbas.database.model.Payload;
 import io.openbas.database.repository.DocumentRepository;
+import io.openbas.database.repository.PayloadRepository;
 import io.openbas.rest.payload.form.PayloadCreateInput;
+import io.openbas.rest.payload.form.PayloadUpdateInput;
 import io.openbas.utils.mockUser.WithMockAdminUser;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +21,7 @@ import java.util.List;
 import static io.openbas.utils.JsonUtils.asJsonString;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -31,6 +35,8 @@ public class PayloadApiTest extends IntegrationTest {
     private MockMvc mvc;
     @Autowired
     private DocumentRepository documentRepository;
+    @Autowired
+    private PayloadRepository payloadRepository;
 
     @BeforeAll
     void beforeAll() {
@@ -43,27 +49,24 @@ public class PayloadApiTest extends IntegrationTest {
     @AfterAll
     void afterAll() {
         this.documentRepository.deleteAll(List.of(EXECUTABLE_FILE));
+        this.payloadRepository.deleteAll();
     }
 
     @Test
     @DisplayName("Create Executable Payload")
     @WithMockAdminUser
     void createExecutablePayload() throws Exception {
-        PayloadCreateInput input = new PayloadCreateInput();
-        input.setType("Executable");
-        input.setName("My Executable Payload");
-        input.setSource(Payload.PAYLOAD_SOURCE.MANUAL);
-        input.setStatus(Payload.PAYLOAD_STATUS.VERIFIED);
-        input.setPlatforms(new Endpoint.PLATFORM_TYPE[]{Endpoint.PLATFORM_TYPE.Linux});
-        input.setAttackPatternsIds(Collections.emptyList());
-        input.setTagIds(Collections.emptyList());
-        input.setExecutableArch(Endpoint.PLATFORM_ARCH.x86_64);
-        input.setExecutableFile(EXECUTABLE_FILE.getId());
+        PayloadCreateInput input = getExecutablePayloadCreateInput();
 
         mvc.perform(post(PAYLOAD_URI)
             .contentType(MediaType.APPLICATION_JSON)
             .content(asJsonString(input)))
             .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.payload_name").value("My Executable Payload"))
+            .andExpect(jsonPath("$.payload_description").value("Executable description"))
+            .andExpect(jsonPath("$.payload_source").value("MANUAL"))
+            .andExpect(jsonPath("$.payload_status").value("VERIFIED"))
+            .andExpect(jsonPath("$.payload_platforms.[0]").value("Linux"))
             .andExpect(jsonPath("$.executable_arch").value("x86_64"));
     }
 
@@ -71,19 +74,89 @@ public class PayloadApiTest extends IntegrationTest {
     @DisplayName("Creating an Executable Payload without Arch should fail")
     @WithMockAdminUser
     void createExecutablePayloadWithoutArch() throws Exception {
+        PayloadCreateInput input = getExecutablePayloadCreateInput();
+        input.setExecutableArch(null);
+
+        mvc.perform(post(PAYLOAD_URI)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(asJsonString(input)))
+            .andExpect(status().isBadRequest());
+    }
+
+
+    @Test
+    @DisplayName("Update Executable Payload")
+    @WithMockAdminUser
+    void updateExecutablePayload() throws Exception {
+        PayloadCreateInput createInput = getExecutablePayloadCreateInput();
+
+        String response = mvc.perform(post(PAYLOAD_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(createInput)))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.payload_name").value("My Executable Payload"))
+            .andExpect(jsonPath("$.payload_platforms.[0]").value("Linux"))
+            .andExpect(jsonPath("$.executable_arch").value("x86_64"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        var payloadId = JsonPath.read(response, "$.payload_id");
+
+        PayloadUpdateInput updateInput = new PayloadUpdateInput();
+        updateInput.setName("My Updated Executable Payload");
+        updateInput.setPlatforms(new Endpoint.PLATFORM_TYPE[]{Endpoint.PLATFORM_TYPE.MacOS});
+        updateInput.setExecutableArch(Endpoint.PLATFORM_ARCH.arm64);
+        updateInput.setExecutableFile(EXECUTABLE_FILE.getId());
+
+        mvc.perform(put(PAYLOAD_URI + "/" + payloadId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(updateInput)))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.payload_name").value("My Updated Executable Payload"))
+            .andExpect(jsonPath("$.payload_platforms.[0]").value("MacOS"))
+            .andExpect(jsonPath("$.executable_arch").value("arm64"));
+    }
+
+    @Test
+    @DisplayName("Updating an Executable Payload without arch should fail")
+    @WithMockAdminUser
+    void updateExecutablePayloadWithoutArch() throws Exception {
+        PayloadCreateInput createInput = getExecutablePayloadCreateInput();
+
+        String response = mvc.perform(post(PAYLOAD_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(createInput)))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        var payloadId = JsonPath.read(response, "$.payload_id");
+
+        PayloadUpdateInput updateInput = new PayloadUpdateInput();
+        updateInput.setName("My Updated Executable Payload");
+        updateInput.setPlatforms(new Endpoint.PLATFORM_TYPE[]{Endpoint.PLATFORM_TYPE.MacOS});
+        updateInput.setExecutableFile(EXECUTABLE_FILE.getId());
+
+        mvc.perform(put(PAYLOAD_URI + "/" + payloadId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(updateInput)))
+            .andExpect(status().isBadRequest());
+    }
+
+    private PayloadCreateInput getExecutablePayloadCreateInput() {
         PayloadCreateInput input = new PayloadCreateInput();
         input.setType("Executable");
         input.setName("My Executable Payload");
+        input.setDescription("Executable description");
         input.setSource(Payload.PAYLOAD_SOURCE.MANUAL);
         input.setStatus(Payload.PAYLOAD_STATUS.VERIFIED);
         input.setPlatforms(new Endpoint.PLATFORM_TYPE[]{Endpoint.PLATFORM_TYPE.Linux});
         input.setAttackPatternsIds(Collections.emptyList());
         input.setTagIds(Collections.emptyList());
         input.setExecutableFile(EXECUTABLE_FILE.getId());
-
-        mvc.perform(post(PAYLOAD_URI)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(asJsonString(input)))
-            .andExpect(status().isBadRequest());
+        input.setExecutableArch(Endpoint.PLATFORM_ARCH.x86_64);
+        return input;
     }
 }

--- a/openbas-api/src/test/java/io/openbas/rest/PayloadApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/PayloadApiTest.java
@@ -1,0 +1,68 @@
+package io.openbas.rest;
+
+import io.openbas.IntegrationTest;
+import io.openbas.database.model.Document;
+import io.openbas.database.model.Endpoint;
+import io.openbas.database.model.Payload;
+import io.openbas.database.repository.DocumentRepository;
+import io.openbas.rest.payload.form.PayloadCreateInput;
+import io.openbas.utils.mockUser.WithMockAdminUser;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static io.openbas.utils.JsonUtils.asJsonString;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestInstance(PER_CLASS)
+public class PayloadApiTest extends IntegrationTest {
+
+    private static final String PAYLOAD_URI = "/api/payloads";
+    private static Document EXECUTABLE_FILE;
+
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private DocumentRepository documentRepository;
+
+    @BeforeAll
+    void beforeAll() {
+        Document executableFile = new Document();
+        executableFile.setName("Executable file");
+        executableFile.setType("text/x-sh");
+        EXECUTABLE_FILE = documentRepository.save(executableFile);
+    }
+
+    @AfterAll
+    void afterAll() {
+        this.documentRepository.deleteAll(List.of(EXECUTABLE_FILE));
+    }
+    @Test
+    @DisplayName("Create Executable Payload")
+    @WithMockAdminUser
+    void createExecutablePayload() throws Exception {
+        PayloadCreateInput input = new PayloadCreateInput();
+        input.setType("Executable");
+        input.setName("My Executable Payload");
+        input.setSource(Payload.PAYLOAD_SOURCE.MANUAL);
+        input.setStatus(Payload.PAYLOAD_STATUS.VERIFIED);
+        input.setPlatforms(new Endpoint.PLATFORM_TYPE[]{Endpoint.PLATFORM_TYPE.Linux});
+        input.setAttackPatternsIds(Collections.emptyList());
+        input.setTagIds(Collections.emptyList());
+        input.setExecutableArch(Endpoint.PLATFORM_ARCH.x86_64);
+        input.setExecutableFile(EXECUTABLE_FILE.getId());
+
+        mvc.perform(post(PAYLOAD_URI)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(asJsonString(input)))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.executable_arch").value("x86_64"));
+    }
+}

--- a/openbas-api/src/test/java/io/openbas/rest/PayloadApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/PayloadApiTest.java
@@ -44,6 +44,7 @@ public class PayloadApiTest extends IntegrationTest {
     void afterAll() {
         this.documentRepository.deleteAll(List.of(EXECUTABLE_FILE));
     }
+
     @Test
     @DisplayName("Create Executable Payload")
     @WithMockAdminUser
@@ -64,5 +65,25 @@ public class PayloadApiTest extends IntegrationTest {
             .content(asJsonString(input)))
             .andExpect(status().is2xxSuccessful())
             .andExpect(jsonPath("$.executable_arch").value("x86_64"));
+    }
+
+    @Test
+    @DisplayName("Creating an Executable Payload without Arch should fail")
+    @WithMockAdminUser
+    void createExecutablePayloadWithoutArch() throws Exception {
+        PayloadCreateInput input = new PayloadCreateInput();
+        input.setType("Executable");
+        input.setName("My Executable Payload");
+        input.setSource(Payload.PAYLOAD_SOURCE.MANUAL);
+        input.setStatus(Payload.PAYLOAD_STATUS.VERIFIED);
+        input.setPlatforms(new Endpoint.PLATFORM_TYPE[]{Endpoint.PLATFORM_TYPE.Linux});
+        input.setAttackPatternsIds(Collections.emptyList());
+        input.setTagIds(Collections.emptyList());
+        input.setExecutableFile(EXECUTABLE_FILE.getId());
+
+        mvc.perform(post(PAYLOAD_URI)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(asJsonString(input)))
+            .andExpect(status().isBadRequest());
     }
 }

--- a/openbas-api/src/test/java/io/openbas/service/ExerciseExpectationServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/service/ExerciseExpectationServiceTest.java
@@ -7,10 +7,7 @@ import io.openbas.database.model.Team;
 import io.openbas.database.repository.*;
 import io.openbas.rest.exercise.form.ExpectationUpdateInput;
 import io.openbas.utils.fixtures.InjectExpectationFixture;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -57,6 +54,11 @@ public class ExerciseExpectationServiceTest {
     getInjectExpectation(injectCreated, teamCreated, exerciseCreated);
   }
 
+  @AfterAll
+  void afterAll() {
+    this.exerciseRepository.deleteById(EXERCISE_ID);
+  }
+
   @DisplayName("Retrieve inject expectations")
   @Test
   void retrieveInjectExpectations() {
@@ -86,7 +88,7 @@ public class ExerciseExpectationServiceTest {
 
   protected Exercise getExercise() {
     Exercise exercise = new Exercise();
-    exercise.setName("Exercice name");
+    exercise.setName("Exercise name");
     exercise.setStatus(SCHEDULED);
     exercise.setFrom("test@test.com");
     exercise.setReplyTos(List.of("test@test.com"));

--- a/openbas-api/src/test/java/io/openbas/service/InjectTestStatusServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/service/InjectTestStatusServiceTest.java
@@ -59,7 +59,7 @@ public class InjectTestStatusServiceTest {
   @BeforeAll
   void beforeAll() {
     Exercise exercise = new Exercise();
-    exercise.setName("Exercice name");
+    exercise.setName("Exercise name");
     exercise.setFrom("test@test.com");
     exercise.setReplyTos(List.of("test@test.com"));
     EXERCISE = this.exerciseRepository.save(exercise);

--- a/openbas-api/src/test/java/io/openbas/service/VariableServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/service/VariableServiceTest.java
@@ -12,8 +12,10 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @SpringBootTest
+@TestInstance(PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class VariableServiceTest {
 
@@ -23,24 +25,32 @@ public class VariableServiceTest {
   @Autowired
   private ExerciseRepository exerciseRepository;
 
-  static String EXERCISE_ID;
+  static Exercise EXERCISE;
   static String VARIABLE_ID;
+
+  @BeforeAll
+  void beforeAll() {
+    Exercise exercise = new Exercise();
+    exercise.setName("Exercise name");
+    exercise.setFrom("test@test.com");
+    exercise.setReplyTos(List.of("test@test.com"));
+    EXERCISE = this.exerciseRepository.save(exercise);
+  }
+
+  @AfterAll
+  void afterAll() {
+    this.exerciseRepository.deleteById(EXERCISE.getId());
+  }
 
   @DisplayName("Create variable")
   @Test
   @Order(1)
   void createVariableTest() {
     // -- PREPARE --
-    Exercise exercise = new Exercise();
-    exercise.setName("Exercice name");
-    exercise.setFrom("test@test.com");
-    exercise.setReplyTos(List.of("test@test.com"));
-    Exercise exerciseCreated = this.exerciseRepository.save(exercise);
-    EXERCISE_ID = exerciseCreated.getId();
     Variable variable = new Variable();
     String variableKey = "key";
     variable.setKey(variableKey);
-    variable.setExercise(exerciseCreated);
+    variable.setExercise(EXERCISE);
 
     // -- EXECUTE --
     Variable variableCreated = this.variableService.createVariable(variable);
@@ -60,7 +70,7 @@ public class VariableServiceTest {
     Variable variable = this.variableService.variable(VARIABLE_ID);
     assertNotNull(variable);
 
-    List<Variable> variables = this.variableService.variablesFromExercise(EXERCISE_ID);
+    List<Variable> variables = this.variableService.variablesFromExercise(EXERCISE.getId());
     assertNotNull(variable);
     assertEquals(VARIABLE_ID, variables.get(0).getId());
   }

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/PayloadFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/PayloadFixture.java
@@ -32,4 +32,14 @@ public class PayloadFixture {
     return dnsResolution;
   }
 
+  public static Payload createDefaultExecutable() {
+    Executable executable = new Executable("executable-id", Executable.EXECUTABLE_TYPE, "executable payload");
+    executable.setPlatforms(new Endpoint.PLATFORM_TYPE[]{Endpoint.PLATFORM_TYPE.MacOS});
+    executable.setExecutableArch(Endpoint.PLATFORM_ARCH.arm64);
+    executable.setSource(MANUAL);
+    executable.setStatus(VERIFIED);
+    executable.setAttackPatterns(Collections.emptyList());
+    return executable;
+  }
+
 }

--- a/openbas-framework/src/main/java/io/openbas/integrations/PayloadService.java
+++ b/openbas-framework/src/main/java/io/openbas/integrations/PayloadService.java
@@ -144,33 +144,33 @@ public class PayloadService {
   public Payload duplicate(@NotBlank final String payloadId) {
     Payload origin = this.payloadRepository.findById(payloadId).orElseThrow();
     Payload duplicate;
-    switch (origin.getType()) {
-      case "Command":
+    switch (PayloadType.fromString(origin.getType())) {
+      case PayloadType.COMMAND:
         Command originCommand = (Command) Hibernate.unproxy(origin);
         Command duplicateCommand = new Command();
         duplicateCommonProperties(originCommand, duplicateCommand);
         duplicate = payloadRepository.save(duplicateCommand);
         break;
-      case "Executable":
+      case PayloadType.EXECUTABLE:
         Executable originExecutable = (Executable) Hibernate.unproxy(origin);
         Executable duplicateExecutable = new Executable();
         duplicateCommonProperties(originExecutable, duplicateExecutable);
         duplicateExecutable.setExecutableFile(originExecutable.getExecutableFile());
         duplicate = payloadRepository.save(duplicateExecutable);
         break;
-      case "FileDrop":
+      case PayloadType.FILE_DROP:
         FileDrop originFileDrop = (FileDrop) Hibernate.unproxy(origin);
         FileDrop duplicateFileDrop = new FileDrop();
         duplicateCommonProperties(originFileDrop, duplicateFileDrop);
         duplicate = payloadRepository.save(duplicateFileDrop);
         break;
-      case "DnsResolution":
+      case PayloadType.DNS_RESOLUTION:
         DnsResolution originDnsResolution = (DnsResolution) Hibernate.unproxy(origin);
         DnsResolution duplicateDnsResolution = new DnsResolution();
         duplicateCommonProperties(originDnsResolution, duplicateDnsResolution);
         duplicate = payloadRepository.save(duplicateDnsResolution);
         break;
-      case "NetworkTraffic":
+      case PayloadType.NETWORK_TRAFFIC:
         NetworkTraffic originNetworkTraffic = (NetworkTraffic) Hibernate.unproxy(origin);
         NetworkTraffic duplicateNetworkTraffic = new NetworkTraffic();
         duplicateCommonProperties(originNetworkTraffic, duplicateNetworkTraffic);

--- a/openbas-framework/src/main/java/io/openbas/utils/FilterUtilsJpa.java
+++ b/openbas-framework/src/main/java/io/openbas/utils/FilterUtilsJpa.java
@@ -89,7 +89,12 @@ public class FilterUtilsJpa {
     String filterKey = filter.getKey();
 
     return (root, query, cb) -> {
-      List<PropertySchema> propertySchemas = SchemaUtils.schema(root.getJavaType());
+      List<PropertySchema> propertySchemas;
+      try {
+          propertySchemas = SchemaUtils.schemaWithSubtypes(root.getJavaType());
+      } catch (ClassNotFoundException e) {
+          throw new RuntimeException(e);
+      }
       List<PropertySchema> filterableProperties = getFilterableProperties(propertySchemas);
       PropertySchema filterableProperty = retrieveProperty(filterableProperties, filterKey);
       Expression<U> paths = toPath(filterableProperty, root, joinMap);

--- a/openbas-framework/src/main/java/io/openbas/utils/SubclassScanner.java
+++ b/openbas-framework/src/main/java/io/openbas/utils/SubclassScanner.java
@@ -1,0 +1,23 @@
+package io.openbas.utils;
+
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SubclassScanner {
+    public static Set<Class<?>> getSubclasses(String basePackage, Class<?> clazz) {
+        ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false);
+        provider.addIncludeFilter(new AssignableTypeFilter(clazz));
+        return provider.findCandidateComponents(basePackage).stream()
+            .map(beanDefinition -> {
+                try {
+                    return Class.forName(beanDefinition.getBeanClassName());
+                } catch (ClassNotFoundException e) {
+                    return null;
+                }
+            })
+            .collect(Collectors.toSet());
+    }
+}

--- a/openbas-front/src/actions/atomic_testings/atomic-testing-actions.ts
+++ b/openbas-front/src/actions/atomic_testings/atomic-testing-actions.ts
@@ -1,7 +1,7 @@
 import { simpleCall, simpleDelCall, simplePostCall, simplePutCall } from '../../utils/Action';
 import type { AtomicTestingInput, SearchPaginationInput } from '../../utils/api-types';
 
-const ATOMIC_TESTING_URI = '/api/atomic_testings';
+const ATOMIC_TESTING_URI = '/api/atomic-testings';
 
 export const searchAtomicTestings = (searchPaginationInput: SearchPaginationInput) => {
   const data = searchPaginationInput;

--- a/openbas-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
+++ b/openbas-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
@@ -25,6 +25,8 @@ interface Props {
   onSubmit: (endpointIds: string[]) => void;
   title: string;
   platforms?: string[];
+  payloadType?: string;
+  payloadArch?: string;
 }
 
 const EndpointsDialogAdding: FunctionComponent<Props> = ({
@@ -34,6 +36,8 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
   onSubmit,
   title,
   platforms,
+  payloadType,
+  payloadArch,
 }) => {
   // Standard hooks
   const dispatch = useAppDispatch();
@@ -90,6 +94,11 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
         width: 20,
       },
       {
+        field: 'endpoint_arch',
+        value: (endpoint: EndpointStore) => endpoint.endpoint_arch,
+        width: 20,
+      },
+      {
         field: 'asset_tags',
         value: (endpoint: EndpointStore) => <ItemTags variant="reduced-view" tags={endpoint.asset_tags} />,
         width: 30,
@@ -103,6 +112,7 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
   const availableFilterNames = [
     'asset_tags',
     'endpoint_platform',
+    'endpoint_arch',
   ];
   const quickFilter: FilterGroup = {
     mode: 'and',
@@ -110,6 +120,9 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
       buildFilter('endpoint_platform', platforms ?? [], 'contains'),
     ],
   };
+  if (quickFilter.filters && payloadType === 'Executable' && payloadArch) {
+    quickFilter.filters?.push(buildFilter('endpoint_arch', [payloadArch], 'contains'));
+  }
   const { queryableHelpers, searchPaginationInput } = useQueryable(buildSearchPagination({
     filterGroup: quickFilter,
   }));

--- a/openbas-front/src/admin/components/common/injects/CreateInject.tsx
+++ b/openbas-front/src/admin/components/common/injects/CreateInject.tsx
@@ -180,6 +180,7 @@ const CreateInject: FunctionComponent<Props> = ({ title, onCreateInject, open = 
     'injector_contract_labels',
     'injector_contract_platforms',
     'injector_contract_players',
+    'injector_contract_arch',
   ];
 
   // Contracts

--- a/openbas-front/src/admin/components/common/injects/CreateInjectDetails.js
+++ b/openbas-front/src/admin/components/common/injects/CreateInjectDetails.js
@@ -387,7 +387,7 @@ const CreateInjectDetails = ({
                       inject_asset_groups: [],
                       inject_documents: [],
                     }}
-                    injectorContract={contractContent}
+                    injectorContract={{ ...contractContent, payloadType: contract.injector_contract_payload_type, payloadArch: contract.injector_contract_arch }}
                     handleClose={handleClose}
                     tagsMap={tagsMap}
                     permissions={permissions}

--- a/openbas-front/src/admin/components/common/injects/InjectDefinition.js
+++ b/openbas-front/src/admin/components/common/injects/InjectDefinition.js
@@ -1200,6 +1200,8 @@ class InjectDefinition extends Component {
                 onSubmit={this.handleAddAssets.bind(this)}
                 disabled={fieldAssets.readOnly}
                 platforms={injectorContract.platforms}
+                payloadType={injectorContract.payloadType}
+                payloadArch={injectorContract.payloadArch}
               />
             </>
           )}

--- a/openbas-front/src/admin/components/payloads/PayloadForm.tsx
+++ b/openbas-front/src/admin/components/payloads/PayloadForm.tsx
@@ -106,6 +106,7 @@ const PayloadForm: FunctionComponent<Props> = ({
           id: z.string().min(1, { message: t('Should not be empty') }),
           label: z.string().min(1, { message: t('Should not be empty') }),
         }),
+        executable_arch: z.enum(['x86_64', 'arm64'], { message: t('Should not be empty') }),
       });
       break;
     case 'FileDrop':
@@ -174,6 +175,30 @@ const PayloadForm: FunctionComponent<Props> = ({
           />
         )}
       />
+
+      {type === 'Executable' && (
+        <Controller
+          control={control}
+          name="executable_arch"
+          render={({ field }) => (
+            <TextField
+              select
+              variant="standard"
+              fullWidth
+              value={field.value}
+              label={t('Architecture')}
+              style={{ marginTop: 20 }}
+              error={!!errors.executable_arch}
+              helperText={errors.executable_arch?.message}
+              inputProps={register('executable_arch')}
+              InputLabelProps={{ required: true }}
+            >
+              <MenuItem value='x86_64'>{t('x86_64')}</MenuItem>
+              <MenuItem value='arm64'>{t('arm64')}</MenuItem>
+            </TextField>
+          )}
+        />
+      )}
 
       <TextField
         name="payload_description"

--- a/openbas-front/src/admin/components/payloads/PayloadPopover.js
+++ b/openbas-front/src/admin/components/payloads/PayloadPopover.js
@@ -88,6 +88,7 @@ const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate
       'file_drop_file',
       'payload_attack_patterns',
       'payload_tags',
+      'executable_arch',
     ]),
     R.assoc('payload_platforms', payloadPlatforms),
     R.assoc('executable_file', R.head(payloadExecutableFiles)),

--- a/openbas-front/src/admin/components/payloads/Payloads.tsx
+++ b/openbas-front/src/admin/components/payloads/Payloads.tsx
@@ -190,6 +190,7 @@ const Payloads = () => {
     'payload_status',
     'payload_tags',
     'payload_updated_at',
+    'executable_arch',
   ];
   const [payloads, setPayloads] = useState<PayloadStore[]>([]);
   const { queryableHelpers, searchPaginationInput } = useQueryableWithLocalStorage('payloads', buildSearchPagination({
@@ -336,6 +337,18 @@ const Payloads = () => {
               <PlatformIcon platform={t('No inject in this scenario')} tooltip width={25} />
             ) : selectedPayload?.payload_platforms?.map(
               (platform) => <PlatformIcon key={platform} platform={platform} tooltip width={25} marginRight={10} />,
+            )}
+            {(selectedPayload?.executable_arch) && (
+            <>
+              <Typography
+                variant="h3"
+                gutterBottom
+                style={{ marginTop: 20 }}
+              >
+                {t('Architecture')}
+              </Typography>
+              {selectedPayload?.executable_arch}
+            </>
             )}
             <Typography
               variant="h3"

--- a/openbas-front/src/admin/components/simulations/simulation/injects/endpoints/InjectAddEndpoints.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/injects/endpoints/InjectAddEndpoints.tsx
@@ -24,6 +24,8 @@ interface Props {
   endpointIds: string[];
   onSubmit: (endpointIds: string[]) => void;
   platforms?: string[];
+  payloadType?: string;
+  payloadArch?: string;
 }
 
 const InjectAddEndpoints: FunctionComponent<Props> = ({
@@ -31,6 +33,8 @@ const InjectAddEndpoints: FunctionComponent<Props> = ({
   endpointIds,
   onSubmit,
   platforms,
+  payloadType,
+  payloadArch,
 }) => {
   // Standard hooks
   const classes = useStyles();
@@ -59,7 +63,7 @@ const InjectAddEndpoints: FunctionComponent<Props> = ({
           classes={{ primary: classes.text }}
         />
       </ListItemButton>
-      <EndpointsDialogAdding initialState={endpointIds} open={openDialog} platforms={platforms}
+      <EndpointsDialogAdding initialState={endpointIds} open={openDialog} platforms={platforms} payloadType={payloadType} payloadArch={payloadArch}
         onClose={handleClose} onSubmit={onSubmit}
         title={t('Add assets in this inject')}
       />

--- a/openbas-front/src/components/common/queryable/filter/FilterChipPopoverInput.tsx
+++ b/openbas-front/src/components/common/queryable/filter/FilterChipPopoverInput.tsx
@@ -5,6 +5,7 @@ import { useFormatter } from '../../../i18n';
 import type { Filter, PropertySchemaDTO } from '../../../../utils/api-types';
 import { FilterHelpers } from './FilterHelpers';
 import useSearchOptions from './useSearchOptions';
+import wordsToExcludeFromTranslation from './WordsToExcludeFromTranslation';
 
 interface Props {
   filter: Filter;
@@ -54,7 +55,10 @@ export const BasicSelectInput: FunctionComponent<Props & { propertySchema: Prope
   const { options, setOptions, searchOptions } = useSearchOptions();
   useEffect(() => {
     if (propertySchema.schema_property_values && propertySchema.schema_property_values?.length > 0) {
-      setOptions(propertySchema.schema_property_values.map((v) => ({ id: v, label: t(v.charAt(0).toUpperCase() + v.slice(1).toLowerCase()) })));
+      setOptions(propertySchema.schema_property_values.map((value) => {
+        const label = wordsToExcludeFromTranslation.includes(value) ? value : t(value.charAt(0).toUpperCase() + value.slice(1).toLowerCase());
+        return ({ id: value, label });
+      }));
     } else {
       searchOptions(filter.key);
     }

--- a/openbas-front/src/components/common/queryable/filter/WordsToExcludeFromTranslation.ts
+++ b/openbas-front/src/components/common/queryable/filter/WordsToExcludeFromTranslation.ts
@@ -1,0 +1,3 @@
+const wordsToExclude = ['MacOS', 'x86_64', 'arm64'];
+
+export default wordsToExclude;

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -889,6 +889,7 @@ const i18n = {
       injector_contract_injector: 'Injector',
       injector_contract_labels: 'Label',
       injector_contract_platforms: 'Platforms',
+      injector_contract_arch: 'Architecture',
       // Scenario
       scenario_category: 'Catégorie',
       scenario_kill_chain_phases: 'Phase de kill chain',
@@ -915,6 +916,7 @@ const i18n = {
       payload_status: 'Statut',
       payload_tags: 'Tags',
       payload_updated_at: 'Mis à jour à',
+      executable_arch: 'Architecture',
       // Team
       team_tags: 'Tags',
       // User
@@ -2790,6 +2792,7 @@ const i18n = {
       injector_contract_injector: 'Injector',
       injector_contract_labels: 'Label',
       injector_contract_platforms: 'Platforms',
+      injector_contract_arch: 'Architecture',
       // Scenario
       scenario_category: 'Category',
       scenario_kill_chain_phases: 'Kill chain phase',
@@ -2816,6 +2819,7 @@ const i18n = {
       payload_status: 'Status',
       payload_tags: 'Tags',
       payload_updated_at: 'Updated',
+      executable_arch: 'Architecture',
       // Team
       team_tags: 'Tags',
       // User

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -1498,6 +1498,7 @@ export interface InjectorContractOutput {
     | "Internal"
     | "Unknown"
   )[];
+  injector_contract_arch?: "x86_64" | "arm64";
 }
 
 export interface InjectorContractUpdateInput {
@@ -2351,6 +2352,7 @@ export interface Payload {
   payload_type?: string;
   /** @format date-time */
   payload_updated_at: string;
+  executable_arch?: "x86_64" | "arm64";
 }
 
 export interface PayloadArgument {
@@ -2365,6 +2367,7 @@ export interface PayloadCreateInput {
   command_executor?: string;
   dns_resolution_hostname?: string;
   executable_file?: string;
+  executable_arch?: "x86_64" | "arm64";
   file_drop_file?: string;
   payload_arguments?: PayloadArgument[];
   payload_attack_patterns?: string[];

--- a/openbas-model/src/main/java/io/openbas/database/model/Executable.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Executable.java
@@ -2,9 +2,11 @@ package io.openbas.database.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.openbas.annotation.Queryable;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -25,6 +27,13 @@ public class Executable extends Payload {
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("executable_file")
   private Document executableFile;
+
+  @Queryable(filterable = true, searchable = true)
+  @Column(name = "executable_arch")
+  @JsonProperty("executable_arch")
+  @Enumerated(EnumType.STRING)
+  @NotNull
+  private Endpoint.PLATFORM_ARCH executableArch;
 
   public Executable() {
 

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectorContract.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectorContract.java
@@ -70,6 +70,16 @@ public class InjectorContract implements Base {
     @Queryable(filterable = true)
     private Endpoint.PLATFORM_TYPE[] platforms = new Endpoint.PLATFORM_TYPE[0];
 
+    @Queryable(filterable = true, dynamicValues = true, path="payload.executableArch")
+    @JsonProperty("injector_contract_arch")
+    @Enumerated(EnumType.STRING)
+    public Endpoint.PLATFORM_ARCH getArch() {
+        return Optional.ofNullable(getPayload())
+            .filter(payload -> payload instanceof Executable)
+            .map(payload -> ((Executable) payload).getExecutableArch())
+            .orElse(null);
+    };
+
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "injector_contract_payload")
     @JsonProperty("injector_contract_payload")

--- a/openbas-model/src/main/java/io/openbas/database/model/PayloadType.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/PayloadType.java
@@ -1,0 +1,24 @@
+package io.openbas.database.model;
+
+public enum PayloadType {
+    COMMAND("Command"),
+    EXECUTABLE("Executable"),
+    FILE_DROP("FileDrop"),
+    DNS_RESOLUTION("DnsResolution"),
+    NETWORK_TRAFFIC("NetworkTraffic");
+
+    public final String key;
+
+    PayloadType(String key) {
+        this.key = key;
+    }
+
+    public static PayloadType fromString(String key) {
+        for (PayloadType type : PayloadType.values()) {
+            if (type.key.equalsIgnoreCase(key)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("No PayloadType found for key: " + key);
+    }
+}


### PR DESCRIPTION
### Proposed changes

-  Give the opportunity for a user to declare the compatible architecture of an Executable Payload.

### Related issues

* Closes #1189 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)