### PR TITLE
[backend] Adding the content-type header when calling MistralAI

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/stream/ai/AiApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/stream/ai/AiApi.java
@@ -54,6 +54,7 @@ public class AiApi extends RestBehavior {
             .POST(HttpRequest.BodyPublishers.ofString(body))
             .header("Authorization", "Bearer " + aiConfig.getToken())
             .header("Accept", "text/event-stream")
+            .header("Content-Type", "application/json")
             .build();
     Flux<AiResult> dataFlux =
         Flux.create(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Adding the Content-Type in the headers
*

### Related issues

* Closes #2063 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
