### PR TITLE
[frontend] Payload - Enforce required cleanup command AND executor when choosing one of the two (#1621)

### DIFF
--- a/openbas-front/src/admin/components/payloads/CreatePayload.js
+++ b/openbas-front/src/admin/components/payloads/CreatePayload.js
@@ -39,18 +39,18 @@ class CreatePayload extends Component {
   }
 
   onSubmit(data) {
-      function handleCleanupExecutorValue(payload_cleanup_executor, payload_cleanup_command) {
-          if (payload_cleanup_executor !== '' && handleCleanupCommandValue(payload_cleanup_command) !== null) {
-              return payload_cleanup_executor;
-          }
-          return null;
-      }
+    function handleCleanupCommandValue(payload_cleanup_command) {
+      return payload_cleanup_command === '' ? null : payload_cleanup_command;
+    }
 
-      function handleCleanupCommandValue(payload_cleanup_command) {
-          return payload_cleanup_command === '' ? null : payload_cleanup_command;
+    function handleCleanupExecutorValue(payload_cleanup_executor, payload_cleanup_command) {
+      if (payload_cleanup_executor !== '' && handleCleanupCommandValue(payload_cleanup_command) !== null) {
+        return payload_cleanup_executor;
       }
+      return null;
+    }
 
-      const inputValues = R.pipe(
+    const inputValues = R.pipe(
       R.assoc('payload_type', this.state.selectedType),
       R.assoc('payload_source', 'MANUAL'),
       R.assoc('payload_status', 'VERIFIED'),

--- a/openbas-front/src/admin/components/payloads/CreatePayload.js
+++ b/openbas-front/src/admin/components/payloads/CreatePayload.js
@@ -39,7 +39,18 @@ class CreatePayload extends Component {
   }
 
   onSubmit(data) {
-    const inputValues = R.pipe(
+      function handleCleanupExecutorValue(payload_cleanup_executor, payload_cleanup_command) {
+          if (payload_cleanup_executor !== '' && handleCleanupCommandValue(payload_cleanup_command) !== null) {
+              return payload_cleanup_executor;
+          }
+          return null;
+      }
+
+      function handleCleanupCommandValue(payload_cleanup_command) {
+          return payload_cleanup_command === '' ? null : payload_cleanup_command;
+      }
+
+      const inputValues = R.pipe(
       R.assoc('payload_type', this.state.selectedType),
       R.assoc('payload_source', 'MANUAL'),
       R.assoc('payload_status', 'VERIFIED'),
@@ -47,8 +58,8 @@ class CreatePayload extends Component {
       R.assoc('payload_tags', data.payload_tags),
       R.assoc('payload_attack_patterns', data.payload_attack_patterns),
       R.assoc('executable_file', data.executable_file?.id),
-      R.assoc('payload_cleanup_executor', data.payload_cleanup_executor === '' ? null : data.payload_cleanup_executor),
-      R.assoc('payload_cleanup_command', data.payload_cleanup_command === '' ? null : data.payload_cleanup_command),
+      R.assoc('payload_cleanup_executor', handleCleanupExecutorValue(data.payload_cleanup_executor, data.payload_cleanup_command)),
+      R.assoc('payload_cleanup_command', handleCleanupCommandValue(data.payload_cleanup_command)),
     )(data);
     return this.props
       .addPayload(inputValues)

--- a/openbas-front/src/admin/components/payloads/PayloadForm.tsx
+++ b/openbas-front/src/admin/components/payloads/PayloadForm.tsx
@@ -126,10 +126,6 @@ const PayloadForm: FunctionComponent<Props> = ({
   }
 
   extendedSchema = extendedSchema.refine(input =>
-    !(!input.payload_cleanup_command && input.payload_cleanup_executor), {
-    message: t('Cleanup command and executor must be defined together or none at all'),
-    path: ['payload_cleanup_command'],
-  }).refine(input =>
     !(input.payload_cleanup_command && !input.payload_cleanup_executor), {
     message: t('Cleanup command and executor must be defined together or none at all'),
     path: ['payload_cleanup_executor'],

--- a/openbas-front/src/admin/components/payloads/PayloadPopover.js
+++ b/openbas-front/src/admin/components/payloads/PayloadPopover.js
@@ -29,16 +29,15 @@ const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate
   };
   const handleCloseEdit = () => setOpenEdit(false);
   const onSubmitEdit = (data) => {
-      function handleCleanupExecutorValue(payload_cleanup_executor, payload_cleanup_command) {
-          if (payload_cleanup_executor !== '' && handleCleanupCommandValue(payload_cleanup_command) !== null) {
-              return payload_cleanup_executor;
-          }
-          return null;
+    function handleCleanupCommandValue(payload_cleanup_command) {
+      return payload_cleanup_command === '' ? null : payload_cleanup_command;
+    }
+    function handleCleanupExecutorValue(payload_cleanup_executor, payload_cleanup_command) {
+      if (payload_cleanup_executor !== '' && handleCleanupCommandValue(payload_cleanup_command) !== null) {
+        return payload_cleanup_executor;
       }
-
-      function handleCleanupCommandValue(payload_cleanup_command) {
-          return payload_cleanup_command === '' ? null : payload_cleanup_command;
-      }
+      return null;
+    }
     const inputValues = R.pipe(
       R.assoc('payload_platforms', R.pluck('id', data.payload_platforms)),
       R.assoc('payload_tags', data.payload_tags),

--- a/openbas-front/src/admin/components/payloads/PayloadPopover.js
+++ b/openbas-front/src/admin/components/payloads/PayloadPopover.js
@@ -29,13 +29,23 @@ const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate
   };
   const handleCloseEdit = () => setOpenEdit(false);
   const onSubmitEdit = (data) => {
+      function handleCleanupExecutorValue(payload_cleanup_executor, payload_cleanup_command) {
+          if (payload_cleanup_executor !== '' && handleCleanupCommandValue(payload_cleanup_command) !== null) {
+              return payload_cleanup_executor;
+          }
+          return null;
+      }
+
+      function handleCleanupCommandValue(payload_cleanup_command) {
+          return payload_cleanup_command === '' ? null : payload_cleanup_command;
+      }
     const inputValues = R.pipe(
       R.assoc('payload_platforms', R.pluck('id', data.payload_platforms)),
       R.assoc('payload_tags', data.payload_tags),
       R.assoc('payload_attack_patterns', data.payload_attack_patterns),
       R.assoc('executable_file', data.executable_file?.id),
-      R.assoc('payload_cleanup_executor', data.payload_cleanup_executor === '' ? null : data.payload_cleanup_executor),
-      R.assoc('payload_cleanup_command', data.payload_cleanup_command === '' ? null : data.payload_cleanup_command),
+      R.assoc('payload_cleanup_executor', handleCleanupExecutorValue(data.payload_cleanup_executor, data.payload_cleanup_command)),
+      R.assoc('payload_cleanup_command', handleCleanupCommandValue(data.payload_cleanup_command)),
     )(data);
     return dispatch(updatePayload(payload.payload_id, inputValues)).then((result) => {
       if (onUpdate) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Further changes requested after demo:

> Hello du coup j'ai un peu regarder, si on veut avoir une logique qui ne sera pas à retoucher plus tard, mieux serait de cacher la complexité en laissant la possibilité d'avoir un champ vide, on pourrait donc appliquer les regles suivantes:
>  
> Pour le cleanup:
> Si il y a  command mais pas d'executor: error message + impossible de sauver le payload
> Si pas de command mais un executor de définit: possibilité de sauver mais le clean up executor est reset to "null" 
> Et pas de modif visible dans l'UI 
> 

 
 

### Related issues

* Closes #1621 
* Related #1825 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
