### PR TITLE
[backend] update kill chain phase options api to sort by order

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/kill_chain_phase/KillChainPhaseApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/kill_chain_phase/KillChainPhaseApi.java
@@ -138,7 +138,7 @@ public class KillChainPhaseApi extends RestBehavior {
       @RequestParam(required = false) final String searchText) {
     return fromIterable(
             this.killChainPhaseRepository.findAll(
-                byName(searchText), Sort.by(Sort.Direction.ASC, "name")))
+                byName(searchText), Sort.by(Sort.Direction.ASC, "order")))
         .stream()
         .map(i -> new FilterUtilsJpa.Option(i.getId(), i.getName()))
         .toList();

--- a/openbas-api/src/test/java/io/openbas/killChainPhase/KillChainPhaseApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/killChainPhase/KillChainPhaseApiTest.java
@@ -23,7 +23,6 @@ import io.openbas.utils.fixtures.PaginationFixture;
 import io.openbas.utils.mockUser.WithMockAdminUser;
 import io.openbas.utils.pagination.SearchPaginationInput;
 import io.openbas.utils.pagination.SortField;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -45,20 +44,16 @@ public class KillChainPhaseApiTest extends IntegrationTest {
 
   @Autowired private KillChainPhaseRepository killChainPhaseRepository;
 
-  @Mock
-  private KillChainPhaseRepository mockKillChainPhaseRepository;
+  @Mock private KillChainPhaseRepository mockKillChainPhaseRepository;
 
-
-  @InjectMocks
-  private KillChainPhaseApi killChainPhaseApi;
-
+  @InjectMocks private KillChainPhaseApi killChainPhaseApi;
 
   private static final KillChainPhase KILL_CHAIN_PHASE_1 = getKillChainPhase("name1", 1L);
   private static final KillChainPhase KILL_CHAIN_PHASE_2 = getKillChainPhase("name2", 2L);
   private static final KillChainPhase KILL_CHAIN_PHASE_3 = getKillChainPhase("name3", 3L);
 
-  private final static String SEARCH_INPUT = "search input";
-  private final static Specification<KillChainPhase> spec = byName(SEARCH_INPUT);
+  private static final String SEARCH_INPUT = "search input";
+  private static final Specification<KillChainPhase> spec = byName(SEARCH_INPUT);
 
   private static String KILL_CHAIN_PHASE_ID_1;
   private static String KILL_CHAIN_PHASE_ID_2;
@@ -66,10 +61,8 @@ public class KillChainPhaseApiTest extends IntegrationTest {
 
   private static List<KillChainPhase> killChainPhaseList = new ArrayList<>();
 
-
   @BeforeAll
   public void beforeAll() {
-
 
     KILL_CHAIN_PHASE_ID_1 = this.killChainPhaseRepository.save(KILL_CHAIN_PHASE_1).getId();
     KILL_CHAIN_PHASE_ID_2 = this.killChainPhaseRepository.save(KILL_CHAIN_PHASE_2).getId();
@@ -78,7 +71,7 @@ public class KillChainPhaseApiTest extends IntegrationTest {
     killChainPhaseList = Arrays.asList(KILL_CHAIN_PHASE_1, KILL_CHAIN_PHASE_2, KILL_CHAIN_PHASE_3);
 
     when(mockKillChainPhaseRepository.findAll(spec, Sort.by(Sort.Direction.ASC, "order")))
-            .thenReturn(killChainPhaseList);
+        .thenReturn(killChainPhaseList);
   }
 
   @AfterAll
@@ -240,7 +233,6 @@ public class KillChainPhaseApiTest extends IntegrationTest {
               .sorts(List.of(SortField.builder().property("phase_name").direction("desc").build()))
               .build();
 
-
       mvc.perform(
               post("/api/kill_chain_phases/search")
                   .contentType(MediaType.APPLICATION_JSON)
@@ -256,13 +248,17 @@ public class KillChainPhaseApiTest extends IntegrationTest {
   @Test
   void optionsByNameTest() throws Exception {
 
-    try (MockedStatic<KillChainPhaseSpecification> mocked = Mockito.mockStatic(KillChainPhaseSpecification.class)) {
+    try (MockedStatic<KillChainPhaseSpecification> mocked =
+        Mockito.mockStatic(KillChainPhaseSpecification.class)) {
       when(KillChainPhaseSpecification.byName(SEARCH_INPUT)).thenReturn(spec);
       List<FilterUtilsJpa.Option> result = killChainPhaseApi.optionsByName(SEARCH_INPUT);
 
       verify(mockKillChainPhaseRepository).findAll(spec, Sort.by(Sort.Direction.ASC, "order"));
-      assertEquals(killChainPhaseList.stream().map(i -> new FilterUtilsJpa.Option(i.getId(), i.getName())).toList(),
-              result);
+      assertEquals(
+          killChainPhaseList.stream()
+              .map(i -> new FilterUtilsJpa.Option(i.getId(), i.getName()))
+              .toList(),
+          result);
     }
   }
 }

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/KillChainPhaseFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/KillChainPhaseFixture.java
@@ -10,11 +10,13 @@ public class KillChainPhaseFixture {
 
   private static final Random RANDOM = new Random();
 
-  public static KillChainPhase getKillChainPhase(@NotBlank final String name) {
+  public static KillChainPhase getKillChainPhase(@NotBlank final String name,
+                                                 @NotBlank final Long order) {
     KillChainPhase killChainPhase = new KillChainPhase();
     killChainPhase.setName(name);
     killChainPhase.setShortName(name);
     killChainPhase.setKillChainName("mitre-attack");
+    killChainPhase.setOrder(order);
     killChainPhase.setExternalId(valueOf(RANDOM.nextInt()));
     return killChainPhase;
   }

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/KillChainPhaseFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/KillChainPhaseFixture.java
@@ -10,8 +10,8 @@ public class KillChainPhaseFixture {
 
   private static final Random RANDOM = new Random();
 
-  public static KillChainPhase getKillChainPhase(@NotBlank final String name,
-                                                 @NotBlank final Long order) {
+  public static KillChainPhase getKillChainPhase(
+      @NotBlank final String name, @NotBlank final Long order) {
     KillChainPhase killChainPhase = new KillChainPhase();
     killChainPhase.setName(name);
     killChainPhase.setShortName(name);


### PR DESCRIPTION

### Proposed changes

* Update the order of the KillChainPhase returned by **/api/kill_chain_phases/options** to be ordered by phase order instead of alphabetical order


### Related issues

* Closes  [1662](https://github.com/OpenBAS-Platform/openbas/issues/1662)

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

