### PR TITLE
[backend] Use join map to avoid duplicate join

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
@@ -665,9 +665,10 @@ public class ExerciseApi extends RestBehavior {
             );
         } else {
             return buildPaginationCriteriaBuilder(
-                    (Specification<Exercise> specification, Pageable pageable) -> this.exerciseService.exercises(
+                    (Specification<Exercise> specification, Specification<Exercise> specificationCount, Pageable pageable) -> this.exerciseService.exercises(
                         findGrantedFor(currentUser().getId()).and(specification),
-                            pageable
+                        findGrantedFor(currentUser().getId()).and(specificationCount),
+                        pageable
                     ),
                     searchPaginationInput,
                     Exercise.class

--- a/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseService.java
@@ -77,7 +77,10 @@ public class ExerciseService {
     private OpenBASConfig openBASConfig;
     // endregion
 
-    public Page<ExerciseSimple> exercises(Specification<Exercise> specification, Pageable pageable) {
+    public Page<ExerciseSimple> exercises(
+        Specification<Exercise> specification,
+        Specification<Exercise> specificationCount,
+        Pageable pageable) {
         CriteriaBuilder cb = this.entityManager.getCriteriaBuilder();
 
         CriteriaQuery<Tuple> cq = cb.createTupleQuery();
@@ -133,7 +136,7 @@ public class ExerciseService {
         }
 
         // -- Count Query --
-        Long total = countQuery(cb, this.entityManager, Exercise.class, specification);
+        Long total = countQuery(cb, this.entityManager, Exercise.class, specificationCount);
 
         return new PageImpl<>(exercises, pageable, total);
     }

--- a/openbas-api/src/main/java/io/openbas/rest/inject/ExerciseInjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/ExerciseInjectApi.java
@@ -59,8 +59,10 @@ public class ExerciseInjectApi extends RestBehavior {
       @PathVariable @NotBlank final String exerciseId,
       @RequestBody @Valid final SearchPaginationInput searchPaginationInput) {
     return buildPaginationCriteriaBuilder(
-        (Specification<Inject> specification, Pageable pageable) -> this.injectService.injects(
-            fromExercise(exerciseId).and(specification), pageable
+        (Specification<Inject> specification, Specification<Inject> specificationCount, Pageable pageable) -> this.injectService.injects(
+            fromExercise(exerciseId).and(specification),
+            fromExercise(exerciseId).and(specificationCount),
+            pageable
         ),
         searchPaginationInput,
         Inject.class

--- a/openbas-api/src/main/java/io/openbas/rest/inject/ScenarioInjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/ScenarioInjectApi.java
@@ -47,8 +47,10 @@ public class ScenarioInjectApi extends RestBehavior {
       @PathVariable @NotBlank final String scenarioId,
       @RequestBody @Valid final SearchPaginationInput searchPaginationInput) {
     return buildPaginationCriteriaBuilder(
-        (Specification<Inject> specification, Pageable pageable) -> this.injectService.injects(
-            fromScenario(scenarioId).and(specification), pageable
+        (Specification<Inject> specification, Specification<Inject> specificationCount, Pageable pageable) -> this.injectService.injects(
+            fromScenario(scenarioId).and(specification),
+            fromScenario(scenarioId).and(specificationCount),
+            pageable
         ),
         searchPaginationInput,
         Inject.class

--- a/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractService.java
@@ -3,7 +3,6 @@ package io.openbas.rest.injector_contract;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.InjectorContractRepository;
 import io.openbas.injectors.email.EmailContract;
-import io.openbas.injectors.email.EmailInjector;
 import io.openbas.injectors.ovh.OvhSmsContract;
 import io.openbas.rest.injector_contract.output.InjectorContractOutput;
 import jakarta.persistence.EntityManager;
@@ -64,6 +63,7 @@ public class InjectorContractService {
 
   public Page<InjectorContractOutput> injectorContracts(
       @Nullable final Specification<InjectorContract> specification,
+      @Nullable final Specification<InjectorContract> specificationCount,
       @NotNull final Pageable pageable) {
     CriteriaBuilder cb = this.entityManager.getCriteriaBuilder();
 
@@ -94,7 +94,7 @@ public class InjectorContractService {
     List<InjectorContractOutput> injectorContractOutputs = execInjectorContract(query);
 
     // -- Count Query --
-    Long total = countQuery(cb, this.entityManager, InjectorContract.class, specification);
+    Long total = countQuery(cb, this.entityManager, InjectorContract.class, specificationCount);
 
     return new PageImpl<>(injectorContractOutputs, pageable, total);
   }

--- a/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
@@ -299,19 +299,3 @@ public class ScenarioApi extends RestBehavior {
   }
 
 }
-
-// -- After --
-
-// Without filters
-// Time: back-end 0.06   front-end 0.08
-
-// With filters
-// Time: back-end 0.47   front-end 0.5
-
-// -- Before --
-
-// Without filters
-// Time: back-end 0.02   front-end 0.04
-
-// With filters
-// Time: back-end 0.02   front-end 0.03

--- a/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioApi.java
@@ -1,5 +1,6 @@
 package io.openbas.rest.scenario;
 
+import io.openbas.aop.LogExecutionTime;
 import io.openbas.database.model.*;
 import io.openbas.database.raw.RawPaginationScenario;
 import io.openbas.database.repository.*;
@@ -82,6 +83,7 @@ public class ScenarioApi extends RestBehavior {
     return this.scenarioService.scenarios();
   }
 
+  @LogExecutionTime
   @PostMapping(SCENARIO_URI + "/search")
   public Page<RawPaginationScenario> scenarios(@RequestBody @Valid final SearchPaginationInput searchPaginationInput) {
     return this.scenarioService.scenarios(searchPaginationInput);
@@ -297,3 +299,19 @@ public class ScenarioApi extends RestBehavior {
   }
 
 }
+
+// -- After --
+
+// Without filters
+// Time: back-end 0.06   front-end 0.08
+
+// With filters
+// Time: back-end 0.47   front-end 0.5
+
+// -- Before --
+
+// Without filters
+// Time: back-end 0.02   front-end 0.04
+
+// With filters
+// Time: back-end 0.02   front-end 0.03

--- a/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioExerciseApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/scenario/ScenarioExerciseApi.java
@@ -40,8 +40,9 @@ public class ScenarioExerciseApi {
       @PathVariable @NotBlank final String scenarioId,
       @RequestBody @Valid final SearchPaginationInput searchPaginationInput) {
     return buildPaginationCriteriaBuilder(
-        (Specification<Exercise> specification, Pageable pageable) -> this.exerciseService.exercises(
+        (Specification<Exercise> specification, Specification<Exercise> specificationCount, Pageable pageable) -> this.exerciseService.exercises(
             fromScenario(scenarioId).and(specification),
+            fromScenario(scenarioId).and(specificationCount),
             pageable
         ),
         searchPaginationInput,

--- a/openbas-api/src/main/java/io/openbas/rest/scenario/utils/ScenarioUtils.java
+++ b/openbas-api/src/main/java/io/openbas/rest/scenario/utils/ScenarioUtils.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import static io.openbas.utils.CustomFilterUtils.computeMode;
@@ -23,14 +22,9 @@ public class ScenarioUtils {
   private static final String SCENARIO_RECURRENCE_FILTER = "scenario_recurrence";
 
   /**
-   * Manage filters that are not directly managed by the generic mechanics -> scenario_kill_chain_phases
+   * Manage filters that are not directly managed by the generic mechanics
    */
-  public static Function<Specification<Scenario>, Specification<Scenario>> handleDeepFilter(
-      @NotNull final SearchPaginationInput searchPaginationInput) {
-    return handleCustomFilter(searchPaginationInput);
-  }
-
-  private static UnaryOperator<Specification<Scenario>> handleCustomFilter(
+  public static UnaryOperator<Specification<Scenario>> handleCustomFilter(
       @NotNull final SearchPaginationInput searchPaginationInput) {
     // Existence of the filter
     Optional<Filters.Filter> scenarioRecurrenceFilterOpt = ofNullable(searchPaginationInput.getFilterGroup())

--- a/openbas-api/src/main/java/io/openbas/service/AtomicTestingService.java
+++ b/openbas-api/src/main/java/io/openbas/service/AtomicTestingService.java
@@ -290,15 +290,21 @@ public class AtomicTestingService {
             return predicate;
         });
         return buildPaginationCriteriaBuilder(
-                (Specification<Inject> specification, Pageable pageable) -> this.atomicTestings(
-                    customSpec.and(specification), pageable),
+                (Specification<Inject> specification, Specification<Inject> specificationCount, Pageable pageable) -> this.atomicTestings(
+                    customSpec.and(specification),
+                    customSpec.and(specificationCount),
+                    pageable
+                ),
                 searchPaginationInput,
                 Inject.class
         );
     }
 
 
-    public Page<AtomicTestingOutput> atomicTestings(Specification<Inject> specification, Pageable pageable) {
+    public Page<AtomicTestingOutput> atomicTestings(
+        Specification<Inject> specification,
+        Specification<Inject> specificationCount,
+        Pageable pageable) {
         CriteriaBuilder cb = this.entityManager.getCriteriaBuilder();
 
         CriteriaQuery<Tuple> cq = cb.createTupleQuery();
@@ -368,8 +374,8 @@ public class AtomicTestingService {
             );
         }
 
-    // -- Count Query --
-    Long total = countQuery(cb, this.entityManager, Inject.class, specification);
+        // -- Count Query --
+        Long total = countQuery(cb, this.entityManager, Inject.class, specificationCount);
 
         return new PageImpl<>(injects, pageable, total);
     }

--- a/openbas-api/src/main/java/io/openbas/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectService.java
@@ -177,7 +177,10 @@ public class InjectService {
     return execInject(query);
   }
 
-    public Page<InjectOutput> injects(Specification<Inject> specification, Pageable pageable) {
+    public Page<InjectOutput> injects(
+        Specification<Inject> specification,
+        Specification<Inject> specificationCount,
+        Pageable pageable) {
         CriteriaBuilder cb = this.entityManager.getCriteriaBuilder();
 
         CriteriaQuery<Tuple> cq = cb.createTupleQuery();
@@ -207,7 +210,7 @@ public class InjectService {
         List<InjectOutput> injects = execInject(query);
 
         // -- Count Query --
-        Long total = countQuery(cb, this.entityManager, Inject.class, specification);
+        Long total = countQuery(cb, this.entityManager, Inject.class, specificationCount);
 
         return new PageImpl<>(injects, pageable, total);
     }

--- a/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
@@ -46,7 +46,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.*;
-import java.util.function.Function;
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
@@ -56,7 +57,7 @@ import static io.openbas.config.SessionHelper.currentUser;
 import static io.openbas.database.criteria.GenericCriteria.countQuery;
 import static io.openbas.database.specification.ScenarioSpecification.findGrantedFor;
 import static io.openbas.helper.StreamHelper.fromIterable;
-import static io.openbas.rest.scenario.utils.ScenarioUtils.handleDeepFilter;
+import static io.openbas.rest.scenario.utils.ScenarioUtils.handleCustomFilter;
 import static io.openbas.service.ImportService.EXPORT_ENTRY_ATTACHMENT;
 import static io.openbas.service.ImportService.EXPORT_ENTRY_SCENARIO;
 import static io.openbas.utils.Constants.ARTICLES;
@@ -122,31 +123,45 @@ public class ScenarioService {
   }
 
   public Page<RawPaginationScenario> scenarios(@NotNull final SearchPaginationInput searchPaginationInput) {
-    Function<Specification<Scenario>, Specification<Scenario>> finalSpecification = handleDeepFilter(searchPaginationInput);
+    Map<String, Join<Base, Base>> joinMap = new HashMap<>();
+
+    // Compute custom filter
+    UnaryOperator<Specification<Scenario>> deepFilterSpecification = handleCustomFilter(
+        searchPaginationInput
+    );
+
+    // Compute find all method
+    BiFunction<Specification<Scenario>, Pageable, Page<RawPaginationScenario>> findAll = getFindAllFunction(
+        deepFilterSpecification, joinMap
+    );
+
+    // Compute pagination from find all
+    return buildPaginationCriteriaBuilder(findAll, searchPaginationInput, Scenario.class, joinMap);
+  }
+
+  private BiFunction<Specification<Scenario>, Pageable, Page<RawPaginationScenario>> getFindAllFunction(
+      UnaryOperator<Specification<Scenario>> deepFilterSpecification,
+      Map<String, Join<Base, Base>> joinMap) {
+
     if (currentUser().isAdmin()) {
-      return buildPaginationCriteriaBuilder(
-          (Specification<Scenario> specification, Pageable pageable) -> this.findAllWithCriteriaBuilder(
-              finalSpecification.apply(specification),
-              pageable
-          ),
-          searchPaginationInput,
-          Scenario.class
+      return (specification, pageable) -> this.findAllWithCriteriaBuilder(
+          deepFilterSpecification.apply(specification),
+          pageable,
+          joinMap
       );
     } else {
-      return buildPaginationCriteriaBuilder(
-          (Specification<Scenario> specification, Pageable pageable) -> this.findAllWithCriteriaBuilder(
-              findGrantedFor(currentUser().getId()).and(finalSpecification.apply(specification)),
-              pageable
-          ),
-          searchPaginationInput,
-          Scenario.class
+      return (specification, pageable) -> this.findAllWithCriteriaBuilder(
+          findGrantedFor(currentUser().getId()).and(deepFilterSpecification.apply(specification)),
+          pageable,
+          joinMap
       );
     }
   }
 
   private Page<RawPaginationScenario> findAllWithCriteriaBuilder(
       Specification<Scenario> specification,
-      Pageable pageable) {
+      Pageable pageable,
+      Map<String, Join<Base, Base>> joinMap) {
     CriteriaBuilder cb = entityManager.getCriteriaBuilder();
 
     // -- Create Query --
@@ -154,7 +169,8 @@ public class ScenarioService {
     // FROM
     Root<Scenario> scenarioRoot = cq.from(Scenario.class);
     // Join on TAG
-    Join<Scenario, Tag> scenarioTagsJoin = scenarioRoot.join("tags", JoinType.LEFT);
+    Join<Base, Base> scenarioTagsJoin = scenarioRoot.join("tags", JoinType.LEFT);
+    joinMap.put("tags", scenarioTagsJoin);
     Expression<String[]> tagIdsExpression =
         cb.function(
             "array_remove",
@@ -163,8 +179,10 @@ public class ScenarioService {
             cb.nullLiteral(String.class)
         );
     // Join on INJECT and INJECTOR CONTRACT
-    Join<Scenario, Inject> injectsJoin = scenarioRoot.join("injects", JoinType.LEFT);
-    Join<Inject, InjectorContract> injectorsContractsJoin = injectsJoin.join("injectorContract", JoinType.LEFT);
+    Join<Base, Base> injectsJoin = scenarioRoot.join("injects", JoinType.LEFT);
+    joinMap.put("injects", injectsJoin);
+    Join<Base, Base> injectorsContractsJoin = injectsJoin.join("injectorContract", JoinType.LEFT);
+    joinMap.put("injects.injectorContract", injectorsContractsJoin);
     Expression<String[]> platformExpression =
         cb.function(
             "array_union_agg",
@@ -226,9 +244,7 @@ public class ScenarioService {
   }
 
   /**
-     * Scenario is recurring
-     * AND start date is before now
-     * AND end date is after now
+   * Scenario is recurring AND start date is before now AND end date is after now
    */
   public List<Scenario> recurringScenarios(@NotNull final Instant instant) {
     return this.scenarioRepository.findAll(
@@ -239,10 +255,7 @@ public class ScenarioService {
   }
 
   /**
-     * Scenario is recurring
-     * AND
-     * start date is before now
-     * OR stop date is before now
+   * Scenario is recurring AND start date is before now OR stop date is before now
    */
   public List<Scenario> potentialOutdatedRecurringScenario(@NotNull final Instant instant) {
     return this.scenarioRepository.findAll(
@@ -611,7 +624,7 @@ public class ScenarioService {
     variableService.createVariables(variableList);
   }
 
-  private void getLessonsCategories(Scenario duplicatedScenario, Scenario originalScenario){
+  private void getLessonsCategories(Scenario duplicatedScenario, Scenario originalScenario) {
     List<LessonsCategory> duplicatedCategories = new ArrayList<>();
     for (LessonsCategory originalCategory : originalScenario.getLessonsCategories()) {
       LessonsCategory duplicatedCategory = new LessonsCategory();
@@ -649,7 +662,7 @@ public class ScenarioService {
     duplicatedScenario.setLessonsCategories(duplicatedCategories);
   }
 
-  private void getObjectives(Scenario scenario, Scenario scenarioOrigin){
+  private void getObjectives(Scenario scenario, Scenario scenarioOrigin) {
     List<Objective> duplicatedObjectives = new ArrayList<>();
     for (Objective originalObjective : scenarioOrigin.getObjectives()) {
       Objective duplicatedObjective = new Objective();

--- a/openbas-api/src/main/java/io/openbas/utils/pagination/PaginationUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/pagination/PaginationUtils.java
@@ -1,11 +1,15 @@
 package io.openbas.utils.pagination;
 
+import io.openbas.database.model.Base;
+import jakarta.persistence.criteria.Join;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.BiFunction;
 
 import static io.openbas.utils.FilterUtilsJpa.computeFilterGroupJpa;
@@ -39,15 +43,28 @@ public class PaginationUtils {
   public static <T, U> Page<U> buildPaginationCriteriaBuilder(
       @NotNull final BiFunction<Specification<T>, Pageable, Page<U>> findAll,
       @NotNull final SearchPaginationInput input,
-      @NotNull final Class<T> clazz) {
+      @NotNull final Class<T> clazz,
+      Map<String, Join<Base, Base>> joinMap) {
     // Specification
-    Specification<T> filterSpecifications = computeFilterGroupJpa(input.getFilterGroup());
+    Specification<T> filterSpecifications = computeFilterGroupJpa(input.getFilterGroup(), joinMap);
     Specification<T> searchSpecifications = computeSearchJpa(input.getTextSearch());
 
     // Pageable
     Pageable pageable = PageRequest.of(input.getPage(), input.getSize(), toSortJpa(input.getSorts(), clazz));
 
     return findAll.apply(filterSpecifications.and(searchSpecifications), pageable);
+  }
+
+  public static <T, U> Page<U> buildPaginationCriteriaBuilder(
+      @NotNull final BiFunction<Specification<T>, Pageable, Page<U>> findAll,
+      @NotNull final SearchPaginationInput input,
+      @NotNull final Class<T> clazz) {
+    return buildPaginationCriteriaBuilder(
+        findAll,
+        input,
+        clazz,
+        new HashMap<>()
+    );
   }
 
   /**

--- a/openbas-api/src/main/java/io/openbas/utils/pagination/SearchUtilsJpa.java
+++ b/openbas-api/src/main/java/io/openbas/utils/pagination/SearchUtilsJpa.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.domain.Specification;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.List;
 
 import static io.openbas.utils.JpaUtils.toPath;
@@ -35,7 +36,7 @@ public class SearchUtilsJpa {
       List<PropertySchema> searchableProperties = getSearchableProperties(propertySchemas);
       List<Predicate> predicates = searchableProperties.stream()
           .map(propertySchema -> {
-            Expression<String> paths = toPath(propertySchema, root);
+            Expression<String> paths = toPath(propertySchema, root, new HashMap<>());
             return toPredicate(paths, search, cb, propertySchema.getType());
           })
           .toList();

--- a/openbas-framework/src/main/java/io/openbas/utils/JpaUtils.java
+++ b/openbas-framework/src/main/java/io/openbas/utils/JpaUtils.java
@@ -1,8 +1,11 @@
 package io.openbas.utils;
 
+import io.openbas.database.model.Base;
 import io.openbas.utils.schema.PropertySchema;
 import jakarta.persistence.criteria.*;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.Map;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -12,19 +15,71 @@ public class JpaUtils {
 
   }
 
+  private static <U> Path<U> computePath(
+      @NotNull final From<?, ?> from,
+      @NotNull final String key) {
+    String[] jsonPaths = key.split("\\.");
+
+    // Deep path -> use join
+    if (jsonPaths.length > 1) {
+      From<?, ?> currentFrom = from;
+      for (int i = 0; i < jsonPaths.length - 1; i++) {
+        currentFrom = currentFrom.join(jsonPaths[i], JoinType.LEFT);
+      }
+      // Last path part -> use get
+      return currentFrom.get(jsonPaths[jsonPaths.length - 1]);
+    }
+
+    // Simple path -> use get
+    else if (jsonPaths.length == 1) {
+      return from.get(jsonPaths[0]);
+    }
+
+    return null;
+  }
+
   public static <T, U> Expression<U> toPath(
       @NotNull final PropertySchema propertySchema,
-      @NotNull final Root<T> root) {
+      @NotNull final Root<T> root,
+      @NotNull final Map<String, Join<Base, Base>> joinMap) {
     // Path
     if (hasText(propertySchema.getPath())) {
-      String[] jsonPaths = propertySchema.getPath().split("\\.");
-      if (jsonPaths.length > 0) {
-        Join<Object, Object> paths = root.join(jsonPaths[0], JoinType.LEFT);
-        for (int i = 1; i < jsonPaths.length - 1; i++) {
-          paths = paths.join(jsonPaths[i], JoinType.LEFT);
-        }
-        return paths.get(jsonPaths[jsonPaths.length - 1]);
+      if (joinMap.isEmpty()) {
+        return computePath(root, propertySchema.getPath());
       }
+
+      String existingPath = propertySchema.getPath();
+      Join<Base, Base> existingJoin = null;
+      String existingKey = null;
+
+      // Compute existing join
+      while (hasText(existingPath)) {
+        if (joinMap.containsKey(existingPath)) {
+          existingJoin = joinMap.get(existingPath);
+          existingKey = existingPath;
+          break;
+        }
+        // Nothing found -> exit
+        int lastDotIndex = existingPath.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+          break;
+        }
+        existingPath = existingPath.substring(0, existingPath.lastIndexOf("."));
+      }
+
+      // If existing join in joinMap
+      if (existingJoin != null) {
+        // If equals to key -> return it
+        if (existingKey.equals(propertySchema.getPath())) {
+          return (Expression<U>) existingJoin;
+          // If not, compute the remaining path and return it
+        } else {
+          String remainingPath = propertySchema.getPath().substring(existingKey.length() + 1);
+          return computePath(existingJoin, remainingPath);
+        }
+      }
+
+      return computePath(root, propertySchema.getPath());
     }
     // Join
     if (propertySchema.getJoinTable() != null) {
@@ -50,11 +105,16 @@ public class JpaUtils {
 
   // -- JOIN --
 
-  public static <X, Y> Join<X, Y> createLeftJoin(Root<X> root, String attributeName) {
+  public static <X, Y> Join<X, Y> createLeftJoin(
+      Root<X> root,
+      String attributeName) {
     return root.join(attributeName, JoinType.LEFT);
   }
 
-  public static <X, Y> Expression<String[]> createJoinArrayAggOnId(CriteriaBuilder cb, Root<X> root, String attributeName) {
+  public static <X, Y> Expression<String[]> createJoinArrayAggOnId(
+      CriteriaBuilder cb,
+      Root<X> root,
+      String attributeName) {
     Join<X, Y> join = createLeftJoin(root, attributeName);
     return arrayAggOnId(cb, join);
   }


### PR DESCRIPTION
### Proposed changes

* Use join map to avoid duplicate join

### Related issues

* https://github.com/OpenBAS-Platform/openbas/issues/1583

Query without filters:
```
select
        distinct s1_0.scenario_id,
        s1_0.scenario_name,
        s1_0.scenario_severity,
        s1_0.scenario_category,
        s1_0.scenario_recurrence,
        s1_0.scenario_updated_at,
        array_remove(array_agg(t1_0.tag_id), null),
        array_union_agg(ic1_0.injector_contract_platforms) 
    from
        scenarios s1_0 
    left join
        scenarios_tags t1_0 
            on s1_0.scenario_id=t1_0.scenario_id 
    left join
        injects i1_0 
            on s1_0.scenario_id=i1_0.inject_scenario 
    left join
        injectors_contracts ic1_0 
            on ic1_0.injector_contract_id=i1_0.inject_injector_contract 
    where
        1=1 
        and 1=1 
    group by
        1 
    order by
        6 desc 
    offset
        ? rows 
    fetch
        first ? rows only
```

Query with filters: category + kill chain phases + tags

```
    select
        distinct s1_0.scenario_id,
        s1_0.scenario_name,
        s1_0.scenario_severity,
        s1_0.scenario_category,
        s1_0.scenario_recurrence,
        s1_0.scenario_updated_at,
        array_remove(array_agg(t1_0.tag_id), null),
        array_union_agg(ic1_0.injector_contract_platforms) 
    from
        scenarios s1_0 
    left join
        scenarios_tags t1_0 
            on s1_0.scenario_id=t1_0.scenario_id 
    left join
        injects i1_0 
            on s1_0.scenario_id=i1_0.inject_scenario 
    left join
        injectors_contracts ic1_0 
            on ic1_0.injector_contract_id=i1_0.inject_injector_contract 
    left join
        (injectors_contracts_attack_patterns ap1_0 
    join
        attack_patterns ap1_1 
            on ap1_1.attack_pattern_id=ap1_0.attack_pattern_id) 
        on ic1_0.injector_contract_id=ap1_0.injector_contract_id 
    left join
        attack_patterns_kill_chain_phases kcp1_0 
            on ap1_1.attack_pattern_id=kcp1_0.attack_pattern_id 
    where
        1=1 
        and 1=1 
        and 1=1 
        and 1=1 
    group by
        1 
    order by
        6 desc 
    offset
        ? rows 
    fetch
        first ? rows only
Hibernate: 
    select
        count(distinct s1_0.scenario_id) 
    from
        scenarios s1_0 
    where
        1=1 
        and 1=1 
        and 1=1 
        and 1=1
```