### PR TITLE
[backend] Refact to prevent duplicate values generated by the left jo…

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseService.java
@@ -121,8 +121,8 @@ public class ExerciseService {
 
     for (ExerciseSimple exercise : exercises) {
      if (exercise.getInjectIds() != null) {
-        exercise.setExpectationResultByTypes(resultUtils.getResultsByTypes(List.of(exercise.getInjectIds())));
-        exercise.setTargets(resultUtils.getInjectTargetWithResults(List.of(exercise.getInjectIds())));
+        exercise.setExpectationResultByTypes(resultUtils.getResultsByTypes(new HashSet<>(Arrays.asList(exercise.getInjectIds()))));
+        exercise.setTargets(resultUtils.getInjectTargetWithResults(new HashSet<>(Arrays.asList(exercise.getInjectIds()))));
       }
     }
 

--- a/openbas-api/src/main/java/io/openbas/utils/ResultUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/ResultUtils.java
@@ -31,11 +31,11 @@ public class ResultUtils {
   private final AssetGroupService assetGroupService;
 
   // -- UTILS --
-  public List<AtomicTestingMapper.ExpectationResultsByType> getResultsByTypes(List<String> injectIds) {
+  public List<AtomicTestingMapper.ExpectationResultsByType> getResultsByTypes(Set<String> injectIds) {
     return computeGlobalExpectationResults(injectIds);
   }
 
-  public List<InjectTargetWithResult> getInjectTargetWithResults(List<String> injectIds) {
+  public List<InjectTargetWithResult> getInjectTargetWithResults(Set<String> injectIds) {
     if (injectIds != null) {
       return computeTargetResults(injectIds);
     } else {
@@ -65,62 +65,58 @@ public class ResultUtils {
 
   // -- GLOBAL SCORE --
   public List<ExpectationResultsByType> computeGlobalExpectationResults(
-      @NotNull List<String> injectIds) {
+      @NotNull Set<String> injectIds) {
     return AtomicTestingUtils.getExpectationResultByTypesFromRaw(
         injectExpectationRepository.rawForComputeGlobalByIds(injectIds));
   }
 
   // -- TARGETS WITH RESULTS --
   public List<InjectTargetWithResult> computeTargetResults(
-      @NotNull List<String> injectIds) {
+      @NotNull Set<String> injectIds) {
 
     // -- EXPECTATIONS --
-    List<RawInjectExpectation> rawInjectExpectations = injectExpectationRepository.rawByInjectId(injectIds);
+    Set<RawInjectExpectation> rawInjectExpectations = injectExpectationRepository.rawByInjectId(injectIds);
     Map<String, List<RawInjectExpectation>> expectationMap = rawInjectExpectations
         .stream().collect(Collectors.groupingBy(RawInjectExpectation::getInject_id));
 
     // -- TEAMS INJECT --
 
-    List<String> teamIds = rawInjectExpectations
+    Set<String> teamIds = rawInjectExpectations
         .stream()
         .map(RawInjectExpectation::getTeam_id)
         .filter(Objects::nonNull)
-        .distinct()
-        .toList();
+        .collect(Collectors.toSet());
 
-    List<RawTeam> rawTeams = teamRepository.rawByIdsOrInjectIds(teamIds, injectIds);
+    Set<RawTeam> rawTeams = teamRepository.rawByIdsOrInjectIds(teamIds, injectIds);
     Map<String, RawTeam> teamMap = rawTeams.stream().collect(Collectors.toMap(RawTeam::getTeam_id, rawTeam ->rawTeam));
 
     // -- USER MAP FROM TEAMS --
 
-    List<String> userIds = rawInjectExpectations
+    Set<String> userIds = rawInjectExpectations
         .stream()
         .map(RawInjectExpectation::getUser_id)
         .filter(Objects::nonNull)
-        .distinct()
-        .toList();
+        .collect(Collectors.toSet());
 
-    List<RawUser> rawUsers = userRepository.rawUserByIds(userIds);
+    Set<RawUser> rawUsers = userRepository.rawUserByIds(userIds);
     Map<String, RawUser> userMap = rawUsers.stream().collect(Collectors.toMap(RawUser::getUser_id, rawUser ->rawUser));
 
     // -- ASSETS GROUPS INJECT --
-    List<String> assetGroupIds = rawInjectExpectations
+    Set<String> assetGroupIds = rawInjectExpectations
         .stream()
         .map(RawInjectExpectation::getAsset_group_id)
         .filter(Objects::nonNull)
-        .distinct()
-        .toList();
+        .collect(Collectors.toSet());
 
-    List<RawAssetGroup> rawAssetGroups = assetGroupRepository.rawByIdsOrInjectIds(assetGroupIds, injectIds);
+    Set<RawAssetGroup> rawAssetGroups = assetGroupRepository.rawByIdsOrInjectIds(assetGroupIds, injectIds);
     Map<String, RawAssetGroup> assetGroupMap = rawAssetGroups.stream().collect(Collectors.toMap(RawAssetGroup::getAsset_group_id, rawAssetGroup ->rawAssetGroup));
 
     // -- ASSETS INJECT --
-    List<String> assetIds = rawInjectExpectations
+    Set<String> assetIds = rawInjectExpectations
         .stream()
         .map(RawInjectExpectation::getAsset_id)
         .filter(Objects::nonNull)
-        .distinct()
-        .collect(Collectors.toList());
+        .collect(Collectors.toSet());
 
     assetIds.addAll(rawAssetGroups
         .stream()

--- a/openbas-framework/src/main/java/io/openbas/asset/AssetGroupService.java
+++ b/openbas-framework/src/main/java/io/openbas/asset/AssetGroupService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -127,7 +128,7 @@ public class AssetGroupService {
   /**
    *
    * */
-  public Map<String, List<Endpoint>> computeDynamicAssetFromRaw(@NotNull List<RawAssetGroup> assetGroups) {
+  public Map<String, List<Endpoint>> computeDynamicAssetFromRaw(@NotNull Set<RawAssetGroup> assetGroups) {
     if (assetGroups.isEmpty()) {
       return Map.of();
     }

--- a/openbas-model/src/main/java/io/openbas/database/raw/RawExerciseSimple.java
+++ b/openbas-model/src/main/java/io/openbas/database/raw/RawExerciseSimple.java
@@ -1,7 +1,7 @@
 package io.openbas.database.raw;
 
 import java.time.Instant;
-import java.util.List;
+import java.util.Set;
 
 public interface RawExerciseSimple {
 
@@ -21,7 +21,7 @@ public interface RawExerciseSimple {
 
     String getExercise_subtitle();
 
-    List<String> getExercise_tags();
+    Set<String> getExercise_tags();
 
-    List<String> getInject_ids();
+    Set<String> getInject_ids();
 }

--- a/openbas-model/src/main/java/io/openbas/database/repository/AssetGroupRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/AssetGroupRepository.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 @Repository
 public interface AssetGroupRepository extends CrudRepository<AssetGroup, String>,
@@ -57,7 +58,7 @@ public interface AssetGroupRepository extends CrudRepository<AssetGroup, String>
           "LEFT JOIN asset_groups_assets aga ON aga.asset_group_id = ag.asset_group_id " +
           "WHERE iat.asset_group_id IN (:assetGroupIds) OR iat.inject_id IN (:injectIds) " +
           "GROUP BY ag.asset_group_id, ag.asset_group_name, CAST(ag.asset_group_dynamic_filter as text) ;", nativeQuery = true)
-  List<RawAssetGroup> rawByIdsOrInjectIds(@Param("assetGroupIds") List<String> assetGroupIds, @Param("injectIds") List<String> injectIds);
+  Set<RawAssetGroup> rawByIdsOrInjectIds(@Param("assetGroupIds") Set<String> assetGroupIds, @Param("injectIds") Set<String> injectIds);
 
   // -- PAGINATION --
 

--- a/openbas-model/src/main/java/io/openbas/database/repository/AssetRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/AssetRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 public interface AssetRepository extends CrudRepository<Asset, String>, JpaSpecificationExecutor<Asset> {
@@ -31,6 +32,6 @@ public interface AssetRepository extends CrudRepository<Asset, String>, JpaSpeci
       "FROM assets a " +
       "LEFT JOIN injects_assets ia ON a.asset_id = ia.asset_id " +
       "WHERE a.asset_id IN (:assetIds) OR ia.inject_id IN (:injectIds) ;", nativeQuery = true)
-  List<RawAsset> rawByIdsOrInjectIds(@Param("assetIds") List<String> assetIds, @Param("injectIds") List<String> injectIds);
+  List<RawAsset> rawByIdsOrInjectIds(@Param("assetIds") Set<String> assetIds, @Param("injectIds") Set<String> injectIds);
 }
 

--- a/openbas-model/src/main/java/io/openbas/database/repository/ExerciseRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/ExerciseRepository.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Repository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface ExerciseRepository extends CrudRepository<Exercise, String>,
@@ -236,7 +237,7 @@ public interface ExerciseRepository extends CrudRepository<Exercise, String>,
           + "FROM exercises ex "
           + "LEFT JOIN injects_expectations ie ON ex.exercise_id = ie.exercise_id "
           + "WHERE ex.exercise_id = :exerciseId AND ie.inject_id IS NOT NULL;", nativeQuery = true)
-  List<String> findInjectsByExercise(@Param("exerciseId") String exerciseId);
+  Set<String> findInjectsByExercise(@Param("exerciseId") String exerciseId);
 
   @Query(value =
       " SELECT ex.exercise_id, "
@@ -255,6 +256,6 @@ public interface ExerciseRepository extends CrudRepository<Exercise, String>,
           + "LEFT JOIN injects_expectations ie ON ex.exercise_id = ie.exercise_id "
           + "WHERE s.scenario_id IN (:scenarioIds) "
           + "GROUP BY ex.exercise_id ;", nativeQuery = true)
-  List<RawExerciseSimple> rawAllByScenarioId(@Param("scenarioIds") List<String> scenarioIds);
+  Set<RawExerciseSimple> rawAllByScenarioId(@Param("scenarioIds") List<String> scenarioIds);
 
 }

--- a/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/InjectExpectationRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface InjectExpectationRepository extends CrudRepository<InjectExpectation, String>,
@@ -131,7 +132,7 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
       + "FROM injects_expectations i "
       + "WHERE i.inject_id IN (:injectIds) "
       + "AND i.user_id is null ;", nativeQuery = true) //We don't include expectations for players, only for the team, if applicable
-  List<RawInjectExpectation> rawForComputeGlobalByIds(@Param("injectIds") List<String> injectIds);
+  List<RawInjectExpectation> rawForComputeGlobalByIds(@Param("injectIds") Set<String> injectIds);
 
   @Query(value = "SELECT "
       + "i.inject_expectation_id AS inject_expectation_id, "
@@ -147,5 +148,5 @@ public interface InjectExpectationRepository extends CrudRepository<InjectExpect
       + "i.inject_expectation_group AS inject_expectation_group "
       + "FROM injects_expectations i "
       + "WHERE i.inject_id IN (:injectIds) ; ", nativeQuery = true)
-  List<RawInjectExpectation> rawByInjectId(@Param("injectIds") final List<String> injectIds);
+  Set<RawInjectExpectation> rawByInjectId(@Param("injectIds") final Set<String> injectIds);
 }

--- a/openbas-model/src/main/java/io/openbas/database/repository/TeamRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/TeamRepository.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Repository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface TeamRepository extends CrudRepository<Team, String>,
@@ -56,7 +57,7 @@ public interface TeamRepository extends CrudRepository<Team, String>,
       + "FROM teams t "
       + "LEFT JOIN injects_teams it ON t.team_id = it.team_id "
       + "WHERE t.team_id IN (:ids) OR it.inject_id IN (:injectIds) ;", nativeQuery = true)
-  List<RawTeam> rawByIdsOrInjectIds(@Param("ids") List<String> ids, @Param("injectIds") List<String> injectIds);
+  Set<RawTeam> rawByIdsOrInjectIds(@Param("ids") Set<String> ids, @Param("injectIds") Set<String> injectIds);
 
   @Query(value =
       "SELECT teams.team_id, teams.team_name, teams.team_description, teams.team_created_at, teams.team_updated_at, teams.team_organization, "

--- a/openbas-model/src/main/java/io/openbas/database/repository/UserRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/UserRepository.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Repository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface UserRepository extends CrudRepository<User, String>, JpaSpecificationExecutor<User>,
@@ -91,7 +92,7 @@ public interface UserRepository extends CrudRepository<User, String>, JpaSpecifi
       + "us.user_organization "
       + "FROM users us "
       + "WHERE us.user_id IN :ids ;", nativeQuery = true)
-  List<RawUser> rawUserByIds(@Param("ids") List<String> ids);
+  Set<RawUser> rawUserByIds(@Param("ids") Set<String> ids);
 
   // -- PAGINATION --
 


### PR DESCRIPTION
…in in the filter

<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Refact to void duplicated values generated by query with filter on exercise
Error Postgres: ERROR 14960 --- [OpenBAS API] [0.0-8080-exec-2] o.h.engine.jdbc.spi.SqlExceptionHelper   : PreparedStatement can have at most 65,535 parameters. Please consider using arrays, or splitting the query in several ones, or using COPY. Given query has 89,401 parameters


### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
