### PR TITLE
[backend] Add matching on parent process name for inject expectation signature

### DIFF
--- a/openbas-api/src/main/java/io/openbas/injectors/openbas/OpenBASImplantExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/openbas/OpenBASImplantExecutor.java
@@ -1,5 +1,14 @@
 package io.openbas.injectors.openbas;
 
+import static io.openbas.database.model.InjectExpectationSignature.*;
+import static io.openbas.database.model.InjectStatusExecution.traceError;
+import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAsset;
+import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
+import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAsset;
+import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
+import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAsset;
+import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
+
 import io.openbas.asset.AssetGroupService;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.InjectRepository;
@@ -12,22 +21,12 @@ import io.openbas.model.expectation.DetectionExpectation;
 import io.openbas.model.expectation.ManualExpectation;
 import io.openbas.model.expectation.PreventionExpectation;
 import jakarta.validation.constraints.NotNull;
+import java.util.*;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.hibernate.Hibernate;
 import org.springframework.stereotype.Component;
-
-import java.util.*;
-import java.util.stream.Stream;
-
-import static io.openbas.database.model.InjectExpectationSignature.*;
-import static io.openbas.database.model.InjectStatusExecution.traceError;
-import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAsset;
-import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
-import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAsset;
-import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
-import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAsset;
-import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
 
 @Component(OpenBASImplantContract.TYPE)
 @RequiredArgsConstructor
@@ -257,8 +256,10 @@ public class OpenBASImplantExecutor extends Injector {
                           Command payloadCommand =
                               (Command) Hibernate.unproxy(injectorContract.getPayload());
                           injectExpectationSignatures.add(
-                              InjectExpectationSignature.builder().type(EXPECTATION_SIGNATURE_TYPE_PARENT_PROCESS_NAME)
-                                  .value("obas-implant-" + inject.getId()).build());
+                              InjectExpectationSignature.builder()
+                                  .type(EXPECTATION_SIGNATURE_TYPE_PARENT_PROCESS_NAME)
+                                  .value("obas-implant-" + inject.getId())
+                                  .build());
                           injectExpectationSignatures.add(
                               InjectExpectationSignature.builder()
                                   .type(EXPECTATION_SIGNATURE_TYPE_COMMAND_LINE)

--- a/openbas-api/src/main/java/io/openbas/injectors/openbas/OpenBASImplantExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/openbas/OpenBASImplantExecutor.java
@@ -1,14 +1,5 @@
 package io.openbas.injectors.openbas;
 
-import static io.openbas.database.model.InjectExpectationSignature.*;
-import static io.openbas.database.model.InjectStatusExecution.traceError;
-import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAsset;
-import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
-import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAsset;
-import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
-import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAsset;
-import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
-
 import io.openbas.asset.AssetGroupService;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.InjectRepository;
@@ -21,12 +12,22 @@ import io.openbas.model.expectation.DetectionExpectation;
 import io.openbas.model.expectation.ManualExpectation;
 import io.openbas.model.expectation.PreventionExpectation;
 import jakarta.validation.constraints.NotNull;
-import java.util.*;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.hibernate.Hibernate;
 import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static io.openbas.database.model.InjectExpectationSignature.*;
+import static io.openbas.database.model.InjectStatusExecution.traceError;
+import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAsset;
+import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
+import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAsset;
+import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
+import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAsset;
+import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
 
 @Component(OpenBASImplantContract.TYPE)
 @RequiredArgsConstructor
@@ -255,6 +256,9 @@ public class OpenBASImplantExecutor extends Injector {
                         case "Command":
                           Command payloadCommand =
                               (Command) Hibernate.unproxy(injectorContract.getPayload());
+                          injectExpectationSignatures.add(
+                              InjectExpectationSignature.builder().type(EXPECTATION_SIGNATURE_TYPE_PARENT_PROCESS_NAME)
+                                  .value("obas-implant-" + inject.getId()).build());
                           injectExpectationSignatures.add(
                               InjectExpectationSignature.builder()
                                   .type(EXPECTATION_SIGNATURE_TYPE_COMMAND_LINE)

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectExpectationSignature.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectExpectationSignature.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 @Data
 @Builder
 public class InjectExpectationSignature {
+  public static final String EXPECTATION_SIGNATURE_TYPE_PARENT_PROCESS_NAME = "parent_process_name";
   public static final String EXPECTATION_SIGNATURE_TYPE_PROCESS_NAME = "process_name";
   public static final String EXPECTATION_SIGNATURE_TYPE_COMMAND_LINE = "command_line";
   public static final String EXPECTATION_SIGNATURE_TYPE_HASH = "hash";


### PR DESCRIPTION
Add matching on process parent name to be more accurate when we match prevention & detection expectation.

Linked to https://github.com/OpenBAS-Platform/collectors/pull/48