### PR TITLE
[backend] handle cmd variables

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/ExecutableInjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/ExecutableInjectService.java
@@ -1,5 +1,7 @@
 package io.openbas.rest.inject.service;
 
+import static org.springframework.util.StringUtils.hasText;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.InjectRepository;
@@ -103,8 +105,7 @@ public class ExecutableInjectService {
         .getPrerequisites()
         .forEach(
             prerequisite -> {
-              if (prerequisite.getCheckCommand() != null
-                  && !prerequisite.getCheckCommand().isEmpty()) {
+              if (hasText(prerequisite.getCheckCommand())) {
                 prerequisite.setCheckCommand(
                     processAndEncodeCommand(
                         prerequisite.getCheckCommand(),
@@ -113,7 +114,7 @@ public class ExecutableInjectService {
                         inject.getContent(),
                         "base64"));
               }
-              if (prerequisite.getGetCommand() != null && !prerequisite.getGetCommand().isEmpty()) {
+              if (hasText(prerequisite.getGetCommand())) {
                 prerequisite.setGetCommand(
                     processAndEncodeCommand(
                         prerequisite.getGetCommand(),


### PR DESCRIPTION
### Proposed changes

Fix this problem : 

Instantiating a `cmd `variable and using it in the same line doesn't work as expected. 
For example, the command 
```
set x=test & echo %x%
``` 
won't display the value of x because the variable hasn't been instantiated yet. To fix this, you can use the command 
```
cmd /v /c "set x=test & echo !x!"
``` 
 which enables delayed variable expansion, allowing the variable to be properly referenced
 
 
 In this PR i replace the %test% by !test!
 In this PR https://github.com/OpenBAS-Platform/implant/pull/26 i add the  /v arguments




### Related issues

* Related to this issue https://github.com/OpenBAS-Platform/openbas/issues/1604



