### PR TITLE
[backend] Add validation for default score value

### DIFF
--- a/openbas-api/src/main/resources/application.properties
+++ b/openbas-api/src/main/resources/application.properties
@@ -244,7 +244,7 @@ openbas.expectation.human.expiration-time=86400
 #openbas.expectation.article.expiration-time=3600
 #openbas.expectation.manual.expiration-time=3600
 
-# Minimum value: 0
-# Maximum value: 100
+# Min value: 1
+# Max value: 100
 # Default value: 50
-openbas.expectation.manual.default-score-value=50 
+openbas.expectation.manual.default-score-value=50

--- a/openbas-api/src/main/resources/application.properties
+++ b/openbas-api/src/main/resources/application.properties
@@ -244,4 +244,7 @@ openbas.expectation.human.expiration-time=86400
 #openbas.expectation.article.expiration-time=3600
 #openbas.expectation.manual.expiration-time=3600
 
-openbas.expectation.manual.default-score-value=50
+# Minimum value: 0
+# Maximum value: 100
+# Default value: 50
+openbas.expectation.manual.default-score-value=50 

--- a/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
+++ b/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
@@ -3,13 +3,11 @@ package io.openbas.expectation;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.annotation.Validated;
 
 import static java.util.Optional.ofNullable;
 
 @Component
 @Setter
-@Validated
 public class ExpectationPropertiesConfig {
 
   public static long DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME = 21600L; // 6 hours

--- a/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
+++ b/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
@@ -1,6 +1,7 @@
 package io.openbas.expectation;
 
 import lombok.Setter;
+import lombok.extern.java.Log;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -8,6 +9,7 @@ import static java.util.Optional.ofNullable;
 
 @Component
 @Setter
+@Log
 public class ExpectationPropertiesConfig {
 
   public static long DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME = 21600L; // 6 hours
@@ -76,6 +78,7 @@ public class ExpectationPropertiesConfig {
     if (defaultManualExpectationScore == null ||
         defaultManualExpectationScore < 1 ||
         defaultManualExpectationScore > 100) {
+      log.warning("The provided default score value is invalid. It should be within the acceptable range of 0 to 100. The score will be set to the default of 50.");
       return DEFAULT_MANUAL_EXPECTATION_SCORE;
     }
     return defaultManualExpectationScore;

--- a/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
+++ b/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
@@ -1,13 +1,17 @@
 package io.openbas.expectation;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 import static java.util.Optional.ofNullable;
 
 @Component
 @Setter
+@Validated
 public class ExpectationPropertiesConfig {
 
   public static long DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME = 21600L; // 6 hours
@@ -29,7 +33,9 @@ public class ExpectationPropertiesConfig {
   private Long articleExpirationTime;
   @Value("${openbas.expectation.manual.expiration-time:#{null}}")
   private Long manualExpirationTime;
-  @Value("${openbas.expectation.manual.default-score-value:#{null}}")
+  @Value("${openbas.expectation.manual.default-score-value:50}")
+  @Max(100)
+  @Min(0)
   private Integer defaultManualExpectationScore;
 
   public long getDetectionExpirationTime() {

--- a/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
+++ b/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
@@ -1,7 +1,5 @@
 package io.openbas.expectation;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
+++ b/openbas-framework/src/main/java/io/openbas/expectation/ExpectationPropertiesConfig.java
@@ -33,9 +33,7 @@ public class ExpectationPropertiesConfig {
   private Long articleExpirationTime;
   @Value("${openbas.expectation.manual.expiration-time:#{null}}")
   private Long manualExpirationTime;
-  @Value("${openbas.expectation.manual.default-score-value:50}")
-  @Max(100)
-  @Min(0)
+  @Value("${openbas.expectation.manual.default-score-value:#{null}}")
   private Integer defaultManualExpectationScore;
 
   public long getDetectionExpirationTime() {
@@ -79,8 +77,12 @@ public class ExpectationPropertiesConfig {
   }
 
   public int getDefaultExpectationScoreValue() {
-    return ofNullable(this.defaultManualExpectationScore)
-            .orElse(DEFAULT_MANUAL_EXPECTATION_SCORE);
+    if (defaultManualExpectationScore == null ||
+        defaultManualExpectationScore < 1 ||
+        defaultManualExpectationScore > 100) {
+      return DEFAULT_MANUAL_EXPECTATION_SCORE;
+    }
+    return defaultManualExpectationScore;
   }
 
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add validation for score between 0-100 for openbas.expectation.manual.default-score-value property

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
