### PR TITLE
[frontend] After deleting all expectations from a technical/media/challenge inject, an expectation is added by default to inject again

### DIFF
--- a/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
+++ b/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
@@ -30,7 +30,7 @@ function getInjectorContractWithEmptyPredefinedExpectations(injectorContractCont
   const fieldsOnlyExpectations = fields.filter(
     (f: { key: string }) => f.key === 'expectations',
   );
-  if (fieldsOnlyExpectations.length === 0 || (fieldsOnlyExpectations.length > 0 && !fieldsOnlyExpectations[0].hasAttribute('predefinedExpectations'))) {
+  if (fieldsOnlyExpectations.length === 0 || (fieldsOnlyExpectations.length > 0 && !Object.prototype.hasOwnProperty.call(fieldsOnlyExpectations[0], 'predefinedExpectations'))) {
     return injectorContract;
   }
   const fieldsWithoutExpectations = fields.filter(

--- a/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
+++ b/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
@@ -1,6 +1,6 @@
 import { Tab, Tabs } from '@mui/material';
-import { useEffect, useRef, useState } from 'react';
 import * as React from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { fetchInject } from '../../../../actions/Inject';
 import type { InjectOutputType } from '../../../../actions/injects/Inject';
@@ -22,6 +22,28 @@ interface Props {
   injectId: string;
   isAtomic?: boolean;
   injects?: InjectOutputType[];
+}
+
+function getInjectorContractWithEmptyPredefinedExpectations(injectorContractContent: string) {
+  const injectorContract = JSON.parse(injectorContractContent);
+  const { fields } = injectorContract;
+  const fieldsOnlyExpectations = fields.filter(
+    (f: { key: string }) => f.key === 'expectations',
+  );
+  if (fieldsOnlyExpectations.length === 0 || (fieldsOnlyExpectations.length > 0 && !fieldsOnlyExpectations[0].hasAttribute('predefinedExpectations'))) {
+    return injectorContract;
+  }
+  const fieldsWithoutExpectations = fields.filter(
+    (f: { key: string }) => f.key !== 'expectations',
+  );
+  const fieldsWithEmptyPredefinedExpectations = [
+    ...fieldsWithoutExpectations,
+    {
+      ...fieldsOnlyExpectations[0],
+      predefinedExpectations: [],
+    },
+  ];
+  return { ...injectorContract, fields: fieldsWithEmptyPredefinedExpectations };
 }
 
 const UpdateInject: React.FC<Props> = ({ open, handleClose, onUpdateInject, massUpdateInject, injectId, isAtomic = false, injects, ...props }) => {
@@ -49,7 +71,7 @@ const UpdateInject: React.FC<Props> = ({ open, handleClose, onUpdateInject, mass
   const [injectorContract, setInjectorContract] = useState(null);
   useEffect(() => {
     if (inject?.inject_injector_contract?.injector_contract_content) {
-      setInjectorContract(JSON.parse(inject.inject_injector_contract?.injector_contract_content));
+      setInjectorContract(getInjectorContractWithEmptyPredefinedExpectations(inject.inject_injector_contract?.injector_contract_content));
     }
   }, [inject]);
   return (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
-  On Inject update, empty of predefined expectations since they are no needed if all the expectations where removed by the user

### Related issues

* Closes #1714 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
