### PR TITLE
[backend/frontend] Some payloads coming from Atomic Red team are marked as "Manual"

### DIFF
--- a/openbas-api/src/main/java/io/openbas/migration/V3_48__Set_Payload_source_as_community_and_deprecate.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_48__Set_Payload_source_as_community_and_deprecate.java
@@ -1,0 +1,22 @@
+package io.openbas.migration;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V3_48__Set_Payload_source_as_community_and_deprecate extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Connection connection = context.getConnection();
+    Statement statement = connection.createStatement();
+    statement.execute(
+        "UPDATE payloads SET payload_source = 'COMMUNITY' WHERE payload_collector IS NOT NULL AND payload_source = 'MANUAL';");
+    statement.execute(
+        "UPDATE payloads SET payload_status = 'DEPRECATED' FROM collectors\n"
+            + "    WHERE payload_collector = collector_id AND collector_last_execution - payload_updated_at >= INTERVAL '1 week';");
+  }
+}

--- a/openbas-api/src/main/java/io/openbas/rest/payload/PayloadApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/payload/PayloadApi.java
@@ -15,6 +15,7 @@ import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.payload.form.PayloadCreateInput;
 import io.openbas.rest.payload.form.PayloadUpdateInput;
 import io.openbas.rest.payload.form.PayloadUpsertInput;
+import io.openbas.rest.payload.form.PayloadsDeprecateInput;
 import io.openbas.utils.pagination.SearchPaginationInput;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
@@ -379,5 +380,14 @@ public class PayloadApi extends RestBehavior {
   @DeleteMapping("/api/payloads/{payloadId}")
   public void deletePayload(@PathVariable String payloadId) {
     payloadRepository.deleteById(payloadId);
+  }
+
+  @PostMapping(PAYLOAD_URI + "/deprecate")
+  @Secured(ROLE_ADMIN)
+  @Transactional(rollbackOn = Exception.class)
+  public void deprecateNonProcessedPayloadsByCollector(
+      @Valid @RequestBody PayloadsDeprecateInput input) {
+    this.payloadService.deprecateNonProcessedPayloadsByCollector(
+        input.collectorId(), input.processedPayloadExternalIds());
   }
 }

--- a/openbas-api/src/main/java/io/openbas/rest/payload/form/PayloadsDeprecateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/payload/form/PayloadsDeprecateInput.java
@@ -1,0 +1,9 @@
+package io.openbas.rest.payload.form;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record PayloadsDeprecateInput(
+    @JsonProperty("collector_id") @NotNull String collectorId,
+    @JsonProperty("payload_external_ids") @NotNull List<String> processedPayloadExternalIds) {}

--- a/openbas-api/src/test/java/io/openbas/rest/PayloadApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/PayloadApiTest.java
@@ -2,25 +2,31 @@ package io.openbas.rest;
 
 import static io.openbas.utils.JsonUtils.asJsonString;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import io.openbas.IntegrationTest;
 import io.openbas.database.model.Document;
 import io.openbas.database.model.Endpoint;
+import io.openbas.database.model.Payload;
 import io.openbas.database.repository.DocumentRepository;
 import io.openbas.database.repository.PayloadRepository;
+import io.openbas.rest.collector.form.CollectorCreateInput;
 import io.openbas.rest.payload.form.PayloadCreateInput;
 import io.openbas.rest.payload.form.PayloadUpdateInput;
+import io.openbas.rest.payload.form.PayloadUpsertInput;
+import io.openbas.rest.payload.form.PayloadsDeprecateInput;
 import io.openbas.utils.fixtures.PayloadInputFixture;
 import io.openbas.utils.mockUser.WithMockAdminUser;
+import jakarta.annotation.Resource;
 import java.util.List;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
 @TestInstance(PER_CLASS)
@@ -32,6 +38,8 @@ public class PayloadApiTest extends IntegrationTest {
   @Autowired private MockMvc mvc;
   @Autowired private DocumentRepository documentRepository;
   @Autowired private PayloadRepository payloadRepository;
+
+  @Resource private ObjectMapper objectMapper;
 
   @BeforeAll
   void beforeAll() {
@@ -271,5 +279,117 @@ public class PayloadApiTest extends IntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(asJsonString(updateInput)))
         .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName(
+      "Duplicating a Community and Verified Payload should result in a Manual and Unverified Payload")
+  @WithMockAdminUser
+  void duplicateExecutablePayload() throws Exception {
+    PayloadCreateInput createInput =
+        PayloadInputFixture.createDefaultPayloadCreateInputForExecutable();
+    createInput.setExecutableFile(EXECUTABLE_FILE.getId());
+    createInput.setSource(Payload.PAYLOAD_SOURCE.COMMUNITY);
+    createInput.setStatus(Payload.PAYLOAD_STATUS.VERIFIED);
+
+    String createdPayload =
+        mvc.perform(
+                post(PAYLOAD_URI)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(asJsonString(createInput)))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.payload_name").value("My Executable Payload"))
+            .andExpect(jsonPath("$.payload_platforms.[0]").value("Linux"))
+            .andExpect(jsonPath("$.executable_arch").value("x86_64"))
+            .andExpect(jsonPath("$.payload_source").value("COMMUNITY"))
+            .andExpect(jsonPath("$.payload_status").value("VERIFIED"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    var payloadId = JsonPath.read(createdPayload, "$.payload_id");
+
+    mvc.perform(post(PAYLOAD_URI + "/" + payloadId + "/duplicate"))
+        .andExpect(status().is2xxSuccessful())
+        .andExpect(jsonPath("$.payload_name").value("My Executable Payload (duplicate)"))
+        .andExpect(jsonPath("$.payload_platforms.[0]").value("Linux"))
+        .andExpect(jsonPath("$.executable_arch").value("x86_64"))
+        .andExpect(jsonPath("$.payload_source").value("MANUAL"))
+        .andExpect(jsonPath("$.payload_status").value("UNVERIFIED"));
+  }
+
+  @Test
+  @DisplayName("Process Deprecated Payloads")
+  @WithMockAdminUser
+  void processDeprecatedPayloads() throws Exception {
+    String collectorId = "039eee9b-b95d-4b11-95bb-a9ac233f1738";
+    CollectorCreateInput collectorCreateInput = new CollectorCreateInput();
+    collectorCreateInput.setId(collectorId);
+    collectorCreateInput.setName("My Collector");
+    collectorCreateInput.setType("openbas_atomic_red_team");
+
+    MockMultipartFile inputMultipart =
+        new MockMultipartFile(
+            "input",
+            null,
+            "application/json",
+            objectMapper.writeValueAsString(collectorCreateInput).getBytes());
+
+    mvc.perform(multipart("/api/collectors").file(inputMultipart))
+        .andExpect(status().is2xxSuccessful());
+
+    PayloadUpsertInput payloadUpsertInput1 =
+        PayloadInputFixture.createDefaultPayloadUpsertInputForCommandLine();
+    payloadUpsertInput1.setCollector(collectorId);
+    payloadUpsertInput1.setExternalId("54e03fc3-e906-4b8e-865a-972e3e339d60");
+
+    PayloadUpsertInput payloadUpsertInput2 =
+        PayloadInputFixture.createDefaultPayloadUpsertInputForCommandLine();
+    payloadUpsertInput2.setName("Command Payload 2");
+    payloadUpsertInput2.setCollector(collectorId);
+    payloadUpsertInput2.setExternalId("7a1ecc3c-3201-45cb-9a93-58405c0a680d");
+
+    String upsertedPayload1 =
+        mvc.perform(
+                post(PAYLOAD_URI + "/upsert")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(asJsonString(payloadUpsertInput1)))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String payloadId1 = JsonPath.read(upsertedPayload1, "$.payload_id");
+
+    String upsertedPayload2 =
+        mvc.perform(
+                post(PAYLOAD_URI + "/upsert")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(asJsonString(payloadUpsertInput2)))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String payloadId2 = JsonPath.read(upsertedPayload2, "$.payload_id");
+
+    PayloadsDeprecateInput payloadsDeprecateInput =
+        new PayloadsDeprecateInput(collectorId, List.of(payloadUpsertInput2.getExternalId()));
+
+    mvc.perform(
+            post(PAYLOAD_URI + "/deprecate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(payloadsDeprecateInput)))
+        .andExpect(status().is2xxSuccessful());
+
+    mvc.perform(get(PAYLOAD_URI + "/" + payloadId1))
+        .andExpect(status().is2xxSuccessful())
+        .andExpect(jsonPath("$.payload_name").value("Command line payload"))
+        .andExpect(jsonPath("$.payload_collector").value(collectorId))
+        .andExpect(jsonPath("$.payload_status").value("DEPRECATED"));
+
+    mvc.perform(get(PAYLOAD_URI + "/" + payloadId2))
+        .andExpect(status().is2xxSuccessful())
+        .andExpect(jsonPath("$.payload_name").value("Command Payload 2"))
+        .andExpect(jsonPath("$.payload_collector").value(collectorId))
+        .andExpect(jsonPath("$.payload_status").value("UNVERIFIED"));
   }
 }

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/PayloadInputFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/PayloadInputFixture.java
@@ -4,6 +4,7 @@ import io.openbas.database.model.Document;
 import io.openbas.database.model.Endpoint;
 import io.openbas.database.model.Payload;
 import io.openbas.rest.payload.form.PayloadCreateInput;
+import io.openbas.rest.payload.form.PayloadUpsertInput;
 import java.util.Collections;
 
 public class PayloadInputFixture {
@@ -43,5 +44,20 @@ public class PayloadInputFixture {
     executableFile.setName("Executable file");
     executableFile.setType("text/x-sh");
     return executableFile;
+  }
+
+  public static PayloadUpsertInput createDefaultPayloadUpsertInputForCommandLine() {
+    PayloadUpsertInput input = new PayloadUpsertInput();
+    input.setType("Command");
+    input.setName("Command line payload");
+    input.setDescription("Command line description");
+    input.setSource(Payload.PAYLOAD_SOURCE.COMMUNITY);
+    input.setStatus(Payload.PAYLOAD_STATUS.UNVERIFIED);
+    input.setPlatforms(new Endpoint.PLATFORM_TYPE[] {Endpoint.PLATFORM_TYPE.Linux});
+    input.setAttackPatternsExternalIds(Collections.emptyList());
+    input.setTagIds(Collections.emptyList());
+    input.setExecutor("sh");
+    input.setContent("ufw prepend deny from 1.2.3.4\n" + "ufw status numbered\n");
+    return input;
   }
 }

--- a/openbas-front/src/admin/components/payloads/PayloadPopover.js
+++ b/openbas-front/src/admin/components/payloads/PayloadPopover.js
@@ -11,7 +11,7 @@ import { useFormatter } from '../../../components/i18n';
 import { documentOptions, platformOptions } from '../../../utils/Option';
 import PayloadForm from './PayloadForm';
 
-const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate, disabled }) => {
+const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate, disableUpdate, disableDelete }) => {
   const [openDelete, setOpenDelete] = useState(false);
   const [openDuplicate, setOpenDuplicate] = useState(false);
   const [openEdit, setOpenEdit] = useState(false);
@@ -107,8 +107,8 @@ const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate
         onClose={handlePopoverClose}
       >
         <MenuItem onClick={handleOpenDuplicate}>{t('Duplicate')}</MenuItem>
-        <MenuItem onClick={handleOpenEdit} disabled={disabled}>{t('Update')}</MenuItem>
-        <MenuItem onClick={handleOpenDelete} disabled={disabled}>{t('Delete')}</MenuItem>
+        <MenuItem onClick={handleOpenEdit} disabled={disableUpdate}>{t('Update')}</MenuItem>
+        <MenuItem onClick={handleOpenDelete} disabled={disableDelete}>{t('Delete')}</MenuItem>
       </Menu>
       <Dialog
         open={openDelete}

--- a/openbas-front/src/admin/components/payloads/Payloads.tsx
+++ b/openbas-front/src/admin/components/payloads/Payloads.tsx
@@ -23,6 +23,7 @@ import ItemTags from '../../../components/ItemTags';
 import PayloadIcon from '../../../components/PayloadIcon';
 import PlatformIcon from '../../../components/PlatformIcon';
 import { useHelper } from '../../../store';
+import { PayloadStatus } from '../../../utils/api-types';
 import { useAppDispatch } from '../../../utils/hooks';
 import useDataLoader from '../../../utils/hooks/useDataLoader';
 import CreatePayload from './CreatePayload';
@@ -108,6 +109,18 @@ const chipSx = {
   textTransform: 'uppercase',
   borderRadius: 1,
   width: 120,
+};
+
+const fromPayloadStatusToChipColor = (payloadStatus: PayloadStatus) => {
+  switch (payloadStatus) {
+    case 'VERIFIED':
+      return 'success';
+    case 'UNVERIFIED':
+      return 'warning';
+    case 'DEPRECATED':
+    default:
+      return 'default';
+  }
 };
 
 const Payloads = () => {
@@ -197,7 +210,7 @@ const Payloads = () => {
         <Chip
           variant="outlined"
           classes={{ root: classes.chipInList2 }}
-          color={payload.payload_status === 'VERIFIED' ? 'success' : 'warning'}
+          color={fromPayloadStatusToChipColor(payload.payload_status)}
           label={t(payload.payload_status ?? 'UNVERIFIED')}
         />
       ),
@@ -295,7 +308,8 @@ const Payloads = () => {
                     onUpdate={(result: PayloadStore) => setPayloads(payloads.map(a => (a.payload_id !== result.payload_id ? a : result)))}
                     onDuplicate={(result: PayloadStore) => setPayloads([result, ...payloads])}
                     onDelete={(result: string) => setPayloads(payloads.filter(a => (a.payload_id !== result)))}
-                    disabled={collector !== null}
+                    disableUpdate={collector !== null}
+                    disableDelete={collector !== null && payload.payload_status !== 'DEPRECATED'}
                   />
                 )}
                 disablePadding

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -939,6 +939,7 @@ const i18n = {
       'user_tags': 'Tags',
       'Unverified': 'Non vérifié',
       'Verified': 'Vérifié',
+      'Deprecated': 'Déprécié',
       'Recurrence': 'Récurrence',
       'Does not repeat': 'Ne se répète pas',
       'Daily': 'Quotidien',
@@ -1258,6 +1259,7 @@ const i18n = {
       'FILIGRAN': 'Filigran',
       'VERIFIED': 'Verified',
       'UNVERIFIED': 'Unverified',
+      'DEPRECATED': 'Deprecated',
       // ---Xls mapper
       'Create a xls mapper': 'Créer un mapper xls',
       'Mapper name': 'Nom du mapper',
@@ -2621,6 +2623,7 @@ const i18n = {
       'FILIGRAN': 'Filigran',
       'VERIFIED': '已验证',
       'UNVERIFIED': '未验证',
+      'DEPRECATED': '已弃用',
       // ---Xls mapper
       'Create a xls mapper': '创建xls映射',
       'Mapper name': '映射名称',
@@ -2899,6 +2902,7 @@ const i18n = {
       'FILIGRAN': 'Filigran',
       'VERIFIED': 'Verified',
       'UNVERIFIED': 'Unverified',
+      'DEPRECATED': 'Deprecated',
       // - XLS Mapper
       'Expectation_name': 'Expectation name',
       'Expectation_description': 'Expectation description',

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -2418,6 +2418,8 @@ export interface Pause {
   pause_exercise?: Exercise;
 }
 
+export type PayloadStatus =  "UNVERIFIED" | "VERIFIED" | "DEPRECATED";
+
 export interface Payload {
   listened?: boolean;
   payload_arguments?: PayloadArgument[];
@@ -2436,7 +2438,7 @@ export interface Payload {
   payload_platforms?: ("Linux" | "Windows" | "MacOS" | "Container" | "Service" | "Generic" | "Internal" | "Unknown")[];
   payload_prerequisites?: PayloadPrerequisite[];
   payload_source: "COMMUNITY" | "FILIGRAN" | "MANUAL";
-  payload_status: "UNVERIFIED" | "VERIFIED";
+  payload_status: PayloadStatus;
   /** @uniqueItems true */
   payload_tags?: Tag[];
   payload_type?: string;

--- a/openbas-model/src/main/java/io/openbas/database/model/Payload.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Payload.java
@@ -41,7 +41,8 @@ public class Payload implements Base {
 
   public enum PAYLOAD_STATUS {
     UNVERIFIED,
-    VERIFIED
+    VERIFIED,
+    DEPRECATED
   }
 
   @Id

--- a/openbas-model/src/main/java/io/openbas/database/repository/PayloadRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/PayloadRepository.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +21,18 @@ public interface PayloadRepository
   List<Payload> findByType(@Param("types") final List<String> types);
 
   Optional<Payload> findByExternalId(@NotNull String externalId);
+
+  @Query(
+      value = "SELECT payload_external_id FROM payloads WHERE payload_collector = :collectorId",
+      nativeQuery = true)
+  List<String> findAllExternalIdsByCollectorId(@NotNull @Param("collectorId") String collectorId);
+
+  @Modifying
+  @Query(
+      value =
+          "UPDATE payloads SET payload_status = :payloadStatus WHERE payload_external_id IN :payloadExternalIds",
+      nativeQuery = true)
+  void setPayloadStatusByExternalIds(
+      @Param("payloadStatus") String payloadStatus,
+      @Param("payloadExternalIds") List<String> payloadExternalIds);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Migration: Set payload source as `COMMUNITY` if from a collector, instead of `MANUAL`
- Migration: Set status as `DEPRECATED` when community payload was updated before the update of the collector (proposed interval: one week)
- Set a Payload as `DEPRECATED` when not processed by the Collector

### Related issues

* Closes https://github.com/OpenBAS-Platform/collectors/issues/46

### Related PRs
- https://github.com/OpenBAS-Platform/collectors/pull/52
- https://github.com/OpenBAS-Platform/client-python/pull/39

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
