### PR TITLE
Improv swagger documentation

### DIFF
--- a/openbas-api/pom.xml
+++ b/openbas-api/pom.xml
@@ -96,11 +96,6 @@
             <version>${springdoc.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-            <version>${springdoc.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpg-jdk18on</artifactId>
             <version>${bcpg-jdk18on.version}</version>

--- a/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectExpectationResultsByAttackPattern.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectExpectationResultsByAttackPattern.java
@@ -7,6 +7,7 @@ import io.openbas.database.model.Inject;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.utils.AtomicTestingUtils;
 import io.openbas.utils.AtomicTestingUtils.ExpectationResultsByType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,6 +21,7 @@ public class InjectExpectationResultsByAttackPattern {
 
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_attack_pattern")
+  @Schema(type = "string")
   private AttackPattern attackPattern;
 
   @Data

--- a/openbas-api/src/main/java/io/openbas/rest/report/model/Report.java
+++ b/openbas-api/src/main/java/io/openbas/rest/report/model/Report.java
@@ -9,6 +9,7 @@ import io.openbas.database.model.Base;
 import io.openbas.database.model.Exercise;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiModelDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -69,6 +70,7 @@ public class Report implements Base {
       inverseJoinColumns = @JoinColumn(name = "exercise_id"))
   @JsonProperty("report_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
+  @Schema(type = "string")
   private Exercise exercise;
 
   @OneToMany(

--- a/openbas-api/src/main/java/io/openbas/rest/report/model/ReportInformation.java
+++ b/openbas-api/src/main/java/io/openbas/rest/report/model/ReportInformation.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.model.Base;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.util.Objects;
@@ -30,6 +31,7 @@ public class ReportInformation implements Base {
   @JoinColumn(name = "report_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @NotNull
+  @Schema(type = "string")
   private Report report;
 
   @Enumerated(EnumType.STRING)

--- a/openbas-api/src/main/java/io/openbas/rest/report/model/ReportInjectComment.java
+++ b/openbas-api/src/main/java/io/openbas/rest/report/model/ReportInjectComment.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.model.Inject;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -21,6 +22,7 @@ public class ReportInjectComment {
   @JsonIgnore // Ignore Inject object in JSON
   @JsonSerialize(using = MonoIdDeserializer.class)
   @NotNull
+  @Schema(type = "string")
   private Inject inject;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -29,6 +31,7 @@ public class ReportInjectComment {
   @JsonIgnore // Ignore Inject object in JSON
   @JsonSerialize(using = MonoIdDeserializer.class)
   @NotNull
+  @Schema(type = "string")
   private Report report;
 
   @Column(name = "comment")

--- a/openbas-api/src/main/java/io/openbas/rest/scenario/form/ScenarioSimple.java
+++ b/openbas-api/src/main/java/io/openbas/rest/scenario/form/ScenarioSimple.java
@@ -6,6 +6,8 @@ import io.openbas.database.model.Scenario;
 import io.openbas.database.model.Tag;
 import io.openbas.database.raw.RawScenario;
 import io.openbas.helper.MultiIdSetDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,6 +27,7 @@ public class ScenarioSimple {
   @JsonProperty("scenario_subtitle")
   private String subtitle;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonSerialize(using = MultiIdSetDeserializer.class)
   @JsonProperty("scenario_tags")
   private Set<Tag> tags = new HashSet<>();

--- a/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
@@ -13,6 +13,7 @@ import static io.openbas.utils.pagination.PaginationUtils.buildPaginationCriteri
 import static io.openbas.utils.pagination.SortUtilsCriteriaBuilder.toSortCriteriaBuilder;
 import static java.time.Instant.now;
 import static java.util.Optional.ofNullable;
+import static org.springframework.util.StringUtils.hasText;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -105,7 +106,7 @@ public class ScenarioService {
 
   @Transactional
   public Scenario createScenario(@NotNull final Scenario scenario) {
-    if (!org.springframework.util.StringUtils.hasText(scenario.getFrom())) {
+    if (!hasText(scenario.getFrom())) {
       if (this.imapEnabled) {
         scenario.setFrom(this.imapUsername);
         scenario.setReplyTos(List.of(this.imapUsername));

--- a/openbas-front/src/admin/components/assets/asset_groups/AssetGroupManagement.tsx
+++ b/openbas-front/src/admin/components/assets/asset_groups/AssetGroupManagement.tsx
@@ -11,7 +11,7 @@ import type { UserHelper } from '../../../../actions/helper';
 import SearchFilter from '../../../../components/SearchFilter';
 import type { Theme } from '../../../../components/Theme';
 import { useHelper } from '../../../../store';
-import type { Asset } from '../../../../utils/api-types';
+import type { Endpoint } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import useSearchAnFilter from '../../../../utils/SortingFiltering';
@@ -55,7 +55,7 @@ interface Props {
   assetGroupId: string;
   handleClose: () => void;
   onUpdate?: (result: AssetGroupStore) => void;
-  onRemoveEndpointFromAssetGroup?: (assetId: Asset['asset_id']) => void;
+  onRemoveEndpointFromAssetGroup?: (assetId: Endpoint['asset_id']) => void;
 }
 
 const AssetGroupManagement: FunctionComponent<Props> = ({

--- a/openbas-front/src/admin/components/payloads/Payloads.tsx
+++ b/openbas-front/src/admin/components/payloads/Payloads.tsx
@@ -23,7 +23,7 @@ import ItemTags from '../../../components/ItemTags';
 import PayloadIcon from '../../../components/PayloadIcon';
 import PlatformIcon from '../../../components/PlatformIcon';
 import { useHelper } from '../../../store';
-import { PayloadStatus } from '../../../utils/api-types';
+import { Payload as PayloadType } from '../../../utils/api-types';
 import { useAppDispatch } from '../../../utils/hooks';
 import useDataLoader from '../../../utils/hooks/useDataLoader';
 import CreatePayload from './CreatePayload';
@@ -111,7 +111,7 @@ const chipSx = {
   width: 120,
 };
 
-const fromPayloadStatusToChipColor = (payloadStatus: PayloadStatus) => {
+const fromPayloadStatusToChipColor = (payloadStatus: PayloadType['payload_status']) => {
   switch (payloadStatus) {
     case 'VERIFIED':
       return 'success';

--- a/openbas-front/src/admin/components/scenarios/ScenarioForm.tsx
+++ b/openbas-front/src/admin/components/scenarios/ScenarioForm.tsx
@@ -50,7 +50,7 @@ const ScenarioForm: FunctionComponent<Props> = ({
         scenario_tags: z.string().array().optional(),
         scenario_external_reference: z.string().optional(),
         scenario_external_url: z.string().optional(),
-        scenario_mail_from: z.string().email(t('Should be a valid email address')),
+        scenario_mail_from: z.string().email(t('Should be a valid email address')).optional(),
         scenario_mails_reply_to: z.array(z.string().email(t('Should be a valid email address'))).optional(),
         scenario_message_header: z.string().optional(),
         scenario_message_footer: z.string().optional(),

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -43,20 +43,20 @@ export interface AiResult {
 
 export interface Article {
   article_author?: string;
-  article_channel: Channel;
+  article_channel: string;
   /** @format int32 */
   article_comments?: number;
   article_content?: string;
   /** @format date-time */
   article_created_at: string;
-  article_documents?: Document[];
-  article_exercise?: Exercise;
+  article_documents?: string[];
+  article_exercise?: string;
   article_id: string;
   article_is_scheduled?: boolean;
   /** @format int32 */
   article_likes?: number;
   article_name?: string;
-  article_scenario?: Scenario;
+  article_scenario?: string;
   /** @format int32 */
   article_shares?: number;
   /** @format date-time */
@@ -96,50 +96,24 @@ export interface ArticleUpdateInput {
   article_shares?: number;
 }
 
-export interface Asset {
-  asset_active?: boolean;
-  asset_children?: Asset[];
-  /** @format date-time */
-  asset_cleared_at?: string;
-  /** @format date-time */
-  asset_created_at: string;
-  asset_description?: string;
-  asset_executor?: Executor;
-  asset_external_reference?: string;
-  asset_id: string;
-  asset_inject?: Inject;
-  /** @format date-time */
-  asset_last_seen?: string;
-  asset_name: string;
-  asset_parent?: Asset;
-  asset_process_name?: string;
-  /** @uniqueItems true */
-  asset_tags?: Tag[];
-  asset_type?: string;
-  /** @format date-time */
-  asset_updated_at: string;
-  listened?: boolean;
-}
-
 export interface AssetAgentJob {
-  asset_agent_asset?: Asset;
+  asset_agent_asset?: string;
   asset_agent_command: string;
   asset_agent_id: string;
-  asset_agent_inject?: Inject;
+  asset_agent_inject?: string;
   listened?: boolean;
 }
 
 export interface AssetGroup {
-  asset_group_assets?: Asset[];
+  asset_group_assets?: string[];
   /** @format date-time */
   asset_group_created_at: string;
   asset_group_description?: string;
-  asset_group_dynamic_assets?: Asset[];
+  asset_group_dynamic_assets?: string[];
   asset_group_dynamic_filter?: FilterGroup;
   asset_group_id: string;
   asset_group_name: string;
-  /** @uniqueItems true */
-  asset_group_tags?: Tag[];
+  asset_group_tags?: string[];
   /** @format date-time */
   asset_group_updated_at: string;
   listened?: boolean;
@@ -186,9 +160,9 @@ export interface AttackPattern {
   attack_pattern_description?: string;
   attack_pattern_external_id: string;
   attack_pattern_id: string;
-  attack_pattern_kill_chain_phases?: KillChainPhase[];
+  attack_pattern_kill_chain_phases?: string[];
   attack_pattern_name: string;
-  attack_pattern_parent?: AttackPattern;
+  attack_pattern_parent?: string;
   attack_pattern_permissions_required?: string[];
   attack_pattern_platforms?: string[];
   attack_pattern_stix_id: string;
@@ -231,7 +205,7 @@ export interface Challenge {
   challenge_content?: string;
   /** @format date-time */
   challenge_created_at: string;
-  challenge_documents?: Document[];
+  challenge_documents?: string[];
   challenge_exercises?: string[];
   challenge_flags: ChallengeFlag[];
   challenge_id: string;
@@ -241,8 +215,7 @@ export interface Challenge {
   challenge_scenarios?: string[];
   /** @format double */
   challenge_score?: number;
-  /** @uniqueItems true */
-  challenge_tags?: Tag[];
+  challenge_tags?: string[];
   /** @format date-time */
   challenge_updated_at: string;
   /** @format date-time */
@@ -251,7 +224,7 @@ export interface Challenge {
 }
 
 export interface ChallengeFlag {
-  flag_challenge?: Challenge;
+  flag_challenge?: string;
   /** @format date-time */
   flag_created_at?: string;
   flag_id?: string;
@@ -304,8 +277,8 @@ export interface Channel {
   channel_created_at: string;
   channel_description?: string;
   channel_id: string;
-  channel_logo_dark?: Document;
-  channel_logo_light?: Document;
+  channel_logo_dark?: string;
+  channel_logo_light?: string;
   channel_mode?: string;
   channel_name?: string;
   channel_primary_color_dark?: string;
@@ -383,14 +356,14 @@ export interface CollectorUpdateInput {
 export interface Comcheck {
   /** @format date-time */
   comcheck_end_date: string;
-  comcheck_exercise?: Exercise;
+  comcheck_exercise?: string;
   comcheck_id: string;
   comcheck_message?: string;
   comcheck_name?: string;
   /** @format date-time */
   comcheck_start_date: string;
   comcheck_state?: "RUNNING" | "EXPIRED" | "FINISHED";
-  comcheck_statuses?: ComcheckStatus[];
+  comcheck_statuses?: string[];
   comcheck_subject?: string;
   /** @format int64 */
   comcheck_users_number?: number;
@@ -407,7 +380,7 @@ export interface ComcheckInput {
 }
 
 export interface ComcheckStatus {
-  comcheckstatus_comcheck?: Comcheck;
+  comcheckstatus_comcheck?: string;
   comcheckstatus_id?: string;
   /** @format date-time */
   comcheckstatus_receive_date?: string;
@@ -416,7 +389,7 @@ export interface ComcheckStatus {
   /** @format int32 */
   comcheckstatus_sent_retry?: number;
   comcheckstatus_state?: "RUNNING" | "SUCCESS" | "FAILURE";
-  comcheckstatus_user?: User;
+  comcheckstatus_user?: string;
   listened?: boolean;
 }
 
@@ -429,7 +402,7 @@ export interface Communication {
   communication_exercise?: string;
   communication_from: string;
   communication_id: string;
-  communication_inject?: Inject;
+  communication_inject?: string;
   communication_message_id: string;
   /** @format date-time */
   communication_received_at: string;
@@ -437,7 +410,7 @@ export interface Communication {
   communication_sent_at: string;
   communication_subject?: string;
   communication_to: string;
-  communication_users?: User[];
+  communication_users?: string[];
   listened?: boolean;
 }
 
@@ -468,14 +441,11 @@ export interface DirectInjectInput {
 
 export interface Document {
   document_description?: string;
-  /** @uniqueItems true */
-  document_exercises?: Exercise[];
+  document_exercises?: string[];
   document_id: string;
   document_name: string;
-  /** @uniqueItems true */
-  document_scenarios?: Scenario[];
-  /** @uniqueItems true */
-  document_tags?: Tag[];
+  document_scenarios?: string[];
+  document_tags?: string[];
   document_target?: string;
   document_type: string;
   listened?: boolean;
@@ -502,8 +472,8 @@ export interface DocumentUpdateInput {
 export interface DryInject {
   /** @format date-time */
   dryinject_date: string;
-  dryinject_dryrun?: Dryrun;
-  dryinject_exercise?: Exercise;
+  dryinject_dryrun?: string;
+  dryinject_exercise?: string;
   dryinject_id?: string;
   dryinject_inject?: Inject;
   dryinject_status?: DryInjectStatus;
@@ -545,7 +515,7 @@ export interface Dryrun {
   dryrun_date: string;
   /** @format date-time */
   dryrun_end_date?: string;
-  dryrun_exercise?: Exercise;
+  dryrun_exercise?: string;
   dryrun_finished?: boolean;
   dryrun_id: string;
   dryrun_name?: string;
@@ -553,7 +523,7 @@ export interface Dryrun {
   dryrun_speed?: number;
   /** @format date-time */
   dryrun_start_date?: string;
-  dryrun_users?: User[];
+  dryrun_users?: string[];
   /** @format int64 */
   dryrun_users_number?: number;
   listened?: boolean;
@@ -566,23 +536,22 @@ export interface DryrunCreateInput {
 
 export interface Endpoint {
   asset_active?: boolean;
-  asset_children?: Asset[];
+  asset_children?: string[];
   /** @format date-time */
   asset_cleared_at?: string;
   /** @format date-time */
   asset_created_at: string;
   asset_description?: string;
-  asset_executor?: Executor;
+  asset_executor?: string;
   asset_external_reference?: string;
   asset_id: string;
-  asset_inject?: Inject;
+  asset_inject?: string;
   /** @format date-time */
   asset_last_seen?: string;
   asset_name: string;
-  asset_parent?: Asset;
+  asset_parent?: string;
   asset_process_name?: string;
-  /** @uniqueItems true */
-  asset_tags?: Tag[];
+  asset_tags?: string[];
   asset_type?: string;
   /** @format date-time */
   asset_updated_at: string;
@@ -636,12 +605,12 @@ export interface Evaluation {
   /** @format date-time */
   evaluation_created_at: string;
   evaluation_id: string;
-  evaluation_objective: Objective;
+  evaluation_objective: string;
   /** @format int64 */
   evaluation_score?: number;
   /** @format date-time */
   evaluation_updated_at: string;
-  evaluation_user: User;
+  evaluation_user: string;
   listened?: boolean;
 }
 
@@ -678,26 +647,26 @@ export interface ExecutorUpdateInput {
 export interface Exercise {
   /** @format int64 */
   exercise_all_users_number?: number;
-  exercise_articles?: Article[];
+  exercise_articles?: string[];
   exercise_category?: string;
   /** @format int64 */
   exercise_communications_number?: number;
   /** @format date-time */
   exercise_created_at: string;
   exercise_description?: string;
-  exercise_documents?: Document[];
+  exercise_documents?: string[];
   /** @format date-time */
   exercise_end_date?: string;
   exercise_id: string;
-  exercise_injects?: Inject[];
+  exercise_injects?: string[];
   exercise_injects_statistics?: Record<string, number>;
   exercise_kill_chain_phases?: KillChainPhase[];
   exercise_lessons_anonymized?: boolean;
   /** @format int64 */
   exercise_lessons_answers_number?: number;
-  exercise_lessons_categories?: LessonsCategory[];
-  exercise_logo_dark?: Document;
-  exercise_logo_light?: Document;
+  exercise_lessons_categories?: string[];
+  exercise_logo_dark?: string;
+  exercise_logo_light?: string;
   /** @format int64 */
   exercise_logs_number?: number;
   exercise_mail_from: string;
@@ -709,11 +678,11 @@ export interface Exercise {
   /** @format date-time */
   exercise_next_inject_date?: string;
   exercise_next_possible_status?: ("SCHEDULED" | "CANCELED" | "RUNNING" | "PAUSED" | "FINISHED")[];
-  exercise_observers?: User[];
-  exercise_pauses?: Pause[];
-  exercise_planners?: User[];
+  exercise_observers?: string[];
+  exercise_pauses?: string[];
+  exercise_planners?: string[];
   exercise_platforms?: ("Linux" | "Windows" | "MacOS" | "Container" | "Service" | "Generic" | "Internal" | "Unknown")[];
-  exercise_scenario?: Scenario;
+  exercise_scenario?: string;
   /** @format double */
   exercise_score?: number;
   exercise_severity?: "low" | "medium" | "high" | "critical";
@@ -721,13 +690,12 @@ export interface Exercise {
   exercise_start_date?: string;
   exercise_status: "SCHEDULED" | "CANCELED" | "RUNNING" | "PAUSED" | "FINISHED";
   exercise_subtitle?: string;
-  /** @uniqueItems true */
-  exercise_tags?: Tag[];
+  exercise_tags?: string[];
   exercise_teams?: string[];
   exercise_teams_users?: ExerciseTeamUser[];
   /** @format date-time */
   exercise_updated_at: string;
-  exercise_users?: User[];
+  exercise_users?: string[];
   /** @format int64 */
   exercise_users_number?: number;
   listened?: boolean;
@@ -835,9 +803,9 @@ export interface ExerciseTeamPlayersEnableInput {
 }
 
 export interface ExerciseTeamUser {
-  exercise_id?: Exercise;
-  team_id?: Team;
-  user_id?: User;
+  exercise_id?: string;
+  team_id?: string;
+  user_id?: string;
 }
 
 export interface ExerciseUpdateLogoInput {
@@ -926,11 +894,11 @@ export interface FullTextSearchResult {
 }
 
 export interface Grant {
-  grant_exercise?: Exercise;
-  grant_group?: Group;
+  grant_exercise?: string;
+  grant_group?: string;
   grant_id: string;
   grant_name: "OBSERVER" | "PLANNER";
-  grant_scenario?: Scenario;
+  grant_scenario?: string;
   listened?: boolean;
 }
 
@@ -946,8 +914,8 @@ export interface Group {
   group_grants?: Grant[];
   group_id: string;
   group_name: string;
-  group_organizations?: Organization[];
-  group_users?: User[];
+  group_organizations?: string[];
+  group_users?: string[];
   listened?: boolean;
 }
 
@@ -1026,11 +994,11 @@ export interface Inject {
   footer?: string;
   header?: string;
   inject_all_teams?: boolean;
-  inject_asset_groups?: AssetGroup[];
-  inject_assets?: Asset[];
+  inject_asset_groups?: string[];
+  inject_assets?: string[];
   inject_attack_patterns?: AttackPattern[];
   inject_city?: string;
-  inject_communications?: Communication[];
+  inject_communications?: string[];
   /** @format int64 */
   inject_communications_not_ack_number?: number;
   /** @format int64 */
@@ -1048,22 +1016,21 @@ export interface Inject {
   inject_depends_duration: number;
   inject_depends_on?: InjectDependency[];
   inject_description?: string;
-  inject_documents?: InjectDocument[];
+  inject_documents?: string[];
   inject_enabled?: boolean;
-  inject_exercise?: Exercise;
-  inject_expectations?: InjectExpectation[];
+  inject_exercise?: string;
+  inject_expectations?: string[];
   inject_id: string;
   inject_injector_contract?: InjectorContract;
   inject_kill_chain_phases?: KillChainPhase[];
-  inject_payloads?: Asset[];
+  inject_payloads?: string[];
   inject_ready?: boolean;
-  inject_scenario?: Scenario;
+  inject_scenario?: string;
   /** @format date-time */
   inject_sent_at?: string;
   inject_status?: InjectStatus;
-  /** @uniqueItems true */
-  inject_tags?: Tag[];
-  inject_teams?: Team[];
+  inject_tags?: string[];
+  inject_teams?: string[];
   inject_testable?: boolean;
   inject_title: string;
   /** @format date-time */
@@ -1071,7 +1038,7 @@ export interface Inject {
   inject_type?: string;
   /** @format date-time */
   inject_updated_at: string;
-  inject_user?: User;
+  inject_user?: string;
   /** @format int64 */
   inject_users_number?: number;
   listened?: boolean;
@@ -1106,13 +1073,6 @@ export interface InjectDependencyInput {
   dependency_relationship?: InjectDependencyIdInput;
 }
 
-export interface InjectDocument {
-  document_attached?: boolean;
-  document_id?: Document;
-  document_name?: string;
-  inject_id?: Inject;
-}
-
 export interface InjectDocumentInput {
   document_attached?: boolean;
   document_id?: string;
@@ -1127,30 +1087,30 @@ export interface InjectExecutionInput {
 }
 
 export interface InjectExpectation {
-  inject_expectation_article?: Article;
-  inject_expectation_asset?: Asset;
-  inject_expectation_asset_group?: AssetGroup;
-  inject_expectation_challenge?: Challenge;
+  inject_expectation_article?: string;
+  inject_expectation_asset?: string;
+  inject_expectation_asset_group?: string;
+  inject_expectation_challenge?: string;
   /** @format date-time */
   inject_expectation_created_at?: string;
   inject_expectation_description?: string;
-  inject_expectation_exercise?: Exercise;
+  inject_expectation_exercise?: string;
   /** @format double */
   inject_expectation_expected_score: number;
   inject_expectation_group?: boolean;
   inject_expectation_id: string;
-  inject_expectation_inject?: Inject;
+  inject_expectation_inject?: string;
   inject_expectation_name?: string;
   inject_expectation_results?: InjectExpectationResult[];
   /** @format double */
   inject_expectation_score?: number;
   inject_expectation_signatures?: InjectExpectationSignature[];
   inject_expectation_status?: "FAILED" | "PENDING" | "PARTIAL" | "UNKNOWN" | "SUCCESS";
-  inject_expectation_team?: Team;
+  inject_expectation_team?: string;
   inject_expectation_type: "TEXT" | "DOCUMENT" | "ARTICLE" | "CHALLENGE" | "MANUAL" | "PREVENTION" | "DETECTION";
   /** @format date-time */
   inject_expectation_updated_at?: string;
-  inject_expectation_user?: User;
+  inject_expectation_user?: string;
   /** @format int64 */
   inject_expiration_time: number;
   listened?: boolean;
@@ -1159,6 +1119,7 @@ export interface InjectExpectation {
 
 export interface InjectExpectationResult {
   date?: string;
+  metadata?: Record<string, string>;
   result: string;
   /** @format double */
   score?: number;
@@ -1168,7 +1129,7 @@ export interface InjectExpectationResult {
 }
 
 export interface InjectExpectationResultsByAttackPattern {
-  inject_attack_pattern?: AttackPattern;
+  inject_attack_pattern?: string;
   inject_expectation_results?: InjectExpectationResultsByType[];
 }
 
@@ -1191,15 +1152,15 @@ export interface InjectExpectationSimple {
 export interface InjectExpectationUpdateInput {
   collector_id: string;
   is_success: boolean;
+  metadata?: Record<string, string>;
   result: string;
-  success?: boolean;
 }
 
 export interface InjectImporter {
   /** @format date-time */
   inject_importer_created_at?: string;
   inject_importer_id: string;
-  inject_importer_injector_contract: InjectorContract;
+  inject_importer_injector_contract: string;
   inject_importer_rule_attributes?: RuleAttribute[];
   inject_importer_type_value: string;
   /** @format date-time */
@@ -1503,14 +1464,14 @@ export interface InjectorContract {
   convertedContent?: object;
   injector_contract_arch?: "x86_64" | "arm64" | "Unknown";
   injector_contract_atomic_testing?: boolean;
-  injector_contract_attack_patterns?: AttackPattern[];
+  injector_contract_attack_patterns?: string[];
   injector_contract_content: string;
   /** @format date-time */
   injector_contract_created_at: string;
   injector_contract_custom?: boolean;
   injector_contract_id: string;
   injector_contract_import_available?: boolean;
-  injector_contract_injector: Injector;
+  injector_contract_injector: string;
   injector_contract_injector_type?: string;
   injector_contract_labels?: Record<string, string>;
   injector_contract_manual?: boolean;
@@ -1725,12 +1686,12 @@ export interface LessonsCategory {
   /** @format date-time */
   lessons_category_created_at: string;
   lessons_category_description?: string;
-  lessons_category_exercise?: Exercise;
+  lessons_category_exercise?: string;
   lessons_category_name: string;
   /** @format int32 */
   lessons_category_order?: number;
   lessons_category_questions?: string[];
-  lessons_category_scenario?: Scenario;
+  lessons_category_scenario?: string;
   lessons_category_teams?: string[];
   /** @format date-time */
   lessons_category_updated_at: string;
@@ -1763,7 +1724,7 @@ export interface LessonsInput {
 
 export interface LessonsQuestion {
   lessons_question_answers?: string[];
-  lessons_question_category: LessonsCategory;
+  lessons_question_category: string;
   lessons_question_content: string;
   /** @format date-time */
   lessons_question_created_at: string;
@@ -1815,8 +1776,8 @@ export interface LessonsTemplateCategory {
   lessons_template_category_name: string;
   /** @format int32 */
   lessons_template_category_order: number;
-  lessons_template_category_questions?: LessonsTemplateQuestion[];
-  lessons_template_category_template?: LessonsTemplate;
+  lessons_template_category_questions?: string[];
+  lessons_template_category_template?: string;
   /** @format date-time */
   lessons_template_category_updated_at: string;
   lessonstemplatecategory_id: string;
@@ -1836,7 +1797,7 @@ export interface LessonsTemplateInput {
 }
 
 export interface LessonsTemplateQuestion {
-  lessons_template_question_category?: LessonsTemplateCategory;
+  lessons_template_question_category?: string;
   lessons_template_question_content: string;
   /** @format date-time */
   lessons_template_question_created_at: string;
@@ -1861,14 +1822,13 @@ export interface Log {
   log_content: string;
   /** @format date-time */
   log_created_at: string;
-  log_exercise?: Exercise;
+  log_exercise?: string;
   log_id: string;
-  /** @uniqueItems true */
-  log_tags?: Tag[];
+  log_tags?: string[];
   log_title: string;
   /** @format date-time */
   log_updated_at: string;
-  log_user?: User;
+  log_user?: string;
 }
 
 export interface LogCreateInput {
@@ -1884,7 +1844,7 @@ export interface LoginUserInput {
 
 export interface Mitigation {
   listened?: boolean;
-  mitigation_attack_patterns?: AttackPattern[];
+  mitigation_attack_patterns?: string[];
   /** @format date-time */
   mitigation_created_at: string;
   mitigation_description?: string;
@@ -1930,12 +1890,12 @@ export interface Objective {
   /** @format date-time */
   objective_created_at: string;
   objective_description?: string;
-  objective_evaluations?: Evaluation[];
-  objective_exercise?: Exercise;
+  objective_evaluations?: string[];
+  objective_exercise?: string;
   objective_id: string;
   /** @format int32 */
   objective_priority?: number;
-  objective_scenario?: Scenario;
+  objective_scenario?: string;
   /** @format double */
   objective_score?: number;
   objective_title?: string;
@@ -1961,12 +1921,11 @@ export interface Organization {
   organization_created_at: string;
   organization_description?: string;
   organization_id: string;
-  organization_injects?: Inject[];
+  organization_injects?: string[];
   /** @format int64 */
   organization_injects_number?: number;
   organization_name: string;
-  /** @uniqueItems true */
-  organization_tags?: Tag[];
+  organization_tags?: string[];
   /** @format date-time */
   organization_updated_at: string;
 }
@@ -2398,25 +2357,15 @@ export interface PageableObject {
   unpaged?: boolean;
 }
 
-export interface Pause {
-  listened?: boolean;
-  log_id?: string;
-  /** @format date-time */
-  pause_date?: string;
-  /** @format int64 */
-  pause_duration?: number;
-  pause_exercise?: Exercise;
-}
-
-export type PayloadStatus =  "UNVERIFIED" | "VERIFIED" | "DEPRECATED";
-
 export interface Payload {
   listened?: boolean;
+  /** @format int32 */
+  numberOfActions?: number;
   payload_arguments?: PayloadArgument[];
-  payload_attack_patterns?: AttackPattern[];
+  payload_attack_patterns?: string[];
   payload_cleanup_command?: string;
   payload_cleanup_executor?: string;
-  payload_collector?: Collector;
+  payload_collector?: string;
   payload_collector_type?: string;
   /** @format date-time */
   payload_created_at: string;
@@ -2428,9 +2377,8 @@ export interface Payload {
   payload_platforms?: ("Linux" | "Windows" | "MacOS" | "Container" | "Service" | "Generic" | "Internal" | "Unknown")[];
   payload_prerequisites?: PayloadPrerequisite[];
   payload_source: "COMMUNITY" | "FILIGRAN" | "MANUAL";
-  payload_status: PayloadStatus;
-  /** @uniqueItems true */
-  payload_tags?: Tag[];
+  payload_status: "UNVERIFIED" | "VERIFIED" | "DEPRECATED";
+  payload_tags?: string[];
   payload_type?: string;
   /** @format date-time */
   payload_updated_at: string;
@@ -2459,7 +2407,7 @@ export interface PayloadCreateInput {
   payload_platforms: ("Linux" | "Windows" | "MacOS" | "Container" | "Service" | "Generic" | "Internal" | "Unknown")[];
   payload_prerequisites?: PayloadPrerequisite[];
   payload_source: "COMMUNITY" | "FILIGRAN" | "MANUAL";
-  payload_status: "UNVERIFIED" | "VERIFIED";
+  payload_status: "UNVERIFIED" | "VERIFIED" | "DEPRECATED";
   payload_tags?: string[];
   payload_type: string;
 }
@@ -2513,9 +2461,14 @@ export interface PayloadUpsertInput {
   payload_platforms?: ("Linux" | "Windows" | "MacOS" | "Container" | "Service" | "Generic" | "Internal" | "Unknown")[];
   payload_prerequisites?: PayloadPrerequisite[];
   payload_source: "COMMUNITY" | "FILIGRAN" | "MANUAL";
-  payload_status: "UNVERIFIED" | "VERIFIED";
+  payload_status: "UNVERIFIED" | "VERIFIED" | "DEPRECATED";
   payload_tags?: string[];
   payload_type: string;
+}
+
+export interface PayloadsDeprecateInput {
+  collector_id: string;
+  payload_external_ids: string[];
 }
 
 export interface PlatformSettings {
@@ -2734,7 +2687,7 @@ export interface Report {
   listened?: boolean;
   /** @format date-time */
   report_created_at: string;
-  report_exercise?: Exercise;
+  report_exercise?: string;
   report_global_observation?: string;
   report_id: string;
   report_informations?: ReportInformation[];
@@ -2747,7 +2700,7 @@ export interface Report {
 export interface ReportInformation {
   id: string;
   listened?: boolean;
-  report: Report;
+  report: string;
   report_informations_display?: boolean;
   report_informations_type:
     | "MAIN_INFORMATION"
@@ -2830,31 +2783,31 @@ export interface Scenario {
   listened?: boolean;
   /** @format int64 */
   scenario_all_users_number?: number;
-  scenario_articles?: Article[];
+  scenario_articles?: string[];
   scenario_category?: string;
   /** @format int64 */
   scenario_communications_number?: number;
   /** @format date-time */
   scenario_created_at: string;
   scenario_description?: string;
-  scenario_documents?: Document[];
-  scenario_exercises?: Exercise[];
+  scenario_documents?: string[];
+  scenario_exercises?: string[];
   scenario_external_reference?: string;
   scenario_external_url?: string;
   scenario_id: string;
-  scenario_injects?: Inject[];
+  scenario_injects?: string[];
   scenario_injects_statistics?: Record<string, number>;
   scenario_kill_chain_phases?: KillChainPhase[];
   scenario_lessons_anonymized?: boolean;
-  scenario_lessons_categories?: LessonsCategory[];
+  scenario_lessons_categories?: string[];
   scenario_mail_from: string;
   scenario_mails_reply_to?: string[];
   scenario_main_focus?: string;
   scenario_message_footer?: string;
   scenario_message_header?: string;
   scenario_name: string;
-  scenario_observers?: User[];
-  scenario_planners?: User[];
+  scenario_observers?: string[];
+  scenario_planners?: string[];
   scenario_platforms?: ("Linux" | "Windows" | "MacOS" | "Container" | "Service" | "Generic" | "Internal" | "Unknown")[];
   scenario_recurrence?: string;
   /** @format date-time */
@@ -2863,13 +2816,12 @@ export interface Scenario {
   scenario_recurrence_start?: string;
   scenario_severity?: "low" | "medium" | "high" | "critical";
   scenario_subtitle?: string;
-  /** @uniqueItems true */
-  scenario_tags?: Tag[];
-  scenario_teams?: Team[];
+  scenario_tags?: string[];
+  scenario_teams?: string[];
   scenario_teams_users?: ScenarioTeamUser[];
   /** @format date-time */
   scenario_updated_at: string;
-  scenario_users?: User[];
+  scenario_users?: string[];
   /** @format int64 */
   scenario_users_number?: number;
 }
@@ -2886,7 +2838,7 @@ export interface ScenarioInput {
   scenario_description?: string;
   scenario_external_reference?: string;
   scenario_external_url?: string;
-  scenario_mail_from: string;
+  scenario_mail_from?: string;
   scenario_mails_reply_to?: string[];
   scenario_main_focus?: string;
   scenario_message_footer?: string;
@@ -2909,8 +2861,7 @@ export interface ScenarioSimple {
   scenario_id?: string;
   scenario_name?: string;
   scenario_subtitle?: string;
-  /** @uniqueItems true */
-  scenario_tags?: Tag[];
+  scenario_tags?: string[];
 }
 
 export interface ScenarioStatistic {
@@ -2924,9 +2875,9 @@ export interface ScenarioTeamPlayersEnableInput {
 }
 
 export interface ScenarioTeamUser {
-  scenario_id?: Scenario;
-  team_id?: Team;
-  user_id?: User;
+  scenario_id?: string;
+  team_id?: string;
+  user_id?: string;
 }
 
 export interface ScenarioUpdateTagsInput {
@@ -2963,29 +2914,28 @@ export interface SearchTerm {
 
 export interface SecurityPlatform {
   asset_active?: boolean;
-  asset_children?: Asset[];
+  asset_children?: string[];
   /** @format date-time */
   asset_cleared_at?: string;
   /** @format date-time */
   asset_created_at: string;
   asset_description?: string;
-  asset_executor?: Executor;
+  asset_executor?: string;
   asset_external_reference?: string;
   asset_id: string;
-  asset_inject?: Inject;
+  asset_inject?: string;
   /** @format date-time */
   asset_last_seen?: string;
   asset_name: string;
-  asset_parent?: Asset;
+  asset_parent?: string;
   asset_process_name?: string;
-  /** @uniqueItems true */
-  asset_tags?: Tag[];
+  asset_tags?: string[];
   asset_type?: string;
   /** @format date-time */
   asset_updated_at: string;
   listened?: boolean;
-  security_platform_logo_dark?: Document;
-  security_platform_logo_light?: Document;
+  security_platform_logo_dark?: string;
+  security_platform_logo_light?: string;
   security_platform_type: "EDR" | "XDR" | "SIEM" | "SOAR" | "NDR" | "ISPM";
 }
 
@@ -3077,13 +3027,13 @@ export interface Team {
   /** @format date-time */
   team_created_at: string;
   team_description?: string;
-  team_exercise_injects?: Inject[];
+  team_exercise_injects?: string[];
   /** @format int64 */
   team_exercise_injects_number?: number;
-  team_exercises?: Exercise[];
-  team_exercises_users?: ExerciseTeamUser[];
+  team_exercises?: string[];
+  team_exercises_users?: string[];
   team_id: string;
-  team_inject_expectations?: InjectExpectation[];
+  team_inject_expectations?: string[];
   /** @format int64 */
   team_injects_expectations_number?: number;
   /** @format double */
@@ -3093,16 +3043,15 @@ export interface Team {
   team_injects_expectations_total_score: number;
   team_injects_expectations_total_score_by_exercise: Record<string, number>;
   team_name: string;
-  team_organization?: Organization;
-  team_scenario_injects?: Inject[];
+  team_organization?: string;
+  team_scenario_injects?: string[];
   /** @format int64 */
   team_scenario_injects_number?: number;
-  team_scenarios?: Scenario[];
-  /** @uniqueItems true */
-  team_tags?: Tag[];
+  team_scenarios?: string[];
+  team_tags?: string[];
   /** @format date-time */
   team_updated_at: string;
-  team_users?: User[];
+  team_users?: string[];
   /** @format int64 */
   team_users_number?: number;
 }
@@ -3157,7 +3106,7 @@ export interface Token {
   /** @format date-time */
   token_created_at: string;
   token_id: string;
-  token_user?: User;
+  token_user?: string;
   token_value: string;
 }
 
@@ -3206,22 +3155,18 @@ export interface UpdateUsersTeamInput {
 
 export interface User {
   user_phone2?: string;
-  injects?: Inject[];
   listened?: boolean;
   user_admin?: boolean;
   user_city?: string;
-  user_communications?: Communication[];
+  user_communications?: string[];
   user_country?: string;
   /** @format date-time */
   user_created_at: string;
   user_email: string;
   user_firstname?: string;
   user_gravatar?: string;
-  user_groups?: Group[];
+  user_groups?: string[];
   user_id: string;
-  user_injects?: Inject[];
-  /** @format int64 */
-  user_injects_number?: number;
   user_is_external?: boolean;
   user_is_manager?: boolean;
   user_is_observer?: boolean;
@@ -3232,14 +3177,13 @@ export interface User {
   /** @format date-time */
   user_last_comcheck?: string;
   user_lastname?: string;
-  user_organization?: Organization;
+  user_organization?: string;
   user_pgp_key?: string;
   user_phone?: string;
   /** @format int32 */
   user_status: number;
-  /** @uniqueItems true */
-  user_tags?: Tag[];
-  user_teams?: Team[];
+  user_tags?: string[];
+  user_teams?: string[];
   user_theme?: string;
   /** @format date-time */
   user_updated_at: string;
@@ -3265,11 +3209,11 @@ export interface Variable {
   /** @format date-time */
   variable_created_at: string;
   variable_description?: string;
-  variable_exercise?: Exercise;
+  variable_exercise?: string;
   variable_id: string;
   /** @pattern ^[a-z_]+$ */
   variable_key: string;
-  variable_scenario?: Scenario;
+  variable_scenario?: string;
   variable_type: "String" | "Object";
   /** @format date-time */
   variable_updated_at: string;

--- a/openbas-model/src/main/java/io/openbas/database/model/Article.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Article.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -72,12 +74,14 @@ public class Article implements Base {
   @JoinColumn(name = "article_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("article_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "article_scenario")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("article_scenario")
+  @Schema(type = "string")
   private Scenario scenario;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -85,8 +89,10 @@ public class Article implements Base {
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("article_channel")
   @NotNull
+  @Schema(type = "string")
   private Channel channel;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "articles_documents",

--- a/openbas-model/src/main/java/io/openbas/database/model/Asset.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Asset.java
@@ -11,6 +11,8 @@ import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
 import io.openbas.helper.MultiIdSetDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -75,6 +77,7 @@ public class Asset implements Base {
 
   // -- TAG --
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Queryable(filterable = true, sortable = true, dynamicValues = true, path = "tags.id")
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
@@ -90,14 +93,17 @@ public class Asset implements Base {
   @JoinColumn(name = "asset_executor")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("asset_executor")
+  @Schema(type = "string")
   private Executor executor;
 
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "asset_parent")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("asset_parent")
+  @Schema(type = "string")
   private Asset parent;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(fetch = FetchType.EAGER)
   @JoinColumn(name = "asset_parent")
   @JsonSerialize(using = MultiIdListDeserializer.class)
@@ -108,6 +114,7 @@ public class Asset implements Base {
   @JoinColumn(name = "asset_inject")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("asset_inject")
+  @Schema(type = "string")
   private Inject inject;
 
   @JsonProperty("asset_active")

--- a/openbas-model/src/main/java/io/openbas/database/model/AssetAgentJob.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/AssetAgentJob.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Objects;
@@ -30,6 +31,7 @@ public class AssetAgentJob implements Base {
   @JoinColumn(name = "asset_agent_inject")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("asset_agent_inject")
+  @Schema(type = "string")
   private Inject inject;
 
   @Getter
@@ -37,6 +39,7 @@ public class AssetAgentJob implements Base {
   @JoinColumn(name = "asset_agent_asset")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("asset_agent_asset")
+  @Schema(type = "string")
   private Asset asset;
 
   @Getter

--- a/openbas-model/src/main/java/io/openbas/database/model/AssetGroup.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/AssetGroup.java
@@ -11,6 +11,8 @@ import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.database.model.Filters.FilterGroup;
 import io.openbas.helper.MultiIdListDeserializer;
 import io.openbas.helper.MultiIdSetDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -58,6 +60,7 @@ public class AssetGroup implements Base {
   @JsonProperty("asset_group_dynamic_filter")
   private FilterGroup dynamicFilter;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(
       name = "asset_groups_assets",
@@ -73,6 +76,7 @@ public class AssetGroup implements Base {
   private List<Asset> dynamicAssets = new ArrayList<>();
 
   // Getter is Mandatory when we use @Transient annotation
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<Asset> getDynamicAssets() {
     return this.dynamicAssets;
@@ -80,6 +84,7 @@ public class AssetGroup implements Base {
 
   // -- TAG --
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "asset_groups_tags",

--- a/openbas-model/src/main/java/io/openbas/database/model/AttackPattern.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/AttackPattern.java
@@ -9,6 +9,8 @@ import io.openbas.annotation.Queryable;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import java.time.Instant;
@@ -79,8 +81,10 @@ public class AttackPattern implements Base {
   @JoinColumn(name = "attack_pattern_parent")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("attack_pattern_parent")
+  @Schema(type = "string")
   private AttackPattern parent;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "attack_patterns_kill_chain_phases",

--- a/openbas-model/src/main/java/io/openbas/database/model/Challenge.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Challenge.java
@@ -8,6 +8,8 @@ import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MultiIdListDeserializer;
 import io.openbas.helper.MultiIdSetDeserializer;
 import io.openbas.helper.MultiModelDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -75,6 +77,7 @@ public class Challenge implements Base {
   @NotEmpty
   private List<ChallengeFlag> flags = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "challenges_tags",
@@ -84,6 +87,7 @@ public class Challenge implements Base {
   @JsonProperty("challenge_tags")
   private Set<Tag> tags = new HashSet<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "challenges_documents",

--- a/openbas-model/src/main/java/io/openbas/database/model/ChallengeFlag.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/ChallengeFlag.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.Objects;
@@ -58,6 +59,7 @@ public class ChallengeFlag implements Base {
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JoinColumn(name = "flag_challenge")
   @JsonProperty("flag_challenge")
+  @Schema(type = "string")
   private Challenge challenge;
 
   @Override

--- a/openbas-model/src/main/java/io/openbas/database/model/Channel.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Channel.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -76,12 +77,14 @@ public class Channel implements Base {
   @JoinColumn(name = "channel_logo_dark")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("channel_logo_dark")
+  @Schema(type = "string")
   private Document logoDark;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "channel_logo_light")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("channel_logo_light")
+  @Schema(type = "string")
   private Document logoLight;
 
   @Override

--- a/openbas-model/src/main/java/io/openbas/database/model/Comcheck.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Comcheck.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -68,9 +70,11 @@ public class Comcheck implements Base {
   @JoinColumn(name = "comcheck_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("comcheck_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   // CascadeType.ALL is required here because comcheck statuses are embedded
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(mappedBy = "comcheck", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @JsonProperty("comcheck_statuses")

--- a/openbas-model/src/main/java/io/openbas/database/model/ComcheckStatus.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/ComcheckStatus.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.Objects;
@@ -35,12 +36,14 @@ public class ComcheckStatus implements Base {
   @JoinColumn(name = "status_user")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("comcheckstatus_user")
+  @Schema(type = "string")
   private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "status_comcheck")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("comcheckstatus_comcheck")
+  @Schema(type = "string")
   private Comcheck comcheck;
 
   @Column(name = "status_sent_date")

--- a/openbas-model/src/main/java/io/openbas/database/model/Communication.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Communication.java
@@ -9,6 +9,8 @@ import io.hypersistence.utils.hibernate.type.array.StringArrayType;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -71,8 +73,10 @@ public class Communication implements Base {
   @JoinColumn(name = "communication_inject")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("communication_inject")
+  @Schema(type = "string")
   private Inject inject;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "communications_users",

--- a/openbas-model/src/main/java/io/openbas/database/model/Document.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Document.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.annotation.Queryable;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MultiIdSetDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import java.util.*;
@@ -58,6 +60,7 @@ public class Document implements Base {
   @NotBlank
   private String type;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "documents_tags",
@@ -68,6 +71,7 @@ public class Document implements Base {
   @Queryable(sortable = true)
   private Set<Tag> tags = new HashSet<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "exercises_documents",
@@ -77,6 +81,7 @@ public class Document implements Base {
   @JsonProperty("document_exercises")
   private Set<Exercise> exercises = new HashSet<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "scenarios_documents",

--- a/openbas-model/src/main/java/io/openbas/database/model/DryInject.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/DryInject.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
@@ -44,6 +45,7 @@ public class DryInject implements Base, Injection {
   @JoinColumn(name = "dryinject_dryrun")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("dryinject_dryrun")
+  @Schema(type = "string")
   private Dryrun run;
 
   @Getter
@@ -60,6 +62,7 @@ public class DryInject implements Base, Injection {
   @Override
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("dryinject_exercise")
+  @Schema(type = "string")
   public Exercise getExercise() {
     return getInject().getExercise();
   }

--- a/openbas-model/src/main/java/io/openbas/database/model/Dryrun.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Dryrun.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -50,12 +52,14 @@ public class Dryrun implements Base {
   @JoinColumn(name = "dryrun_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("dryrun_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @OneToMany(mappedBy = "run", fetch = FetchType.LAZY)
   @JsonIgnore
   private List<DryInject> injects = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "dryruns_users",

--- a/openbas-model/src/main/java/io/openbas/database/model/Evaluation.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Evaluation.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -35,6 +36,7 @@ public class Evaluation implements Base {
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("evaluation_objective")
   @NotNull
+  @Schema(type = "string")
   private Objective objective;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -42,6 +44,7 @@ public class Evaluation implements Base {
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("evaluation_user")
   @NotNull
+  @Schema(type = "string")
   private User user;
 
   @Column(name = "evaluation_score")

--- a/openbas-model/src/main/java/io/openbas/database/model/Executable.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Executable.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.annotation.Queryable;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -26,6 +27,7 @@ public class Executable extends Payload {
   @JoinColumn(name = "executable_file")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("executable_file")
+  @Schema(type = "string")
   private Document executableFile;
 
   @Queryable(filterable = true, searchable = true)

--- a/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
@@ -127,6 +127,7 @@ public class Exercise implements Base {
   @JoinColumn(name = "exercise_logo_dark")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("exercise_logo_dark")
+  @Schema(type = "string")
   private Document logoDark;
 
   @Getter
@@ -134,6 +135,7 @@ public class Exercise implements Base {
   @JoinColumn(name = "exercise_logo_light")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("exercise_logo_light")
+  @Schema(type = "string")
   private Document logoLight;
 
   @Getter
@@ -151,6 +153,7 @@ public class Exercise implements Base {
       inverseJoinColumns = @JoinColumn(name = "scenario_id"))
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("exercise_scenario")
+  @Schema(type = "string")
   @Queryable(filterable = true, dynamicValues = true)
   private Scenario scenario;
 
@@ -176,6 +179,7 @@ public class Exercise implements Base {
   @JsonIgnore
   private List<Grant> grants = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(mappedBy = "exercise", fetch = FetchType.LAZY)
   @JsonProperty("exercise_injects")
   @JsonSerialize(using = MultiIdListDeserializer.class)
@@ -212,12 +216,14 @@ public class Exercise implements Base {
   @JsonIgnore
   private List<Log> logs = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @OneToMany(mappedBy = "exercise", fetch = FetchType.LAZY)
   @JsonProperty("exercise_pauses")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   private List<Pause> pauses = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
@@ -229,6 +235,7 @@ public class Exercise implements Base {
   @Queryable(filterable = true, dynamicValues = true, path = "tags.id")
   private Set<Tag> tags = new HashSet<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
@@ -239,12 +246,14 @@ public class Exercise implements Base {
   @JsonProperty("exercise_documents")
   private List<Document> documents = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @OneToMany(mappedBy = "exercise", fetch = FetchType.LAZY)
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @JsonProperty("exercise_articles")
   private List<Article> articles = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @OneToMany(mappedBy = "exercise", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JsonSerialize(using = MultiIdListDeserializer.class)
@@ -267,12 +276,14 @@ public class Exercise implements Base {
         .count();
   }
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonProperty("exercise_planners")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<User> getPlanners() {
     return getUsersByType(this.getGrants(), PLANNER);
   }
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonProperty("exercise_observers")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<User> getObservers() {
@@ -305,6 +316,7 @@ public class Exercise implements Base {
     return getTeamUsers().stream().map(ExerciseTeamUser::getUser).distinct().count();
   }
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonProperty("exercise_users")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<User> getUsers() {

--- a/openbas-model/src/main/java/io/openbas/database/model/ExerciseTeamUser.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/ExerciseTeamUser.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.raw.RawExerciseTeamUser;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import java.util.Objects;
 
@@ -18,6 +19,7 @@ public class ExerciseTeamUser {
   @JoinColumn(name = "exercise_id")
   @JsonProperty("exercise_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
+  @Schema(type = "string")
   private Exercise exercise;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -25,6 +27,7 @@ public class ExerciseTeamUser {
   @JoinColumn(name = "team_id")
   @JsonProperty("team_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
+  @Schema(type = "string")
   private Team team;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -32,6 +35,7 @@ public class ExerciseTeamUser {
   @JoinColumn(name = "user_id")
   @JsonProperty("user_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
+  @Schema(type = "string")
   private User user;
 
   public ExerciseTeamUserId getCompositeId() {

--- a/openbas-model/src/main/java/io/openbas/database/model/FileDrop.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/FileDrop.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,6 +25,7 @@ public class FileDrop extends Payload {
   @JoinColumn(name = "file_drop_file")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("file_drop_file")
+  @Schema(type = "string")
   private Document fileDropFile;
 
   public FileDrop() {}

--- a/openbas-model/src/main/java/io/openbas/database/model/Grant.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Grant.java
@@ -3,6 +3,7 @@ package io.openbas.database.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -40,18 +41,21 @@ public class Grant implements Base {
   @JoinColumn(name = "grant_group")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("grant_group")
+  @Schema(type = "string")
   private Group group;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "grant_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("grant_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "grant_scenario")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("grant_scenario")
+  @Schema(type = "string")
   private Scenario scenario;
 
   @Override

--- a/openbas-model/src/main/java/io/openbas/database/model/Group.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Group.java
@@ -6,6 +6,8 @@ import io.openbas.annotation.Queryable;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MultiIdListDeserializer;
 import io.openbas.helper.MultiModelDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import java.util.ArrayList;
@@ -69,6 +71,7 @@ public class Group implements Base {
   @Fetch(value = FetchMode.SUBSELECT)
   private List<Grant> grants = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(
       name = "users_groups",
@@ -79,6 +82,7 @@ public class Group implements Base {
   @Fetch(value = FetchMode.SUBSELECT)
   private List<User> users = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "groups_organizations",

--- a/openbas-model/src/main/java/io/openbas/database/model/Inject.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Inject.java
@@ -14,6 +14,8 @@ import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.database.converter.ContentConverter;
 import io.openbas.database.raw.*;
 import io.openbas.helper.*;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -113,6 +115,7 @@ public class Inject implements Base, Injection {
   @JoinColumn(name = "inject_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @Getter
@@ -120,6 +123,7 @@ public class Inject implements Base, Injection {
   @JoinColumn(name = "inject_scenario")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_scenario")
+  @Schema(type = "string")
   private Scenario scenario;
 
   @Getter
@@ -150,6 +154,7 @@ public class Inject implements Base, Injection {
   @JoinColumn(name = "inject_user")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_user")
+  @Schema(type = "string")
   private User user;
 
   // CascadeType.ALL is required here because inject status are embedded
@@ -158,6 +163,7 @@ public class Inject implements Base, Injection {
   @Queryable(filterable = true, sortable = true)
   private InjectStatus status;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
@@ -169,6 +175,7 @@ public class Inject implements Base, Injection {
   @Queryable(filterable = true, dynamicValues = true)
   private Set<Tag> tags = new HashSet<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(
@@ -179,6 +186,7 @@ public class Inject implements Base, Injection {
   @JsonProperty("inject_teams")
   private List<Team> teams = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(
@@ -189,6 +197,7 @@ public class Inject implements Base, Injection {
   @JsonProperty("inject_assets")
   private List<Asset> assets = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(
@@ -199,6 +208,7 @@ public class Inject implements Base, Injection {
   @JsonProperty("inject_asset_groups")
   private List<AssetGroup> assetGroups = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(
@@ -210,6 +220,7 @@ public class Inject implements Base, Injection {
   private List<Asset> payloads = new ArrayList<>();
 
   // CascadeType.ALL is required here because of complex relationships
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @OneToMany(
       mappedBy = "inject",
@@ -221,6 +232,7 @@ public class Inject implements Base, Injection {
   private List<InjectDocument> documents = new ArrayList<>();
 
   // CascadeType.ALL is required here because communications are embedded
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @OneToMany(
       mappedBy = "inject",
@@ -232,6 +244,7 @@ public class Inject implements Base, Injection {
   private List<Communication> communications = new ArrayList<>();
 
   // CascadeType.ALL is required here because expectations are embedded
+  @ArraySchema(schema = @Schema(type = "string"))
   @Getter
   @OneToMany(
       mappedBy = "inject",

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectDocument.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectDocument.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import java.util.Objects;
 import lombok.Getter;
@@ -22,6 +23,7 @@ public class InjectDocument {
   @JoinColumn(name = "inject_id")
   @JsonProperty("inject_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
+  @Schema(type = "string")
   private Inject inject;
 
   @ManyToOne(fetch = FetchType.EAGER)
@@ -29,6 +31,7 @@ public class InjectDocument {
   @JoinColumn(name = "document_id")
   @JsonProperty("document_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
+  @Schema(type = "string")
   private Document document;
 
   @Column(name = "document_attached")

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectExpectation.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -155,6 +156,7 @@ public class InjectExpectation implements Base {
   @JoinColumn(name = "exercise_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_expectation_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @Setter
@@ -162,6 +164,7 @@ public class InjectExpectation implements Base {
   @JoinColumn(name = "inject_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_expectation_inject")
+  @Schema(type = "string")
   private Inject inject;
 
   @Setter
@@ -169,6 +172,7 @@ public class InjectExpectation implements Base {
   @JoinColumn(name = "user_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_expectation_user")
+  @Schema(type = "string")
   private User user;
 
   @Setter
@@ -176,6 +180,7 @@ public class InjectExpectation implements Base {
   @JoinColumn(name = "team_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_expectation_team")
+  @Schema(type = "string")
   private Team team;
 
   @Setter
@@ -183,6 +188,7 @@ public class InjectExpectation implements Base {
   @JoinColumn(name = "asset_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_expectation_asset")
+  @Schema(type = "string")
   private Asset asset;
 
   @Setter
@@ -190,6 +196,7 @@ public class InjectExpectation implements Base {
   @JoinColumn(name = "asset_group_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_expectation_asset_group")
+  @Schema(type = "string")
   private AssetGroup assetGroup;
 
   // endregion
@@ -198,12 +205,14 @@ public class InjectExpectation implements Base {
   @JoinColumn(name = "article_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_expectation_article")
+  @Schema(type = "string")
   private Article article;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "challenge_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("inject_expectation_challenge")
+  @Schema(type = "string")
   private Challenge challenge;
 
   public void setArticle(Article article) {

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectImporter.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectImporter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -41,6 +42,7 @@ public class InjectImporter implements Base {
   @JsonProperty("inject_importer_injector_contract")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @NotNull
+  @Schema(type = "string")
   private InjectorContract injectorContract;
 
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectorContract.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectorContract.java
@@ -13,6 +13,8 @@ import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.database.converter.ContentConverter;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -101,8 +103,10 @@ public class InjectorContract implements Base {
   @JsonProperty("injector_contract_injector")
   @Queryable(filterable = true, dynamicValues = true)
   @NotNull
+  @Schema(type = "string")
   private Injector injector;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Setter
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(

--- a/openbas-model/src/main/java/io/openbas/database/model/LessonsAnswer.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/LessonsAnswer.java
@@ -35,8 +35,8 @@ public class LessonsAnswer implements Base {
   @JoinColumn(name = "lessons_answer_question")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("lessons_answer_question")
-  @Schema(type = "string")
   @NotNull
+  @Schema(type = "string")
   private LessonsQuestion question;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/openbas-model/src/main/java/io/openbas/database/model/LessonsCategory.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/LessonsCategory.java
@@ -39,12 +39,14 @@ public class LessonsCategory implements Base {
   @JoinColumn(name = "lessons_category_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("lessons_category_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "lessons_category_scenario")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("lessons_category_scenario")
+  @Schema(type = "string")
   private Scenario scenario;
 
   @Column(name = "lessons_category_created_at")

--- a/openbas-model/src/main/java/io/openbas/database/model/LessonsQuestion.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/LessonsQuestion.java
@@ -41,6 +41,7 @@ public class LessonsQuestion implements Base {
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("lessons_question_category")
   @NotNull
+  @Schema(type = "string")
   private LessonsCategory category;
 
   @Column(name = "lessons_question_created_at")

--- a/openbas-model/src/main/java/io/openbas/database/model/LessonsTemplateCategory.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/LessonsTemplateCategory.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -33,6 +35,7 @@ public class LessonsTemplateCategory implements Base {
   @JoinColumn(name = "lessons_template_category_template")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("lessons_template_category_template")
+  @Schema(type = "string")
   private LessonsTemplate template;
 
   @Column(name = "lessons_template_category_created_at")
@@ -59,6 +62,7 @@ public class LessonsTemplateCategory implements Base {
   @NotNull
   private int order;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(mappedBy = "category", fetch = FetchType.EAGER)
   @JsonProperty("lessons_template_category_questions")
   @JsonSerialize(using = MultiIdListDeserializer.class)

--- a/openbas-model/src/main/java/io/openbas/database/model/LessonsTemplateQuestion.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/LessonsTemplateQuestion.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -30,6 +31,7 @@ public class LessonsTemplateQuestion implements Base {
   @JoinColumn(name = "lessons_template_question_category")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("lessons_template_question_category")
+  @Schema(type = "string")
   private LessonsTemplateCategory category;
 
   @Column(name = "lessons_template_question_created_at")

--- a/openbas-model/src/main/java/io/openbas/database/model/Log.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Log.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdSetDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -35,12 +37,14 @@ public class Log implements Base {
   @JoinColumn(name = "log_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("log_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "log_user")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("log_user")
+  @Schema(type = "string")
   private User user;
 
   @Column(name = "log_title")
@@ -63,6 +67,7 @@ public class Log implements Base {
   @NotNull
   private Instant updated = now();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "logs_tags",

--- a/openbas-model/src/main/java/io/openbas/database/model/Mitigation.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Mitigation.java
@@ -8,6 +8,8 @@ import io.hypersistence.utils.hibernate.type.array.StringArrayType;
 import io.openbas.annotation.Queryable;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MultiIdListDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -75,6 +77,7 @@ public class Mitigation implements Base {
   @NotNull
   private Instant updatedAt = now();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "mitigations_attack_patterns",

--- a/openbas-model/src/main/java/io/openbas/database/model/Objective.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Objective.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -37,12 +39,14 @@ public class Objective implements Base {
   @JoinColumn(name = "objective_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("objective_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "objective_scenario")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("objective_scenario")
+  @Schema(type = "string")
   private Scenario scenario;
 
   @Column(name = "objective_title")
@@ -67,6 +71,7 @@ public class Objective implements Base {
   @NotNull
   private Instant updatedAt = now();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(mappedBy = "objective", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @JsonProperty("objective_evaluations")

--- a/openbas-model/src/main/java/io/openbas/database/model/Organization.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Organization.java
@@ -10,6 +10,8 @@ import io.openbas.annotation.Queryable;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MultiIdListDeserializer;
 import io.openbas.helper.MultiIdSetDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -57,6 +59,7 @@ public class Organization implements Base {
   @JsonIgnore
   private List<User> users = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Setter
   @Getter
   @ManyToMany(fetch = FetchType.LAZY)
@@ -87,6 +90,7 @@ public class Organization implements Base {
             .collect(Collectors.toList());
   }
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonProperty("organization_injects")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<Inject> getOrganizationInject() {

--- a/openbas-model/src/main/java/io/openbas/database/model/Pause.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Pause.java
@@ -3,6 +3,7 @@ package io.openbas.database.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.Objects;
@@ -31,6 +32,7 @@ public class Pause implements Base {
   @JoinColumn(name = "pause_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("pause_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @Override

--- a/openbas-model/src/main/java/io/openbas/database/model/Payload.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Payload.java
@@ -14,6 +14,8 @@ import io.openbas.database.model.Endpoint.PLATFORM_TYPE;
 import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
 import io.openbas.helper.MultiIdSetDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -78,6 +80,7 @@ public class Payload implements Base {
   @JsonProperty("payload_platforms")
   private PLATFORM_TYPE[] platforms = new PLATFORM_TYPE[0];
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Setter
   @ManyToMany(fetch = FetchType.EAGER)
   @JoinTable(
@@ -143,10 +146,12 @@ public class Payload implements Base {
   @JoinColumn(name = "payload_collector")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("payload_collector")
+  @Schema(type = "string")
   private Collector collector;
 
   // -- TAG --
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Queryable(filterable = true, dynamicValues = true)
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(

--- a/openbas-model/src/main/java/io/openbas/database/model/Scenario.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Scenario.java
@@ -16,6 +16,8 @@ import io.openbas.helper.InjectStatisticsHelper;
 import io.openbas.helper.MultiIdListDeserializer;
 import io.openbas.helper.MultiIdSetDeserializer;
 import io.openbas.helper.MultiModelDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -150,12 +152,14 @@ public class Scenario implements Base {
   @JsonIgnore
   private List<Grant> grants = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(mappedBy = "scenario", fetch = FetchType.LAZY)
   @JsonProperty("scenario_injects")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @Getter(NONE)
   private Set<Inject> injects = new HashSet<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "scenarios_teams",
@@ -178,6 +182,7 @@ public class Scenario implements Base {
   @JsonIgnore
   private List<Objective> objectives = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "scenarios_tags",
@@ -188,6 +193,7 @@ public class Scenario implements Base {
   @Queryable(filterable = true, dynamicValues = true, path = "tags.id")
   private Set<Tag> tags = new HashSet<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "scenarios_documents",
@@ -197,16 +203,19 @@ public class Scenario implements Base {
   @JsonProperty("scenario_documents")
   private List<Document> documents = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(mappedBy = "scenario", fetch = FetchType.LAZY)
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @JsonProperty("scenario_articles")
   private List<Article> articles = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(mappedBy = "scenario", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @JsonProperty("scenario_lessons_categories")
   private List<LessonsCategory> lessonsCategories = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "scenarios_exercises",
@@ -229,12 +238,14 @@ public class Scenario implements Base {
 
   // -- SECURITY --
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonProperty("scenario_planners")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<User> getPlanners() {
     return getUsersByType(this.getGrants(), PLANNER);
   }
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonProperty("scenario_observers")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<User> getObservers() {
@@ -258,6 +269,7 @@ public class Scenario implements Base {
     return getTeamUsers().stream().map(ScenarioTeamUser::getUser).distinct().count();
   }
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonProperty("scenario_users")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<User> getUsers() {

--- a/openbas-model/src/main/java/io/openbas/database/model/ScenarioTeamUser.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/ScenarioTeamUser.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -19,6 +20,7 @@ public class ScenarioTeamUser {
   @JoinColumn(name = "scenario_id")
   @JsonProperty("scenario_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
+  @Schema(type = "string")
   private Scenario scenario;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -26,6 +28,7 @@ public class ScenarioTeamUser {
   @JoinColumn(name = "team_id")
   @JsonProperty("team_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
+  @Schema(type = "string")
   private Team team;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -33,5 +36,6 @@ public class ScenarioTeamUser {
   @JoinColumn(name = "user_id")
   @JsonProperty("user_id")
   @JsonSerialize(using = MonoIdDeserializer.class)
+  @Schema(type = "string")
   private User user;
 }

--- a/openbas-model/src/main/java/io/openbas/database/model/SecurityPlatform.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/SecurityPlatform.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.annotation.Queryable;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -45,12 +46,14 @@ public class SecurityPlatform extends Asset {
   @JoinColumn(name = "security_platform_logo_light")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("security_platform_logo_light")
+  @Schema(type = "string")
   private Document logoLight;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "security_platform_logo_dark")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("security_platform_logo_dark")
+  @Schema(type = "string")
   private Document logoDark;
 
   public SecurityPlatform() {}

--- a/openbas-model/src/main/java/io/openbas/database/model/Team.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Team.java
@@ -10,6 +10,8 @@ import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
 import io.openbas.helper.MultiIdSetDeserializer;
 import io.openbas.helper.MultiModelDeserializer;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -61,6 +63,7 @@ public class Team implements Base {
   @NotNull
   private Instant updatedAt = now();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Queryable(filterable = true, dynamicValues = true, path = "tags.id")
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
@@ -75,8 +78,10 @@ public class Team implements Base {
   @JoinColumn(name = "team_organization")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("team_organization")
+  @Schema(type = "string")
   private Organization organization;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "users_teams",
@@ -86,6 +91,7 @@ public class Team implements Base {
   @JsonProperty("team_users")
   private List<User> users = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "exercises_teams",
@@ -95,6 +101,7 @@ public class Team implements Base {
   @JsonProperty("team_exercises")
   private List<Exercise> exercises = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
       name = "scenarios_teams",
@@ -108,6 +115,7 @@ public class Team implements Base {
   @JsonProperty("team_contextual")
   private Boolean contextual = false;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(
       mappedBy = "team",
       fetch = FetchType.LAZY,
@@ -123,6 +131,7 @@ public class Team implements Base {
   }
 
   // region transient
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonProperty("team_exercise_injects")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<Inject> getExercisesInjects() {
@@ -139,6 +148,7 @@ public class Team implements Base {
     return getExercisesInjects().size();
   }
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @JsonProperty("team_scenario_injects")
   @JsonSerialize(using = MultiIdListDeserializer.class)
   public List<Inject> getScenariosInjects() {
@@ -155,6 +165,7 @@ public class Team implements Base {
     return getScenariosInjects().size();
   }
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @OneToMany(mappedBy = "team", fetch = FetchType.LAZY)
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @JsonProperty("team_inject_expectations")

--- a/openbas-model/src/main/java/io/openbas/database/model/Token.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Token.java
@@ -3,6 +3,7 @@ package io.openbas.database.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -32,6 +33,7 @@ public class Token implements Base {
   @JoinColumn(name = "token_user")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("token_user")
+  @Schema(type = "string")
   private User user;
 
   @Column(name = "token_value")

--- a/openbas-model/src/main/java/io/openbas/database/model/User.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/User.java
@@ -14,6 +14,8 @@ import io.openbas.helper.MonoIdDeserializer;
 import io.openbas.helper.MultiIdListDeserializer;
 import io.openbas.helper.MultiIdSetDeserializer;
 import io.openbas.helper.UserHelper;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -127,6 +129,7 @@ public class User implements Base {
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("user_organization")
   @Queryable(dynamicValues = true, filterable = true, sortable = true, path = "organization.id")
+  @Schema(type = "string")
   private Organization organization;
 
   @Setter
@@ -145,6 +148,7 @@ public class User implements Base {
   @JsonProperty("user_city")
   private String city;
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Setter
   // @ManyToMany(fetch = FetchType.LAZY)
   @ManyToMany(fetch = FetchType.EAGER)
@@ -156,6 +160,7 @@ public class User implements Base {
   @JsonProperty("user_groups")
   private List<Group> groups = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Setter
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
@@ -166,6 +171,7 @@ public class User implements Base {
   @JsonProperty("user_teams")
   private List<Team> teams = new ArrayList<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Setter
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
@@ -177,6 +183,7 @@ public class User implements Base {
   @Queryable(dynamicValues = true, filterable = true, sortable = true, path = "tags.id")
   private Set<Tag> tags = new HashSet<>();
 
+  @ArraySchema(schema = @Schema(type = "string"))
   @Setter
   @ManyToMany(fetch = FetchType.LAZY)
   @JoinTable(
@@ -214,29 +221,6 @@ public class User implements Base {
         ofNullable(email)
             .map(String::toLowerCase)
             .orElseThrow(() -> new IllegalArgumentException("Email can't be null"));
-  }
-
-  @Transient private List<Inject> injects = new ArrayList<>();
-
-  public void resolveInjects(Iterable<Inject> injects) {
-    this.injects =
-        stream(injects.spliterator(), false)
-            .filter(
-                inject ->
-                    inject.isAllTeams()
-                        || inject.getTeams().stream().anyMatch(team -> getTeams().contains(team)))
-            .collect(Collectors.toList());
-  }
-
-  @JsonProperty("user_injects")
-  @JsonSerialize(using = MultiIdListDeserializer.class)
-  public List<Inject> getUserInject() {
-    return this.injects;
-  }
-
-  @JsonProperty("user_injects_number")
-  public long getUserInjectsNumber() {
-    return this.injects.size();
   }
 
   @JsonProperty("user_gravatar")

--- a/openbas-model/src/main/java/io/openbas/database/model/User.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/User.java
@@ -2,7 +2,6 @@ package io.openbas.database.model;
 
 import static java.time.Instant.now;
 import static java.util.Optional.ofNullable;
-import static java.util.stream.StreamSupport.stream;
 import static lombok.AccessLevel.NONE;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -21,7 +20,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.*;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;

--- a/openbas-model/src/main/java/io/openbas/database/model/Variable.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Variable.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -60,12 +61,14 @@ public class Variable implements Base {
   @JoinColumn(name = "variable_exercise")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("variable_exercise")
+  @Schema(type = "string")
   private Exercise exercise;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "variable_scenario")
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("variable_scenario")
+  @Schema(type = "string")
   private Scenario scenario;
 
   // -- AUDIT --


### PR DESCRIPTION
### Proposed changes

Generating the swagger doc takes a lot of time due to the object nesting that we have in our back-end.
However, these object nestings do not reflect reality, since we use Deserializers to return the IDs and not the entire object.

Example:
```
public class Exercise implements Base {
...
  @JsonSerialize(using = MonoIdDeserializer.class)
  @JsonProperty("exercise_scenario")
  private Scenario scenario;
...
}
```
The api get exercise_scenario as a string, but the swagger take the full bean.
The idea is to use the swagger api annotations to reflect reality (based on @MarineLeM work & troubleshooting by @savacano28)

```
public class Exercise implements Base {
...
  @JsonSerialize(using = MonoIdDeserializer.class)
  @JsonProperty("exercise_scenario")
  @Schema(type = "string")
  private Scenario scenario;
...
}
```

### Next steps

The next step is to remove the Model**Store** types, which made it possible to reflect the reality of the back side on the front side, in favor of using the types in the api-types file which are now clean.

```
export type ArticleStore = Omit<Article, 'article_channel' | 'article_documents'> & {
  article_channel: string | undefined;
  article_documents: string[] | undefined;
};
```