### PR TITLE
[backend] Allowing metadata to inject expectation result

### DIFF
--- a/openbas-api/src/main/java/io/openbas/collectors/expectations_expiration_manager/service/ExpectationsExpirationManagerService.java
+++ b/openbas-api/src/main/java/io/openbas/collectors/expectations_expiration_manager/service/ExpectationsExpirationManagerService.java
@@ -41,7 +41,7 @@ public class ExpectationsExpirationManagerService {
           if (isExpired(expectation)) {
             String result = computeFailedMessage(expectation.getType());
             this.injectExpectationService.computeExpectation(
-                expectation, this.config.getId(), "collector", PRODUCT_NAME, result, false);
+                expectation, this.config.getId(), "collector", PRODUCT_NAME, result, false, null);
           }
         });
   }
@@ -54,7 +54,7 @@ public class ExpectationsExpirationManagerService {
           if (isExpired(expectation)) {
             String result = computeFailedMessage(expectation.getType());
             this.injectExpectationService.computeExpectation(
-                expectation, this.config.getId(), "collector", PRODUCT_NAME, result, false);
+                expectation, this.config.getId(), "collector", PRODUCT_NAME, result, false, null);
           }
         });
   }

--- a/openbas-api/src/main/java/io/openbas/rest/expectation/ExpectationApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/expectation/ExpectationApi.java
@@ -126,7 +126,8 @@ public class ExpectationApi extends RestBehavior {
             "collector",
             collector.getName(),
             input.getResult(),
-            input.getSuccess());
+            input.getIsSuccess(),
+            input.getMetadata());
 
     // Compute potential expectations for asset groups
     Inject inject = injectExpectation.getInject();

--- a/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectExpectationUpdateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectExpectationUpdateInput.java
@@ -2,7 +2,10 @@ package io.openbas.rest.inject.form;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import lombok.Data;
 
+@Data
 public class InjectExpectationUpdateInput {
   @NotNull
   @JsonProperty("collector_id")
@@ -16,27 +19,6 @@ public class InjectExpectationUpdateInput {
   @JsonProperty("is_success")
   private Boolean isSuccess;
 
-  public String getCollectorId() {
-    return collectorId;
-  }
-
-  public void setCollectorId(String collectorId) {
-    this.collectorId = collectorId;
-  }
-
-  public String getResult() {
-    return result;
-  }
-
-  public void setResult(String result) {
-    this.result = result;
-  }
-
-  public Boolean getSuccess() {
-    return isSuccess;
-  }
-
-  public void setSuccess(Boolean success) {
-    isSuccess = success;
-  }
+  @JsonProperty("metadata")
+  private Map<String, String> metadata;
 }

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationService.java
@@ -18,6 +18,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -45,12 +46,13 @@ public class InjectExpectationService {
       @NotBlank final String sourceType,
       @NotBlank final String sourceName,
       @NotBlank final String result,
-      @NotBlank final Boolean success) {
+      @NotBlank final Boolean success,
+      final Map<String, String> metadata) {
     double actualScore =
         success
             ? expectation.getExpectedScore()
             : expectation.getScore() == null ? 0.0 : expectation.getScore();
-    computeResult(expectation, sourceId, sourceType, sourceName, result, actualScore);
+    computeResult(expectation, sourceId, sourceType, sourceName, result, actualScore, metadata);
     expectation.setScore(actualScore);
     return this.update(expectation);
   }
@@ -75,7 +77,8 @@ public class InjectExpectationService {
         sourceType,
         sourceName,
         success ? "SUCCESS" : "FAILED",
-        success ? expectationAssetGroup.getExpectedScore() : 0);
+        success ? expectationAssetGroup.getExpectedScore() : 0,
+        null);
     expectationAssetGroup.setScore(success ? expectationAssetGroup.getExpectedScore() : 0.0);
     this.update(expectationAssetGroup);
   }

--- a/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
+++ b/openbas-framework/src/main/java/io/openbas/inject_expectation/InjectExpectationUtils.java
@@ -5,15 +5,10 @@ import io.openbas.database.model.InjectExpectationResult;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class InjectExpectationUtils {
-
-  public static List<InjectExpectationResult> resultsBySourceId(
-      @NotNull final InjectExpectation expectation, @NotBlank final String sourceId) {
-    return expectation.getResults().stream().filter(e -> sourceId.equals(e.getSourceId())).toList();
-  }
 
   public static void computeResult(
       @NotNull final InjectExpectation expectation,
@@ -21,11 +16,13 @@ public class InjectExpectationUtils {
       @NotBlank final String sourceType,
       @NotBlank final String sourceName,
       @NotBlank final String result,
-      @NotBlank final Double score) {
+      @NotBlank final Double score,
+      final Map<String, String> metadata) {
     Optional<InjectExpectationResult> exists =
         expectation.getResults().stream().filter(r -> sourceId.equals(r.getSourceId())).findAny();
     if (exists.isPresent()) {
       exists.get().setResult(result);
+      exists.get().setMetadata(metadata);
     } else {
       InjectExpectationResult expectationResult =
           InjectExpectationResult.builder()
@@ -35,6 +32,7 @@ public class InjectExpectationUtils {
               .result(result)
               .date(Instant.now().toString())
               .score(score)
+              .metadata(metadata)
               .build();
       expectation.getResults().add(expectationResult);
     }

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectExpectationResult.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectExpectationResult.java
@@ -1,6 +1,7 @@
 package io.openbas.database.model;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
 
@@ -19,4 +20,6 @@ public class InjectExpectationResult {
   private Double score;
 
   @NotBlank private String result;
+
+  private Map<String, String> metadata;
 }


### PR DESCRIPTION
### Proposed changes

Change strategy level of validation on the Sentinel collector side.
Objective: Sentinel is validated by the fact that an expectation has been validated by Defender. He therefore refers to him to validate his expectations.

The Defender collector fills a metadata property containing the alert ID which validated the expectation.
Sentinel looks for this alert ID in its logs to validate its expectations.

https://github.com/OpenBAS-Platform/openbas/issues/1685