### PR TITLE
Update pom.xml

### DIFF
--- a/openbas-api/pom.xml
+++ b/openbas-api/pom.xml
@@ -320,6 +320,7 @@
                     <apiDocsUrl>http://localhost:8080/api-docs</apiDocsUrl>
                     <outputFileName>swagger.json</outputFileName>
                     <outputDir>.</outputDir>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Skip springdoc-openapi-maven-plugin on mvn clean install.

This plugin throw an exception because the back-end is not start.
It can be play manually.