### PR TITLE
[frontend] Fix uri definition variables

### DIFF
--- a/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
@@ -95,7 +95,7 @@ public class ChannelExecutor extends Injector {
           boolean encrypted = content.isEncrypted();
           users.forEach(userInjectContext -> {
             try {
-              // Put the challenges variables in the injection context
+              // Put the articles variables in the injection context
               List<ArticleVariable> articleVariables = articles.stream()
                   .map(article -> new ArticleVariable(article.getId(), article.getName(),
                       buildArticleUri(userInjectContext, article)))

--- a/openbas-front/src/admin/components/common/injects/UpdateInjectDetails.js
+++ b/openbas-front/src/admin/components/common/injects/UpdateInjectDetails.js
@@ -162,15 +162,9 @@ const UpdateInjectDetails = ({
               && data[field.key]
               && data[field.key].length > 0
             ) {
+              const regex = /&lt;#list\s+(\w+)\s+as\s+(\w+)&gt;/g;
               finalData[field.key] = data[field.key]
-                .replaceAll(
-                  '&lt;#list challenges as challenge&gt;',
-                  '<#list challenges as challenge>',
-                )
-                .replaceAll(
-                  '&lt;#list articles as article&gt;',
-                  '<#list articles as article>',
-                )
+                .replace(regex, (_, listName, identifier) => `<#list ${listName} as ${identifier}>`)
                 .replaceAll('&lt;/#list&gt;', '</#list>');
             } else if (data[field.key] && field.type === 'tuple') {
               if (field.cardinality && field.cardinality === '1') {

--- a/openbas-front/src/admin/components/scenarios/scenario/injects/ScenarioInjects.tsx
+++ b/openbas-front/src/admin/components/scenarios/scenario/injects/ScenarioInjects.tsx
@@ -68,7 +68,7 @@ const ScenarioInjects: FunctionComponent<Props> = () => {
               teams={teams}
               articles={articles}
               variables={variables}
-              uriVariable={`/admin/scenarios/${scenarioId}/definition/variables`}
+              uriVariable={`/admin/scenarios/${scenarioId}/definition`}
               allUsersNumber={scenario.scenario_all_users_number}
               usersNumber={scenario.scenario_users_number}
               // @ts-expect-error typing

--- a/openbas-front/src/admin/components/simulations/simulation/injects/ExerciseInjects.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/injects/ExerciseInjects.tsx
@@ -94,7 +94,7 @@ const ExerciseInjects: FunctionComponent<Props> = () => {
               teams={teams}
               articles={articles}
               variables={variables}
-              uriVariable={`/admin/exercises/${exerciseId}/definition/variables`}
+              uriVariable={`/admin/exercises/${exerciseId}/definition`}
               allUsersNumber={exercise.exercise_all_users_number}
               usersNumber={exercise.exercise_users_number}
               // @ts-expect-error typing

--- a/openbas-front/src/admin/components/simulations/simulation/injects/QuickInject.js
+++ b/openbas-front/src/admin/components/simulations/simulation/injects/QuickInject.js
@@ -1417,7 +1417,7 @@ class QuickInject extends Component {
           </Form>
         </div>
         <AvailableVariablesDialog
-          uriVariable={`/admin/exercises/${exerciseId}/definition/variables`}
+          uriVariable={`/admin/exercises/${exerciseId}/definition`}
           variables={this.props.exerciseVariables}
           open={openVariables}
           handleClose={this.handleCloseVariables.bind(this)}

--- a/openbas-front/src/admin/components/simulations/simulation/variables/AvailableVariablesDialog.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/variables/AvailableVariablesDialog.tsx
@@ -111,11 +111,11 @@ AvailableVariablesDialogProps
             label={t('Builtin variables')}
             value="1"
           />
-          <Tab
+          {uriVariable && <Tab
             sx={{ textTransform: 'none' }}
             label={t('Custom variables')}
             value="2"
-          />
+          />}
         </TabList>
         <DialogContent>
           <TabPanel
@@ -161,7 +161,7 @@ AvailableVariablesDialogProps
               })}
             </List>
           </TabPanel>
-          <TabPanel
+          {uriVariable && <TabPanel
             value="2"
             style={{ maxHeight: '100%', overflow: 'auto', padding: 0 }}
           >
@@ -193,7 +193,7 @@ AvailableVariablesDialogProps
                 </div>
               ))}
             </List>
-          </TabPanel>
+          </TabPanel>}
         </DialogContent>
       </TabContext>
 

--- a/openbas-front/src/admin/components/simulations/simulation/variables/AvailableVariablesDialog.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/variables/AvailableVariablesDialog.tsx
@@ -115,7 +115,7 @@ AvailableVariablesDialogProps
             sx={{ textTransform: 'none' }}
             label={t('Custom variables')}
             value="2"
-          />}
+                          />}
         </TabList>
         <DialogContent>
           <TabPanel
@@ -164,7 +164,7 @@ AvailableVariablesDialogProps
           {uriVariable && <TabPanel
             value="2"
             style={{ maxHeight: '100%', overflow: 'auto', padding: 0 }}
-          >
+                          >
             <Alert severity="info">
               {t('Please follow this link to')}
               {/* TODO: validate when migrate to new react router version */}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix url for **Manage custom variables** on scenario, exercise, quick inject and atomic testing
* On atomic testing page : Currently, we dont have the option for custom variables :
![image](https://github.com/user-attachments/assets/dec61a73-51d5-436f-a64f-933fb3da5a84)
* On scenario, exercise, we redirect to /definition for **Manage the custom variables** : 
![image](https://github.com/user-attachments/assets/7e744167-ab51-4df3-892c-6b2fb6894bfa)


### Related issues

* Closes #1473 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
