### PR TITLE
[backend] Build and save injectExpectations only when an inject is successfully executed (#1832)

### DIFF
--- a/openbas-api/src/main/java/io/openbas/helper/InjectHelper.java
+++ b/openbas-api/src/main/java/io/openbas/helper/InjectHelper.java
@@ -163,7 +163,7 @@ public class InjectHelper {
         .collect(Collectors.toList());
   }
 
-  public ExecutableInject getExecutableInject(Inject inject) {
+  public ExecutableInject getExecutableInjectForOpenBASImplantExecutor(Inject inject) {
     return new ExecutableInject(
         true,
         false,

--- a/openbas-api/src/main/java/io/openbas/helper/InjectHelper.java
+++ b/openbas-api/src/main/java/io/openbas/helper/InjectHelper.java
@@ -162,4 +162,15 @@ public class InjectHelper {
     return concat(concat(executableInjects, executableDryInjects), executableAtomicTests)
         .collect(Collectors.toList());
   }
+
+  public ExecutableInject getExecutableInject(Inject inject) {
+    return new ExecutableInject(
+        true,
+        false,
+        inject,
+        getInjectTeams(inject),
+        inject.getAssets(),
+        inject.getAssetGroups(),
+        usersFromInjection(inject));
+  }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/caldera/CalderaExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/caldera/CalderaExecutor.java
@@ -264,9 +264,10 @@ public class CalderaExecutor extends Injector {
         (assetGroup ->
             computeExpectationsForAssetGroup(
                 expectations, content, assetGroup, new ArrayList<>())));
+
     String message = "Caldera executed the ability on " + asyncIds.size() + " asset(s)";
     execution.addTrace(traceInfo(message, asyncIds));
-    return new ExecutionProcess(true, expectations);
+    return new ExecutionProcess(true);
   }
 
   @Override

--- a/openbas-api/src/main/java/io/openbas/injectors/caldera/CalderaExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/caldera/CalderaExecutor.java
@@ -19,6 +19,7 @@ import io.openbas.database.model.InjectExpectation.EXPECTATION_TYPE;
 import io.openbas.database.repository.InjectRepository;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.Injector;
+import io.openbas.inject_expectation.InjectExpectationService;
 import io.openbas.injectors.caldera.client.model.Ability;
 import io.openbas.injectors.caldera.client.model.Agent;
 import io.openbas.injectors.caldera.client.model.ExploitResult;
@@ -51,6 +52,7 @@ public class CalderaExecutor extends Injector {
   private final CalderaInjectorService calderaService;
   private final EndpointService endpointService;
   private final AssetGroupService assetGroupService;
+  private final InjectExpectationService injectExpectationService;
   private final InjectRepository injectRepository;
 
   @Override
@@ -267,7 +269,7 @@ public class CalderaExecutor extends Injector {
 
     String message = "Caldera executed the ability on " + asyncIds.size() + " asset(s)";
     execution.addTrace(traceInfo(message, asyncIds));
-    // TODO move expectations
+    injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
     return new ExecutionProcess(true);
   }
 

--- a/openbas-api/src/main/java/io/openbas/injectors/caldera/CalderaExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/caldera/CalderaExecutor.java
@@ -267,6 +267,7 @@ public class CalderaExecutor extends Injector {
 
     String message = "Caldera executed the ability on " + asyncIds.size() + " asset(s)";
     execution.addTrace(traceInfo(message, asyncIds));
+    // TODO move expectations
     return new ExecutionProcess(true);
   }
 

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
@@ -11,6 +11,7 @@ import io.openbas.database.repository.ChallengeRepository;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.ExecutionContext;
 import io.openbas.execution.Injector;
+import io.openbas.inject_expectation.InjectExpectationUtils;
 import io.openbas.injectors.challenge.model.ChallengeContent;
 import io.openbas.injectors.challenge.model.ChallengeVariable;
 import io.openbas.injectors.email.service.EmailService;
@@ -147,6 +148,7 @@ public class ChallengeExecutor extends Injector {
                           })
                   .toList());
         }
+        InjectExpectationUtils.extractedExpectations(injection, expectations);
         return new ExecutionProcess(false);
       } else {
         throw new UnsupportedOperationException("Unknown contract " + contract);

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
@@ -11,7 +11,7 @@ import io.openbas.database.repository.ChallengeRepository;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.ExecutionContext;
 import io.openbas.execution.Injector;
-import io.openbas.inject_expectation.InjectExpectationUtils;
+import io.openbas.inject_expectation.InjectExpectationService;
 import io.openbas.injectors.challenge.model.ChallengeContent;
 import io.openbas.injectors.challenge.model.ChallengeVariable;
 import io.openbas.injectors.email.service.EmailService;
@@ -38,6 +38,8 @@ public class ChallengeExecutor extends Injector {
 
   private EmailService emailService;
 
+  private InjectExpectationService injectExpectationService;
+
   @Value("${openbas.mail.imap.enabled}")
   private boolean imapEnabled;
 
@@ -49,6 +51,11 @@ public class ChallengeExecutor extends Injector {
   @Autowired
   public void setEmailService(EmailService emailService) {
     this.emailService = emailService;
+  }
+
+  @Autowired
+  public void setInjectExpectationService(InjectExpectationService injectExpectationService) {
+    this.injectExpectationService = injectExpectationService;
   }
 
   private String buildChallengeUri(
@@ -148,7 +155,9 @@ public class ChallengeExecutor extends Injector {
                           })
                   .toList());
         }
-        InjectExpectationUtils.extractedExpectations(injection, expectations);
+
+        injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
+
         return new ExecutionProcess(false);
       } else {
         throw new UnsupportedOperationException("Unknown contract " + contract);

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
@@ -25,38 +25,22 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component(ChallengeContract.TYPE)
+@RequiredArgsConstructor
 public class ChallengeExecutor extends Injector {
 
   @Resource private OpenBASConfig openBASConfig;
 
-  private ChallengeRepository challengeRepository;
-
-  private EmailService emailService;
-
-  private InjectExpectationService injectExpectationService;
+  private final ChallengeRepository challengeRepository;
+  private final EmailService emailService;
+  private final InjectExpectationService injectExpectationService;
 
   @Value("${openbas.mail.imap.enabled}")
   private boolean imapEnabled;
-
-  @Autowired
-  public void setChallengeRepository(ChallengeRepository challengeRepository) {
-    this.challengeRepository = challengeRepository;
-  }
-
-  @Autowired
-  public void setEmailService(EmailService emailService) {
-    this.emailService = emailService;
-  }
-
-  @Autowired
-  public void setInjectExpectationService(InjectExpectationService injectExpectationService) {
-    this.injectExpectationService = injectExpectationService;
-  }
 
   private String buildChallengeUri(
       ExecutionContext context, Exercise exercise, Challenge challenge) {

--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
@@ -147,13 +147,13 @@ public class ChallengeExecutor extends Injector {
                           })
                   .toList());
         }
-        return new ExecutionProcess(false, expectations);
+        return new ExecutionProcess(false);
       } else {
         throw new UnsupportedOperationException("Unknown contract " + contract);
       }
     } catch (Exception e) {
       execution.addTrace(traceError(e.getMessage()));
     }
-    return new ExecutionProcess(false, List.of());
+    return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
@@ -153,13 +153,13 @@ public class ChannelExecutor extends Injector {
                           })
                   .toList());
         }
-        return new ExecutionProcess(false, expectations);
+        return new ExecutionProcess(false);
       } else {
         throw new UnsupportedOperationException("Unknown contract " + contract);
       }
     } catch (Exception e) {
       execution.addTrace(traceError(e.getMessage()));
     }
-    return new ExecutionProcess(false, List.of());
+    return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
@@ -11,7 +11,7 @@ import io.openbas.database.repository.ArticleRepository;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.ExecutionContext;
 import io.openbas.execution.Injector;
-import io.openbas.inject_expectation.InjectExpectationUtils;
+import io.openbas.inject_expectation.InjectExpectationService;
 import io.openbas.injectors.channel.model.ArticleVariable;
 import io.openbas.injectors.channel.model.ChannelContent;
 import io.openbas.injectors.email.service.EmailService;
@@ -41,6 +41,7 @@ public class ChannelExecutor extends Injector {
   private ArticleRepository articleRepository;
 
   private EmailService emailService;
+  private InjectExpectationService injectExpectationService;
 
   @Value("${openbas.mail.imap.enabled}")
   private boolean imapEnabled;
@@ -53,6 +54,11 @@ public class ChannelExecutor extends Injector {
   @Autowired
   public void setEmailService(EmailService emailService) {
     this.emailService = emailService;
+  }
+
+  @Autowired
+  public void setInjectExpectationService(InjectExpectationService injectExpectationService) {
+    this.injectExpectationService = injectExpectationService;
   }
 
   private String buildArticleUri(ExecutionContext context, Article article) {
@@ -154,7 +160,9 @@ public class ChannelExecutor extends Injector {
                           })
                   .toList());
         }
-        InjectExpectationUtils.extractedExpectations(injection, expectations);
+
+        injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
+
         return new ExecutionProcess(false);
       } else {
         throw new UnsupportedOperationException("Unknown contract " + contract);

--- a/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
@@ -25,41 +25,24 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component(ChannelContract.TYPE)
+@RequiredArgsConstructor
 public class ChannelExecutor extends Injector {
 
   public static final String VARIABLE_ARTICLES = "articles";
-
   public static final String VARIABLE_ARTICLE = "article";
 
   @Resource private OpenBASConfig openBASConfig;
-
-  private ArticleRepository articleRepository;
-
-  private EmailService emailService;
-  private InjectExpectationService injectExpectationService;
+  private final ArticleRepository articleRepository;
+  private final EmailService emailService;
+  private final InjectExpectationService injectExpectationService;
 
   @Value("${openbas.mail.imap.enabled}")
   private boolean imapEnabled;
-
-  @Autowired
-  public void setArticleRepository(ArticleRepository articleRepository) {
-    this.articleRepository = articleRepository;
-  }
-
-  @Autowired
-  public void setEmailService(EmailService emailService) {
-    this.emailService = emailService;
-  }
-
-  @Autowired
-  public void setInjectExpectationService(InjectExpectationService injectExpectationService) {
-    this.injectExpectationService = injectExpectationService;
-  }
 
   private String buildArticleUri(ExecutionContext context, Article article) {
     String userId = context.getUser().getId();

--- a/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
@@ -11,6 +11,7 @@ import io.openbas.database.repository.ArticleRepository;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.ExecutionContext;
 import io.openbas.execution.Injector;
+import io.openbas.inject_expectation.InjectExpectationUtils;
 import io.openbas.injectors.channel.model.ArticleVariable;
 import io.openbas.injectors.channel.model.ChannelContent;
 import io.openbas.injectors.email.service.EmailService;
@@ -153,6 +154,7 @@ public class ChannelExecutor extends Injector {
                           })
                   .toList());
         }
+        InjectExpectationUtils.extractedExpectations(injection, expectations);
         return new ExecutionProcess(false);
       } else {
         throw new UnsupportedOperationException("Unknown contract " + contract);

--- a/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
@@ -8,6 +8,7 @@ import io.openbas.database.model.*;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.ExecutionContext;
 import io.openbas.execution.Injector;
+import io.openbas.inject_expectation.InjectExpectationUtils;
 import io.openbas.injectors.email.model.EmailContent;
 import io.openbas.injectors.email.service.EmailService;
 import io.openbas.model.ExecutionProcess;
@@ -135,6 +136,7 @@ public class EmailExecutor extends Injector {
                       default -> Stream.of();
                     })
             .toList();
+    InjectExpectationUtils.extractedExpectations(injection, expectations);
     return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
@@ -18,30 +18,20 @@ import jakarta.annotation.Resource;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.stream.Stream;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component(EmailContract.TYPE)
+@RequiredArgsConstructor
 public class EmailExecutor extends Injector {
 
   @Resource private OpenBASConfig openBASConfig;
-
-  private EmailService emailService;
-  private InjectExpectationService injectExpectationService;
+  private final EmailService emailService;
+  private final InjectExpectationService injectExpectationService;
 
   @Value("${openbas.mail.imap.enabled}")
   private boolean imapEnabled;
-
-  @Autowired
-  public void setEmailService(EmailService emailService) {
-    this.emailService = emailService;
-  }
-
-  @Autowired
-  public void setInjectExpectationService(InjectExpectationService injectExpectationService) {
-    this.injectExpectationService = injectExpectationService;
-  }
 
   private void sendMulti(
       Execution execution,

--- a/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
@@ -8,7 +8,7 @@ import io.openbas.database.model.*;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.ExecutionContext;
 import io.openbas.execution.Injector;
-import io.openbas.inject_expectation.InjectExpectationUtils;
+import io.openbas.inject_expectation.InjectExpectationService;
 import io.openbas.injectors.email.model.EmailContent;
 import io.openbas.injectors.email.service.EmailService;
 import io.openbas.model.ExecutionProcess;
@@ -28,6 +28,7 @@ public class EmailExecutor extends Injector {
   @Resource private OpenBASConfig openBASConfig;
 
   private EmailService emailService;
+  private InjectExpectationService injectExpectationService;
 
   @Value("${openbas.mail.imap.enabled}")
   private boolean imapEnabled;
@@ -35,6 +36,11 @@ public class EmailExecutor extends Injector {
   @Autowired
   public void setEmailService(EmailService emailService) {
     this.emailService = emailService;
+  }
+
+  @Autowired
+  public void setInjectExpectationService(InjectExpectationService injectExpectationService) {
+    this.injectExpectationService = injectExpectationService;
   }
 
   private void sendMulti(
@@ -136,7 +142,9 @@ public class EmailExecutor extends Injector {
                       default -> Stream.of();
                     })
             .toList();
-    InjectExpectationUtils.extractedExpectations(injection, expectations);
+
+    injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
+
     return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
@@ -135,6 +135,6 @@ public class EmailExecutor extends Injector {
                       default -> Stream.of();
                     })
             .toList();
-    return new ExecutionProcess(false, expectations);
+    return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/lade/LadeExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/lade/LadeExecutor.java
@@ -50,6 +50,6 @@ public class LadeExecutor extends Injector {
     } catch (Exception e) {
       execution.addTrace(traceError(e.getMessage()));
     }
-    return new ExecutionProcess(true, List.of());
+    return new ExecutionProcess(true);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/mastodon/MastodonExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/mastodon/MastodonExecutor.java
@@ -41,6 +41,6 @@ public class MastodonExecutor extends Injector {
     } catch (Exception e) {
       execution.addTrace(traceError(e.getMessage()));
     }
-    return new ExecutionProcess(false, List.of());
+    return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/openbas/OpenBASImplantExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/openbas/OpenBASImplantExecutor.java
@@ -1,28 +1,15 @@
 package io.openbas.injectors.openbas;
 
-import static io.openbas.database.model.InjectExpectationSignature.*;
 import static io.openbas.database.model.InjectStatusExecution.traceError;
-import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAsset;
-import static io.openbas.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
-import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAsset;
-import static io.openbas.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
-import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAsset;
-import static io.openbas.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
 
 import io.openbas.asset.AssetGroupService;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.InjectRepository;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.Injector;
-import io.openbas.injectors.openbas.model.OpenBASImplantInjectContent;
 import io.openbas.model.ExecutionProcess;
-import io.openbas.model.Expectation;
-import io.openbas.model.expectation.DetectionExpectation;
-import io.openbas.model.expectation.ManualExpectation;
-import io.openbas.model.expectation.PreventionExpectation;
-import jakarta.validation.constraints.NotNull;
-import java.util.*;
-import java.util.stream.Stream;
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.stereotype.Component;
@@ -35,197 +22,13 @@ public class OpenBASImplantExecutor extends Injector {
   private final AssetGroupService assetGroupService;
   private final InjectRepository injectRepository;
 
-  private Map<Asset, Boolean> resolveAllAssets(@NotNull final ExecutableInject inject) {
-    Map<Asset, Boolean> assets = new HashMap<>();
-    inject
-        .getAssets()
-        .forEach(
-            (asset -> {
-              assets.put(asset, false);
-            }));
-    inject
-        .getAssetGroups()
-        .forEach(
-            (assetGroup -> {
-              List<Asset> assetsFromGroup =
-                  this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-              // Verify asset validity
-              assetsFromGroup.forEach(
-                  (asset) -> {
-                    assets.put(asset, true);
-                  });
-            }));
-    return assets;
-  }
-
-  /** In case of direct asset, we have an individual expectation for the asset */
-  private void computeExpectationsForAsset(
-      @NotNull final List<Expectation> expectations,
-      @NotNull final OpenBASImplantInjectContent content,
-      @NotNull final Asset asset,
-      final boolean expectationGroup,
-      final List<InjectExpectationSignature> injectExpectationSignatures) {
-    if (!content.getExpectations().isEmpty()) {
-      expectations.addAll(
-          content.getExpectations().stream()
-              .flatMap(
-                  (expectation) ->
-                      switch (expectation.getType()) {
-                        case PREVENTION ->
-                            Stream.of(
-                                preventionExpectationForAsset(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    asset,
-                                    expectationGroup,
-                                    expectation.getExpirationTime(),
-                                    injectExpectationSignatures)); // expectationGroup usefully in
-                        // front-end
-                        case DETECTION ->
-                            Stream.of(
-                                detectionExpectationForAsset(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    asset,
-                                    expectationGroup,
-                                    expectation.getExpirationTime(),
-                                    injectExpectationSignatures));
-                        case MANUAL ->
-                            Stream.of(
-                                manualExpectationForAsset(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    asset,
-                                    expectation.getExpirationTime(),
-                                    expectationGroup));
-                        default -> Stream.of();
-                      })
-              .toList());
-    }
-  }
-
-  /**
-   * In case of asset group if expectation group -> we have an expectation for the group and one for
-   * each asset if not expectation group -> we have an individual expectation for each asset
-   */
-  private void computeExpectationsForAssetGroup(
-      @NotNull final List<Expectation> expectations,
-      @NotNull final OpenBASImplantInjectContent content,
-      @NotNull final AssetGroup assetGroup,
-      final List<InjectExpectationSignature> injectExpectationSignatures) {
-    if (!content.getExpectations().isEmpty()) {
-      expectations.addAll(
-          content.getExpectations().stream()
-              .flatMap(
-                  (expectation) ->
-                      switch (expectation.getType()) {
-                        case PREVENTION -> {
-                          // Verify that at least one asset in the group has been executed
-                          List<Asset> assets =
-                              this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                          if (assets.stream()
-                              .anyMatch(
-                                  (asset) ->
-                                      expectations.stream()
-                                          .filter(
-                                              e ->
-                                                  InjectExpectation.EXPECTATION_TYPE.PREVENTION
-                                                      == e.type())
-                                          .anyMatch(
-                                              (e) ->
-                                                  ((PreventionExpectation) e).getAsset() != null
-                                                      && ((PreventionExpectation) e)
-                                                          .getAsset()
-                                                          .getId()
-                                                          .equals(asset.getId())))) {
-                            yield Stream.of(
-                                preventionExpectationForAssetGroup(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    assetGroup,
-                                    expectation.isExpectationGroup(),
-                                    expectation.getExpirationTime(),
-                                    injectExpectationSignatures));
-                          }
-                          yield Stream.of();
-                        }
-                        case DETECTION -> {
-                          // Verify that at least one asset in the group has been executed
-                          List<Asset> assets =
-                              this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                          if (assets.stream()
-                              .anyMatch(
-                                  (asset) ->
-                                      expectations.stream()
-                                          .filter(
-                                              e ->
-                                                  InjectExpectation.EXPECTATION_TYPE.DETECTION
-                                                      == e.type())
-                                          .anyMatch(
-                                              (e) ->
-                                                  ((DetectionExpectation) e).getAsset() != null
-                                                      && ((DetectionExpectation) e)
-                                                          .getAsset()
-                                                          .getId()
-                                                          .equals(asset.getId())))) {
-                            yield Stream.of(
-                                detectionExpectationForAssetGroup(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    assetGroup,
-                                    expectation.isExpectationGroup(),
-                                    expectation.getExpirationTime(),
-                                    injectExpectationSignatures));
-                          }
-                          yield Stream.of();
-                        }
-                        case MANUAL -> {
-                          // Verify that at least one asset in the group has been executed
-                          List<Asset> assets =
-                              this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                          if (assets.stream()
-                              .anyMatch(
-                                  (asset) ->
-                                      expectations.stream()
-                                          .filter(
-                                              e ->
-                                                  InjectExpectation.EXPECTATION_TYPE.MANUAL
-                                                      == e.type())
-                                          .anyMatch(
-                                              (e) ->
-                                                  ((ManualExpectation) e).getAsset() != null
-                                                      && ((ManualExpectation) e)
-                                                          .getAsset()
-                                                          .getId()
-                                                          .equals(asset.getId())))) {
-                            yield Stream.of(
-                                manualExpectationForAssetGroup(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    assetGroup,
-                                    expectation.getExpirationTime(),
-                                    expectation.isExpectationGroup()));
-                          }
-                          yield Stream.of();
-                        }
-                        default -> Stream.of();
-                      })
-              .toList());
-    }
-  }
-
   @Override
   public ExecutionProcess process(Execution execution, ExecutableInject injection)
       throws Exception {
     Inject inject =
         this.injectRepository.findById(injection.getInjection().getInject().getId()).orElseThrow();
-    Map<Asset, Boolean> assets = this.resolveAllAssets(injection);
+    Map<Asset, Boolean> assets =
+        assetGroupService.resolveAllAssets(injection.getInjection().getInject());
 
     // Check assets target
     if (assets.isEmpty()) {
@@ -234,15 +37,9 @@ public class OpenBASImplantExecutor extends Injector {
               "Found 0 asset to execute the ability on (likely this inject does not have any target or the targeted asset is inactive and has been purged)"));
     }
 
-    // Compute expectations
-    OpenBASImplantInjectContent content =
-        contentConvert(injection, OpenBASImplantInjectContent.class);
-
-    List<Expectation> expectations = new ArrayList<>();
     assets.forEach(
         (asset, isInGroup) -> {
           Optional<InjectorContract> contract = inject.getInjectorContract();
-          List<InjectExpectationSignature> injectExpectationSignatures = new ArrayList<>();
 
           if (contract.isPresent()) {
             Payload payload = contract.get().getPayload();
@@ -251,45 +48,13 @@ public class OpenBASImplantExecutor extends Injector {
                   String.format("No payload for inject %s was found, skipping", inject.getId()));
               return;
             }
-            injectExpectationSignatures = spawnSignatures(inject, payload);
             execution.setExpectedCount(
                 payload.getPrerequisites().size()
                     + (payload.getCleanupCommand() != null ? 1 : 0)
                     + payload.getNumberOfActions());
           }
-          computeExpectationsForAsset(
-              expectations, content, asset, isInGroup, injectExpectationSignatures);
         });
 
-    List<AssetGroup> assetGroups = injection.getAssetGroups();
-    assetGroups.forEach(
-        (assetGroup ->
-            computeExpectationsForAssetGroup(
-                expectations, content, assetGroup, new ArrayList<>())));
     return new ExecutionProcess(true);
-  }
-
-  private List<InjectExpectationSignature> spawnSignatures(Inject inject, Payload payload) {
-    List<InjectExpectationSignature> signatures = new ArrayList<>();
-    List<String> knownPayloadTypes =
-        Arrays.asList("Command", "Executable", "FileDrop", "DnsResolution");
-
-    /*
-     * Always add the "Parent process" signature type for the OpenBAS Implant Executor
-     */
-    signatures.add(
-        createSignature(
-            EXPECTATION_SIGNATURE_TYPE_PARENT_PROCESS_NAME, "obas-implant-" + inject.getId()));
-
-    if (!knownPayloadTypes.contains(payload.getType())) {
-      throw new UnsupportedOperationException(
-          "Payload type " + payload.getType() + " is not supported");
-    }
-    return signatures;
-  }
-
-  private static InjectExpectationSignature createSignature(
-      String signatureType, String signatureValue) {
-    return InjectExpectationSignature.builder().type(signatureType).value(signatureValue).build();
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/openbas/OpenBASImplantExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/openbas/OpenBASImplantExecutor.java
@@ -266,7 +266,7 @@ public class OpenBASImplantExecutor extends Injector {
         (assetGroup ->
             computeExpectationsForAssetGroup(
                 expectations, content, assetGroup, new ArrayList<>())));
-    return new ExecutionProcess(true, expectations);
+    return new ExecutionProcess(true);
   }
 
   private List<InjectExpectationSignature> spawnSignatures(Inject inject, Payload payload) {

--- a/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
@@ -79,6 +79,6 @@ public class OpenCTIExecutor extends Injector {
                       default -> Stream.of();
                     })
             .toList();
-    return new ExecutionProcess(false, expectations);
+    return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
@@ -15,24 +15,15 @@ import io.openbas.model.expectation.ManualExpectation;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.stream.Stream;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component(OpenCTIContract.TYPE)
+@RequiredArgsConstructor
 public class OpenCTIExecutor extends Injector {
 
-  private OpenCTIService openCTIService;
-  private InjectExpectationService injectExpectationService;
-
-  @Autowired
-  public void setOpenCTIService(OpenCTIService openCTIService) {
-    this.openCTIService = openCTIService;
-  }
-
-  @Autowired
-  public void setInjectExpectationService(InjectExpectationService injectExpectationService) {
-    this.injectExpectationService = injectExpectationService;
-  }
+  private final OpenCTIService openCTIService;
+  private final InjectExpectationService injectExpectationService;
 
   private void createCase(
       Execution execution, String name, String description, List<DataAttachment> attachments) {

--- a/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
@@ -6,7 +6,7 @@ import static io.openbas.injectors.opencti.OpenCTIContract.OPENCTI_CREATE_CASE;
 import io.openbas.database.model.*;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.Injector;
-import io.openbas.inject_expectation.InjectExpectationUtils;
+import io.openbas.inject_expectation.InjectExpectationService;
 import io.openbas.injectors.opencti.model.CaseContent;
 import io.openbas.injectors.opencti.service.OpenCTIService;
 import io.openbas.model.ExecutionProcess;
@@ -22,10 +22,16 @@ import org.springframework.stereotype.Component;
 public class OpenCTIExecutor extends Injector {
 
   private OpenCTIService openCTIService;
+  private InjectExpectationService injectExpectationService;
 
   @Autowired
   public void setOpenCTIService(OpenCTIService openCTIService) {
     this.openCTIService = openCTIService;
+  }
+
+  @Autowired
+  public void setInjectExpectationService(InjectExpectationService injectExpectationService) {
+    this.injectExpectationService = injectExpectationService;
   }
 
   private void createCase(
@@ -80,7 +86,9 @@ public class OpenCTIExecutor extends Injector {
                       default -> Stream.of();
                     })
             .toList();
-    InjectExpectationUtils.extractedExpectations(injection, expectations);
+
+    injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
+
     return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/opencti/OpenCTIExecutor.java
@@ -6,6 +6,7 @@ import static io.openbas.injectors.opencti.OpenCTIContract.OPENCTI_CREATE_CASE;
 import io.openbas.database.model.*;
 import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.Injector;
+import io.openbas.inject_expectation.InjectExpectationUtils;
 import io.openbas.injectors.opencti.model.CaseContent;
 import io.openbas.injectors.opencti.service.OpenCTIService;
 import io.openbas.model.ExecutionProcess;
@@ -79,6 +80,7 @@ public class OpenCTIExecutor extends Injector {
                       default -> Stream.of();
                     })
             .toList();
+    InjectExpectationUtils.extractedExpectations(injection, expectations);
     return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
@@ -95,8 +95,8 @@ public class OvhSmsExecutor extends Injector {
                         default -> Stream.of();
                       })
               .toList();
-      return new ExecutionProcess(false, expectations);
+      return new ExecutionProcess(false);
     }
-    return new ExecutionProcess(false, Collections.emptyList());
+    return new ExecutionProcess(false);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
@@ -10,7 +10,7 @@ import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.ExecutionContext;
 import io.openbas.execution.Injector;
 import io.openbas.execution.ProtectUser;
-import io.openbas.inject_expectation.InjectExpectationUtils;
+import io.openbas.inject_expectation.InjectExpectationService;
 import io.openbas.injectors.ovh.model.OvhSmsContent;
 import io.openbas.injectors.ovh.service.OvhSmsService;
 import io.openbas.model.ExecutionProcess;
@@ -31,6 +31,7 @@ import org.springframework.util.StringUtils;
 public class OvhSmsExecutor extends Injector {
 
   private final OvhSmsService smsService;
+  private final InjectExpectationService injectExpectationService;
 
   @Override
   public ExecutionProcess process(
@@ -95,7 +96,9 @@ public class OvhSmsExecutor extends Injector {
                         default -> Stream.of();
                       })
               .toList();
-      InjectExpectationUtils.extractedExpectations(injection, expectations);
+
+      injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
+
       return new ExecutionProcess(false);
     }
     return new ExecutionProcess(false);

--- a/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
@@ -17,7 +17,6 @@ import io.openbas.model.ExecutionProcess;
 import io.openbas.model.Expectation;
 import io.openbas.model.expectation.ManualExpectation;
 import jakarta.validation.constraints.NotNull;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;

--- a/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/ovh/OvhSmsExecutor.java
@@ -10,6 +10,7 @@ import io.openbas.execution.ExecutableInject;
 import io.openbas.execution.ExecutionContext;
 import io.openbas.execution.Injector;
 import io.openbas.execution.ProtectUser;
+import io.openbas.inject_expectation.InjectExpectationUtils;
 import io.openbas.injectors.ovh.model.OvhSmsContent;
 import io.openbas.injectors.ovh.service.OvhSmsService;
 import io.openbas.model.ExecutionProcess;
@@ -95,6 +96,7 @@ public class OvhSmsExecutor extends Injector {
                         default -> Stream.of();
                       })
               .toList();
+      InjectExpectationUtils.extractedExpectations(injection, expectations);
       return new ExecutionProcess(false);
     }
     return new ExecutionProcess(false);

--- a/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
@@ -168,8 +168,8 @@ public class InjectApi extends RestBehavior {
         injectStatus.setName(ExecutionStatus.MAYBE_PARTIAL_PREVENTED);
       }
 
-      // If injectStatus was SUCCESS or PARTIAL, we build the expectation related to this inject
-      if (successCounter > 0) {
+      // If injectStatus was different from ERROR, we build the expectation related to this inject
+      if (ExecutionStatus.ERROR.equals(injectStatus.getName())) {
         List<Expectation> expectations = injectExpectationService.generateExpectations(inject);
         injectExpectationService.buildAndSaveInjectExpectations(
             injectHelper.getExecutableInjectForOpenBASImplantExecutor(inject), expectations);

--- a/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
@@ -168,8 +168,9 @@ public class InjectApi extends RestBehavior {
         injectStatus.setName(ExecutionStatus.MAYBE_PARTIAL_PREVENTED);
       }
 
-      // If injectStatus was different from ERROR, we build the expectation related to this inject
-      if (ExecutionStatus.ERROR.equals(injectStatus.getName())) {
+      // If the injectStatus is different from ERROR, we build the expectations related to this
+      // inject
+      if (!ExecutionStatus.ERROR.equals(injectStatus.getName())) {
         List<Expectation> expectations = injectExpectationService.generateExpectations(inject);
         injectExpectationService.buildAndSaveInjectExpectations(
             injectHelper.getExecutableInjectForOpenBASImplantExecutor(inject), expectations);

--- a/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
@@ -158,9 +158,6 @@ public class InjectApi extends RestBehavior {
 
       if (successCounter >= injectStatus.getTrackingTotalCount()) {
         injectStatus.setName(ExecutionStatus.SUCCESS);
-        List<Expectation> expectations = injectExpectationService.generateExpectations(inject);
-        injectExpectationService.buildAndSaveInjectExpectations(
-            injectHelper.getExecutableInject(inject), expectations);
       } else if (successCounter > 0) {
         injectStatus.setName(ExecutionStatus.PARTIAL);
       } else if (errorCounter >= injectStatus.getTrackingTotalCount()) {
@@ -169,6 +166,13 @@ public class InjectApi extends RestBehavior {
         injectStatus.setName(ExecutionStatus.MAYBE_PREVENTED);
       } else {
         injectStatus.setName(ExecutionStatus.MAYBE_PARTIAL_PREVENTED);
+      }
+
+      // If injectStatus was SUCCESS or PARTIAL, we build the expectation related to this inject
+      if (successCounter > 0) {
+        List<Expectation> expectations = injectExpectationService.generateExpectations(inject);
+        injectExpectationService.buildAndSaveInjectExpectations(
+            injectHelper.getExecutableInjectForOpenBASImplantExecutor(inject), expectations);
       }
     }
     return injectRepository.save(inject);

--- a/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
@@ -130,7 +130,7 @@ public class InjectApi extends RestBehavior {
     if (ExecutionTraceStatus.SUCCESS.equals(executionStatus)) {
       injectStatus.setTrackingTotalSuccess(injectStatus.getTrackingTotalSuccess() + 1);
     } else {
-      injectStatus.setTrackingTotalError(injectStatus.getTrackingTotalSuccess() + 1);
+      injectStatus.setTrackingTotalError(injectStatus.getTrackingTotalError() + 1);
     }
 
     int currentTotal =

--- a/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
@@ -158,6 +158,9 @@ public class InjectApi extends RestBehavior {
 
       if (successCounter >= injectStatus.getTrackingTotalCount()) {
         injectStatus.setName(ExecutionStatus.SUCCESS);
+        List<Expectation> expectations = injectExpectationService.generateExpectations(inject);
+        injectExpectationService.buildAndSaveInjectExpectations(
+            injectHelper.getExecutableInject(inject), expectations);
       } else if (successCounter > 0) {
         injectStatus.setName(ExecutionStatus.PARTIAL);
       } else if (errorCounter >= injectStatus.getTrackingTotalCount()) {
@@ -166,13 +169,6 @@ public class InjectApi extends RestBehavior {
         injectStatus.setName(ExecutionStatus.MAYBE_PREVENTED);
       } else {
         injectStatus.setName(ExecutionStatus.MAYBE_PARTIAL_PREVENTED);
-      }
-
-      // If injectStatus was SUCCESS or PARTIAL, we build the expectation related to this inject
-      if (successCounter > 0) {
-        List<Expectation> expectations = injectExpectationService.generateExpectations(inject);
-        injectExpectationService.buildAndSaveInjectExpectations(
-            injectHelper.getExecutableInject(inject), expectations);
       }
     }
     return injectRepository.save(inject);

--- a/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
@@ -538,7 +538,10 @@ public class AtomicTestingUtils {
   }
 
   public static OptionalDouble calculateAverageFromExpectations(final List<Double> scores) {
-    return scores.stream().filter(Objects::nonNull).mapToDouble(Double::doubleValue).average(); //Null values are expectations for injects in Pending
+    return scores.stream()
+        .filter(Objects::nonNull)
+        .mapToDouble(Double::doubleValue)
+        .average(); // Null values are expectations for injects in Pending
   }
 
   public static List<ResultDistribution> getResultDetail(

--- a/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
@@ -538,7 +538,7 @@ public class AtomicTestingUtils {
   }
 
   public static OptionalDouble calculateAverageFromExpectations(final List<Double> scores) {
-    return scores.stream().filter(Objects::nonNull).mapToDouble(Double::doubleValue).average();
+    return scores.stream().filter(Objects::nonNull).mapToDouble(Double::doubleValue).average(); //Null values are expectations for injects in Pending
   }
 
   public static List<ResultDistribution> getResultDetail(

--- a/openbas-api/src/test/java/io/openbas/injects/email/EmailExecutorTest.java
+++ b/openbas-api/src/test/java/io/openbas/injects/email/EmailExecutorTest.java
@@ -3,13 +3,13 @@ package io.openbas.injects.email;
 import static io.openbas.helper.StreamHelper.fromIterable;
 import static io.openbas.injectors.email.EmailContract.EMAIL_DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openbas.database.model.Execution;
 import io.openbas.database.model.Inject;
 import io.openbas.database.model.InjectExpectation;
 import io.openbas.database.model.User;
+import io.openbas.database.repository.InjectExpectationRepository;
 import io.openbas.database.repository.InjectorContractRepository;
 import io.openbas.database.repository.UserRepository;
 import io.openbas.execution.ExecutableInject;
@@ -17,9 +17,9 @@ import io.openbas.execution.ExecutionContext;
 import io.openbas.execution.ExecutionContextService;
 import io.openbas.injectors.email.EmailExecutor;
 import io.openbas.injectors.email.model.EmailContent;
-import io.openbas.model.ExecutionProcess;
 import io.openbas.model.inject.form.Expectation;
 import jakarta.annotation.Resource;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +31,7 @@ public class EmailExecutorTest {
   @Autowired private EmailExecutor emailExecutor;
   @Autowired private UserRepository userRepository;
   @Autowired private InjectorContractRepository injectorContractRepository;
+  @Autowired private InjectExpectationRepository injectExpectationRepository;
   @Autowired private ExecutionContextService executionContextService;
   @Resource protected ObjectMapper mapper;
 
@@ -61,10 +62,10 @@ public class EmailExecutorTest {
     Execution execution = new Execution(executableInject.isRuntime());
 
     // -- EXECUTE --
-    ExecutionProcess executionProcess = this.emailExecutor.process(execution, executableInject);
+    emailExecutor.process(execution, executableInject);
 
     // -- ASSERT --
-    assertNotNull(executionProcess.getExpectations());
-    assertEquals(10, executionProcess.getExpectations().get(0).getScore());
+    // No injectExpectation should be created.
+    assertEquals(Collections.emptyList(), injectExpectationRepository.findAll());
   }
 }

--- a/openbas-api/src/test/java/io/openbas/rest/InjectApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/InjectApiTest.java
@@ -640,9 +640,9 @@ class InjectApiTest extends IntegrationTest {
 
     InjectStatus injectStatus = new InjectStatus();
     injectStatus.setTrackingSentDate(Instant.now());
-    injectStatus.setTrackingTotalSuccess(1);
+    injectStatus.setTrackingTotalSuccess(0);
     injectStatus.setTrackingTotalError(0);
-    injectStatus.setTrackingTotalCount(2);
+    injectStatus.setTrackingTotalCount(1);
     injectStatus.setName(ExecutionStatus.QUEUING);
     injectStatus.setInject(injectCreated);
     injectStatusRepository.save(injectStatus);
@@ -683,7 +683,7 @@ class InjectApiTest extends IntegrationTest {
     InjectStatus injectStatus = new InjectStatus();
     injectStatus.setTrackingSentDate(Instant.now());
     injectStatus.setTrackingTotalSuccess(0);
-    injectStatus.setTrackingTotalError(1);
+    injectStatus.setTrackingTotalError(0);
     injectStatus.setTrackingTotalCount(1);
     injectStatus.setName(ExecutionStatus.QUEUING);
     injectStatus.setInject(injectCreated);

--- a/openbas-api/src/test/java/io/openbas/rest/InjectApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/InjectApiTest.java
@@ -633,7 +633,7 @@ class InjectApiTest extends IntegrationTest {
         this.injectorContractRepository.findById(CONTRACT_EXAMPLE).orElseThrow();
 
     Inject inject = new Inject();
-    inject.setTitle("Inject to be executed by agent Openbas");
+    inject.setTitle("Inject to be executed by Openbas Agent");
     inject.setInjectorContract(injectorContract);
     inject.setDependsDuration(0L);
     Inject injectCreated = injectRepository.save(inject);
@@ -660,7 +660,7 @@ class InjectApiTest extends IntegrationTest {
             .getContentAsString();
 
     // -- ASSERT --
-    assertEquals("PARTIAL", JsonPath.read(response, "$.inject_status.status_name"));
+    assertNotEquals("ERROR", JsonPath.read(response, "$.inject_status.status_name"));
     // We check if generateExpectations and buildAndSaveInjectExpectations are called
     verify(injectExpectationService).generateExpectations(inject);
     verify(injectExpectationService).buildAndSaveInjectExpectations(any(), any());
@@ -675,7 +675,7 @@ class InjectApiTest extends IntegrationTest {
         this.injectorContractRepository.findById(CONTRACT_EXAMPLE).orElseThrow();
 
     Inject inject = new Inject();
-    inject.setTitle("Inject to be executed by agent Openbas");
+    inject.setTitle("Inject to be executed by Openbas Agent");
     inject.setInjectorContract(injectorContract);
     inject.setDependsDuration(0L);
     Inject injectCreated = injectRepository.save(inject);

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectFixture.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openbas.database.model.Inject;
 import io.openbas.database.model.InjectorContract;
 import io.openbas.injectors.challenge.model.ChallengeContent;
+import io.openbas.rest.inject.form.InjectExecutionInput;
 import java.util.List;
 
 public class InjectFixture {
@@ -32,5 +33,14 @@ public class InjectFixture {
     content.setChallenges(challengeIds);
     inject.setContent(objectMapper.valueToTree(content));
     return inject;
+  }
+
+  public static InjectExecutionInput getInjectExecutionInput() {
+    InjectExecutionInput input = new InjectExecutionInput();
+    input.setMessage("Response from implant");
+    input.setStatus("SUCCESS");
+    input.setDuration(15);
+    input.setIdentifiers(List.of("obas-implant-test"));
+    return input;
   }
 }

--- a/openbas-framework/src/main/java/io/openbas/asset/AssetGroupService.java
+++ b/openbas-framework/src/main/java/io/openbas/asset/AssetGroupService.java
@@ -151,7 +151,7 @@ public class AssetGroupService {
                 }));
   }
 
-  // -- FOR OBAS IMPLANT --
+  // -- FOR OBAS IMPLANT EXECUTOR --
 
   public Map<Asset, Boolean> resolveAllAssets(@NotNull final Inject inject) {
     Map<Asset, Boolean> assets = new HashMap<>();

--- a/openbas-framework/src/main/java/io/openbas/asset/AssetGroupService.java
+++ b/openbas-framework/src/main/java/io/openbas/asset/AssetGroupService.java
@@ -9,10 +9,12 @@ import static java.time.Instant.now;
 import io.openbas.database.model.Asset;
 import io.openbas.database.model.AssetGroup;
 import io.openbas.database.model.Endpoint;
+import io.openbas.database.model.Inject;
 import io.openbas.database.raw.RawAssetGroup;
 import io.openbas.database.repository.AssetGroupRepository;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -128,7 +130,6 @@ public class AssetGroupService {
     return assetGroup;
   }
 
-  /** */
   public Map<String, List<Endpoint>> computeDynamicAssetFromRaw(
       @NotNull Set<RawAssetGroup> assetGroups) {
     if (assetGroups.isEmpty()) {
@@ -148,5 +149,29 @@ public class AssetGroupService {
                       .distinct()
                       .toList();
                 }));
+  }
+
+  // -- FOR OBAS IMPLANT --
+
+  public Map<Asset, Boolean> resolveAllAssets(@NotNull final Inject inject) {
+    Map<Asset, Boolean> assets = new HashMap<>();
+    inject
+        .getAssets()
+        .forEach(
+            (asset -> {
+              assets.put(asset, false);
+            }));
+    inject
+        .getAssetGroups()
+        .forEach(
+            (assetGroup -> {
+              List<Asset> assetsFromGroup = this.assetsFromAssetGroup(assetGroup.getId());
+              // Verify asset validity
+              assetsFromGroup.forEach(
+                  (asset) -> {
+                    assets.put(asset, true);
+                  });
+            }));
+    return assets;
   }
 }

--- a/openbas-framework/src/main/java/io/openbas/execution/Injector.java
+++ b/openbas-framework/src/main/java/io/openbas/execution/Injector.java
@@ -22,8 +22,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;

--- a/openbas-framework/src/main/java/io/openbas/execution/Injector.java
+++ b/openbas-framework/src/main/java/io/openbas/execution/Injector.java
@@ -137,7 +137,6 @@ public abstract class Injector {
     Execution execution = new Execution(executableInject.isRuntime());
     try {
       boolean isScheduledInject = !executableInject.isDirect();
-      boolean isAtomicTesting = executableInject.getInjection().getInject().isAtomicTesting();
       // If empty content, inject must be rejected
       if (executableInject.getInjection().getInject().getContent() == null) {
         throw new UnsupportedOperationException("Inject is empty");
@@ -149,112 +148,12 @@ public abstract class Injector {
       // Process the execution
       ExecutionProcess executionProcess = process(execution, executableInject);
       execution.setAsync(executionProcess.isAsync());
-      extractedExpectations(executableInject, executionProcess, isScheduledInject, isAtomicTesting);
     } catch (Exception e) {
       execution.addTrace(traceError(e.getMessage()));
     } finally {
       execution.stop();
     }
     return execution;
-  }
-
-  private void extractedExpectations(ExecutableInject executableInject, ExecutionProcess executionProcess,
-      boolean isScheduledInject, boolean isAtomicTesting) {
-    List<Expectation> expectations = executionProcess.getExpectations();
-    // Create the expectations
-    List<Team> teams = executableInject.getTeams();
-    List<Asset> assets = executableInject.getAssets();
-    List<AssetGroup> assetGroups = executableInject.getAssetGroups();
-    if ((isScheduledInject || isAtomicTesting) && !expectations.isEmpty()) {
-      if (!teams.isEmpty()) {
-        List<InjectExpectation> injectExpectationsByTeam;
-
-        List<InjectExpectation> injectExpectationsByUserAndTeam;
-        // If atomicTesting, We create expectation for every player and every team
-        if (isAtomicTesting) {
-          injectExpectationsByTeam =
-              teams.stream()
-                  .flatMap(
-                      team ->
-                          expectations.stream()
-                              .map(
-                                  expectation ->
-                                      expectationConverter(team, executableInject, expectation)))
-                  .collect(Collectors.toList());
-
-          injectExpectationsByUserAndTeam =
-              teams.stream()
-                  .flatMap(
-                      team ->
-                          team.getUsers().stream()
-                              .flatMap(
-                                  user ->
-                                      expectations.stream()
-                                          .map(
-                                              expectation ->
-                                                  expectationConverter(
-                                                      team,
-                                                      user,
-                                                      executableInject,
-                                                      expectation))))
-                  .toList();
-        } else {
-          // Create expectations for every enabled player in every team
-          injectExpectationsByUserAndTeam =
-              teams.stream()
-                  .flatMap(
-                      team ->
-                          team.getExerciseTeamUsers().stream()
-                              .filter(
-                                  exerciseTeamUser ->
-                                      exerciseTeamUser
-                                          .getExercise()
-                                          .getId()
-                                          .equals(
-                                              executableInject
-                                                  .getInjection()
-                                                  .getExercise()
-                                                  .getId()))
-                              .flatMap(
-                                  exerciseTeamUser ->
-                                      expectations.stream()
-                                          .map(
-                                              expectation ->
-                                                  expectationConverter(
-                                                      team,
-                                                      exerciseTeamUser.getUser(),
-                                                      executableInject,
-                                                      expectation))))
-                  .toList();
-
-          // Create a set of teams that have at least one enabled player
-          Set<Team> teamsWithEnabledPlayers =
-              injectExpectationsByUserAndTeam.stream()
-                  .map(InjectExpectation::getTeam)
-                  .collect(Collectors.toSet());
-
-          // Add only the expectations where the team has at least one enabled player
-          injectExpectationsByTeam =
-              teamsWithEnabledPlayers.stream()
-                  .flatMap(
-                      team ->
-                          expectations.stream()
-                              .map(
-                                  expectation ->
-                                      expectationConverter(team, executableInject, expectation)))
-                  .collect(Collectors.toList());
-        }
-
-        injectExpectationsByTeam.addAll(injectExpectationsByUserAndTeam);
-        this.injectExpectationRepository.saveAll(injectExpectationsByTeam);
-      } else if (!assets.isEmpty() || !assetGroups.isEmpty()) {
-        List<InjectExpectation> injectExpectations =
-            expectations.stream()
-                .map(expectation -> expectationConverter(executableInject, expectation))
-                .toList();
-        this.injectExpectationRepository.saveAll(injectExpectations);
-      }
-    }
   }
 
   public Execution executeInjection(ExecutableInject executableInject) {

--- a/openbas-framework/src/main/java/io/openbas/execution/Injector.java
+++ b/openbas-framework/src/main/java/io/openbas/execution/Injector.java
@@ -1,17 +1,12 @@
 package io.openbas.execution;
 
 import static io.openbas.database.model.InjectStatusExecution.traceError;
-import static io.openbas.expectation.ExpectationPropertiesConfig.DEFAULT_HUMAN_EXPECTATION_EXPIRATION_TIME;
-import static java.util.Optional.ofNullable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openbas.database.model.*;
-import io.openbas.database.model.InjectExpectation.EXPECTATION_TYPE;
 import io.openbas.database.repository.DocumentRepository;
-import io.openbas.database.repository.InjectExpectationRepository;
 import io.openbas.model.ExecutionProcess;
-import io.openbas.model.Expectation;
 import io.openbas.model.expectation.*;
 import io.openbas.service.FileService;
 import jakarta.annotation.Resource;
@@ -31,13 +26,6 @@ public abstract class Injector {
   @Resource protected ObjectMapper mapper;
   private FileService fileService;
   private DocumentRepository documentRepository;
-  private InjectExpectationRepository injectExpectationRepository;
-
-  @Autowired
-  public void setInjectExpectationRepository(
-      InjectExpectationRepository injectExpectationRepository) {
-    this.injectExpectationRepository = injectExpectationRepository;
-  }
 
   @Autowired
   public void setDocumentRepository(DocumentRepository documentRepository) {
@@ -54,80 +42,6 @@ public abstract class Injector {
 
   public InjectStatusCommandLine getCommandsLines(String externalId) {
     return null;
-  }
-
-  private InjectExpectation expectationConverter(
-      @NotNull final ExecutableInject executableInject, Expectation expectation) {
-    InjectExpectation expectationExecution = new InjectExpectation();
-    return this.expectationConverter(expectationExecution, executableInject, expectation);
-  }
-
-  private InjectExpectation expectationConverter(
-      @NotNull final Team team,
-      @NotNull final ExecutableInject executableInject,
-      Expectation expectation) {
-    InjectExpectation expectationExecution = new InjectExpectation();
-    expectationExecution.setTeam(team);
-    return this.expectationConverter(expectationExecution, executableInject, expectation);
-  }
-
-  private InjectExpectation expectationConverter(
-      @NotNull final Team team,
-      @NotNull final User user,
-      @NotNull final ExecutableInject executableInject,
-      Expectation expectation) {
-    InjectExpectation expectationExecution = new InjectExpectation();
-    expectationExecution.setTeam(team);
-    expectationExecution.setUser(user);
-    return this.expectationConverter(expectationExecution, executableInject, expectation);
-  }
-
-  private InjectExpectation expectationConverter(
-      @NotNull InjectExpectation expectationExecution,
-      @NotNull final ExecutableInject executableInject,
-      @NotNull final Expectation expectation) {
-    expectationExecution.setExercise(executableInject.getInjection().getExercise());
-    expectationExecution.setInject(executableInject.getInjection().getInject());
-    expectationExecution.setExpectedScore(expectation.getScore());
-    expectationExecution.setExpectationGroup(expectation.isExpectationGroup());
-    expectationExecution.setExpirationTime(
-        ofNullable(expectation.getExpirationTime())
-            .orElse(DEFAULT_HUMAN_EXPECTATION_EXPIRATION_TIME));
-    switch (expectation.type()) {
-      case ARTICLE -> {
-        expectationExecution.setName(expectation.getName());
-        expectationExecution.setArticle(((ChannelExpectation) expectation).getArticle());
-      }
-      case CHALLENGE -> {
-        expectationExecution.setName(expectation.getName());
-        expectationExecution.setChallenge(((ChallengeExpectation) expectation).getChallenge());
-      }
-      case DOCUMENT -> expectationExecution.setType(EXPECTATION_TYPE.DOCUMENT);
-      case TEXT -> expectationExecution.setType(EXPECTATION_TYPE.TEXT);
-      case DETECTION -> {
-        DetectionExpectation detectionExpectation = (DetectionExpectation) expectation;
-        expectationExecution.setName(detectionExpectation.getName());
-        expectationExecution.setDetection(
-            detectionExpectation.getAsset(), detectionExpectation.getAssetGroup());
-        expectationExecution.setSignatures(detectionExpectation.getInjectExpectationSignatures());
-      }
-      case PREVENTION -> {
-        PreventionExpectation preventionExpectation = (PreventionExpectation) expectation;
-        expectationExecution.setName(preventionExpectation.getName());
-        expectationExecution.setPrevention(
-            preventionExpectation.getAsset(), preventionExpectation.getAssetGroup());
-        expectationExecution.setSignatures(preventionExpectation.getInjectExpectationSignatures());
-      }
-      case MANUAL -> {
-        ManualExpectation manualExpectation = (ManualExpectation) expectation;
-        expectationExecution.setName(((ManualExpectation) expectation).getName());
-        expectationExecution.setManual(
-            manualExpectation.getAsset(), manualExpectation.getAssetGroup());
-        expectationExecution.setDescription(((ManualExpectation) expectation).getDescription());
-      }
-      default -> throw new IllegalStateException("Unexpected value: " + expectation);
-    }
-    return expectationExecution;
   }
 
   @Transactional

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
@@ -300,7 +300,7 @@ public class InjectExpectationService {
     }
   }
 
-  // -- BUILD AND SAVE EXPECTATION AFTER INJECT BE EXECUTED --
+  // -- BUILD AND SAVE EXPECTATION AFTER SUCCESSFUL INJECT EXECUTION --
 
   public void buildAndSaveInjectExpectations(
       ExecutableInject executableInject, List<Expectation> expectations) {

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
@@ -101,7 +101,7 @@ public class InjectExpectationService {
     return this.injectExpectationRepository.save(injectExpectation);
   }
 
-  // -- GENERATE EXPECTATION AFTER EXECUTION WITH OPENBAS AGENT --
+  // -- GENERATE EXPECTATIONS AFTER EXECUTION WITH OPENBAS AGENT --
 
   public List<Expectation> generateExpectations(Inject inject) throws Exception {
     Map<Asset, Boolean> assets = assetGroupService.resolveAllAssets(inject);

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
@@ -388,7 +388,7 @@ public class InjectExpectationService {
         }
 
         injectExpectationsByTeam.addAll(injectExpectationsByUserAndTeam);
-        this.injectExpectationRepository.saveAll(injectExpectationsByTeam);
+        injectExpectationRepository.saveAll(injectExpectationsByTeam);
       } else if (!assets.isEmpty() || !assetGroups.isEmpty()) {
         List<InjectExpectation> injectExpectations =
             expectations.stream()

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
@@ -1,12 +1,16 @@
 package io.openbas.inject_expectation;
 
-import io.openbas.database.model.InjectExpectation;
-import io.openbas.database.model.InjectExpectationResult;
+import io.openbas.database.model.*;
+import io.openbas.execution.ExecutableInject;
+import io.openbas.model.ExecutionProcess;
+import io.openbas.model.Expectation;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class InjectExpectationUtils {
 
@@ -35,6 +39,105 @@ public class InjectExpectationUtils {
               .metadata(metadata)
               .build();
       expectation.getResults().add(expectationResult);
+    }
+  }
+
+  public static void extractedExpectations(ExecutableInject executableInject, List<Expectation> expectations) {
+    boolean isAtomicTesting = executableInject.getInjection().getInject().isAtomicTesting();
+    boolean isScheduledInject = !executableInject.isDirect();
+    // Create the expectations
+    List<Team> teams = executableInject.getTeams();
+    List<Asset> assets = executableInject.getAssets();
+    List<AssetGroup> assetGroups = executableInject.getAssetGroups();
+    if ((isScheduledInject || isAtomicTesting) && !expectations.isEmpty()) {
+      if (!teams.isEmpty()) {
+        List<InjectExpectation> injectExpectationsByTeam;
+
+        List<InjectExpectation> injectExpectationsByUserAndTeam;
+        // If atomicTesting, We create expectation for every player and every team
+        if (isAtomicTesting) {
+          injectExpectationsByTeam =
+              teams.stream()
+                  .flatMap(
+                      team ->
+                          expectations.stream()
+                              .map(
+                                  expectation ->
+                                      expectationConverter(team, executableInject, expectation)))
+                  .collect(Collectors.toList());
+
+          injectExpectationsByUserAndTeam =
+              teams.stream()
+                  .flatMap(
+                      team ->
+                          team.getUsers().stream()
+                              .flatMap(
+                                  user ->
+                                      expectations.stream()
+                                          .map(
+                                              expectation ->
+                                                  expectationConverter(
+                                                      team,
+                                                      user,
+                                                      executableInject,
+                                                      expectation))))
+                  .toList();
+        } else {
+          // Create expectations for every enabled player in every team
+          injectExpectationsByUserAndTeam =
+              teams.stream()
+                  .flatMap(
+                      team ->
+                          team.getExerciseTeamUsers().stream()
+                              .filter(
+                                  exerciseTeamUser ->
+                                      exerciseTeamUser
+                                          .getExercise()
+                                          .getId()
+                                          .equals(
+                                              executableInject
+                                                  .getInjection()
+                                                  .getExercise()
+                                                  .getId()))
+                              .flatMap(
+                                  exerciseTeamUser ->
+                                      expectations.stream()
+                                          .map(
+                                              expectation ->
+                                                  expectationConverter(
+                                                      team,
+                                                      exerciseTeamUser.getUser(),
+                                                      executableInject,
+                                                      expectation))))
+                  .toList();
+
+          // Create a set of teams that have at least one enabled player
+          Set<Team> teamsWithEnabledPlayers =
+              injectExpectationsByUserAndTeam.stream()
+                  .map(InjectExpectation::getTeam)
+                  .collect(Collectors.toSet());
+
+          // Add only the expectations where the team has at least one enabled player
+          injectExpectationsByTeam =
+              teamsWithEnabledPlayers.stream()
+                  .flatMap(
+                      team ->
+                          expectations.stream()
+                              .map(
+                                  expectation ->
+                                      expectationConverter(team, executableInject, expectation)))
+                  .collect(Collectors.toList());
+        }
+
+        injectExpectationsByTeam.addAll(injectExpectationsByUserAndTeam);
+        this.injectExpectationRepository.saveAll(injectExpectationsByTeam);
+      } else if (!assets.isEmpty() || !assetGroups.isEmpty()) {
+        List<InjectExpectation> injectExpectations =
+            expectations.stream()
+                .map(expectation -> expectationConverter(executableInject, expectation))
+                .toList();
+        this.injectExpectationRepository.saveAll(injectExpectations);
+      }
     }
   }
 }

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
@@ -2,7 +2,6 @@ package io.openbas.inject_expectation;
 
 import io.openbas.database.model.*;
 import io.openbas.execution.ExecutableInject;
-import io.openbas.model.ExecutionProcess;
 import io.openbas.model.Expectation;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -42,7 +41,8 @@ public class InjectExpectationUtils {
     }
   }
 
-  public static void extractedExpectations(ExecutableInject executableInject, List<Expectation> expectations) {
+  public static void extractedExpectations(
+      ExecutableInject executableInject, List<Expectation> expectations) {
     boolean isAtomicTesting = executableInject.getInjection().getInject().isAtomicTesting();
     boolean isScheduledInject = !executableInject.isDirect();
     // Create the expectations
@@ -77,10 +77,7 @@ public class InjectExpectationUtils {
                                           .map(
                                               expectation ->
                                                   expectationConverter(
-                                                      team,
-                                                      user,
-                                                      executableInject,
-                                                      expectation))))
+                                                      team, user, executableInject, expectation))))
                   .toList();
         } else {
           // Create expectations for every enabled player in every team

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
@@ -119,7 +119,7 @@ public class InjectExpectationUtils {
     return expectationExecution;
   }
 
-  // -- INJECT EXPECTATION SIGNATURE --
+  // -- INJECT EXPECTATION SIGNATURE FOR OBAS IMPLANT EXECUTOR --
 
   public static List<InjectExpectationSignature> spawnSignatures(Inject inject, Payload payload) {
     List<InjectExpectationSignature> signatures = new ArrayList<>();

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/OpenBASImplantInjectContent.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/OpenBASImplantInjectContent.java
@@ -1,4 +1,4 @@
-package io.openbas.injectors.openbas.model;
+package io.openbas.inject_expectation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openbas.model.inject.form.Expectation;

--- a/openbas-framework/src/main/java/io/openbas/model/ExecutionProcess.java
+++ b/openbas-framework/src/main/java/io/openbas/model/ExecutionProcess.java
@@ -10,10 +10,7 @@ public class ExecutionProcess {
 
   private boolean async;
 
-  private List<Expectation> expectations;
-
-  public ExecutionProcess(boolean async, List<Expectation> expectations) {
+  public ExecutionProcess(boolean async) {
     this.async = async;
-    this.expectations = expectations;
   }
 }

--- a/openbas-framework/src/main/java/io/openbas/model/ExecutionProcess.java
+++ b/openbas-framework/src/main/java/io/openbas/model/ExecutionProcess.java
@@ -1,6 +1,5 @@
 package io.openbas.model;
 
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/openbas-model/src/main/java/io/openbas/database/model/ExecutionTraceStatus.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/ExecutionTraceStatus.java
@@ -4,7 +4,6 @@ public enum ExecutionTraceStatus {
   SUCCESS,
   ERROR,
   MAYBE_PREVENTED,
-
   INFO,
   COMMAND_NOT_FOUND,
   COMMAND_CANNOT_BE_EXECUTED,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
* https://www.notion.so/filigran/Expectations-creation-workflow-10c8fce17f2a80b99d5cd9b0afa3a668
* Previously, technical expectations were generated during the injection process, regardless of whether the execution was successful. Now, technical expectations are only generated when the injection is executed successfully. If other statuses occur (such as errors or prevention), expectations are not generated.
* Implement a unified method to build and save expectations for all contracts (email, channel, challenge, SMS, Octi, Caldera, OBAS).


### Related issues

* Closes #1832 
* https://github.com/OpenBAS-Platform/openbas/issues/1984

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
