### PR TITLE
[frontend] enable navigating to scenario with no extra load (#1611)

### DIFF
--- a/openbas-front/src/admin/components/simulations/simulation/ExerciseHeader.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/ExerciseHeader.tsx
@@ -1,8 +1,8 @@
-import { CancelOutlined, PauseOutlined, PlayArrowOutlined, RestartAltOutlined } from '@mui/icons-material';
+import { CancelOutlined, MovieFilterOutlined, PauseOutlined, PlayArrowOutlined, RestartAltOutlined } from '@mui/icons-material';
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, Tooltip, Typography } from '@mui/material';
 import { makeStyles, useTheme } from '@mui/styles';
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 
 import { updateExerciseStatus } from '../../../../actions/Exercise';
 import type { ExerciseStore } from '../../../../actions/exercises/Exercise';
@@ -30,10 +30,11 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const Buttons = ({ exerciseId, exerciseStatus, exerciseName }: {
+const Buttons = ({ exerciseId, exerciseStatus, exerciseName, exerciseScenarioId }: {
   exerciseId: ExerciseStore['exercise_id'];
   exerciseStatus: ExerciseStore['exercise_status'];
   exerciseName: ExerciseStore['exercise_name'];
+  exerciseScenarioId: ExerciseStore['exercise_scenario'];
 }) => {
   // Standard hooks
   const { t } = useFormatter();
@@ -44,6 +45,8 @@ const Buttons = ({ exerciseId, exerciseStatus, exerciseName }: {
     dispatch(updateExerciseStatus(exerciseId, status));
     setOpenChangeStatus(null);
   };
+  const scenarioBaseUri = '/admin/scenarios';
+
   const executionButton = () => {
     switch (exerciseStatus) {
       case 'SCHEDULED': {
@@ -158,6 +161,18 @@ const Buttons = ({ exerciseId, exerciseStatus, exerciseName }: {
   };
   return (
     <>
+      {exerciseScenarioId && (
+        <Button
+          component={Link}
+          to={scenarioBaseUri + '/' + exerciseScenarioId}
+          color="primary"
+          variant="outlined"
+          style={{ marginRight: 10 }}
+          startIcon={<MovieFilterOutlined color="primary" />}
+        >
+          {t('scenario_back_to_parent')}
+        </Button>
+      )}
       {executionButton()}
       {dangerousButton()}
       <Dialog
@@ -212,7 +227,12 @@ const ExerciseHeader = () => {
       <div style={{ float: 'left', margin: '3px 10px 0 8px', color: theme.palette.text?.disabled, borderLeft: `1px solid ${theme.palette.text?.disabled}`, height: 20 }} />
       <ExerciseStatus exerciseStatus={exercise.exercise_status} exerciseStartDate={exercise.exercise_start_date} />
       <div className={classes.actions}>
-        <Buttons exerciseId={exercise.exercise_id} exerciseStatus={exercise.exercise_status} exerciseName={exercise.exercise_name} />
+        <Buttons
+          exerciseId={exercise.exercise_id}
+          exerciseStatus={exercise.exercise_status}
+          exerciseName={exercise.exercise_name}
+          exerciseScenarioId={exercise.exercise_scenario}
+        />
         <ExercisePopover
           exercise={exercise}
           actions={actions}

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -918,6 +918,7 @@ const i18n = {
       'scenario_severity': 'Sévérité',
       'scenario_tags': 'Tags',
       'scenario_updated_at': 'Mis à jour à',
+      'scenario_back_to_parent': 'Retour au scénario parent',
       // Exercise
       'exercise_kill_chain_phases': 'Phase de kill chain',
       'exercise_name': 'Nom',
@@ -2321,6 +2322,7 @@ const i18n = {
       'scenario_severity': '严重性',
       'scenario_tags': '标签',
       'scenario_updated_at': '更新于',
+      'scenario_back_to_parent': '回到父母方案',
       // Exercise
       'exercise_kill_chain_phases': '杀伤链阶段',
       'exercise_name': '名称',
@@ -2899,6 +2901,7 @@ const i18n = {
       'scenario_severity': 'Severity',
       'scenario_tags': 'Tags',
       'scenario_updated_at': 'Updated at',
+      'scenario_back_to_parent': 'Back to parent scenario',
       // Exercise
       'exercise_kill_chain_phases': 'Kill chain phase',
       'exercise_name': 'Name',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a button back to parent scenario when available

### Related issues

* Closes #1611

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Second take on a change for #1611 without loading an extra resource (scenario), with a generic wording; born of comment https://github.com/OpenBAS-Platform/openbas/pull/2040#discussion_r1883478393
The display is more stable this way since we are not subjected to varying string lengths to display in a button.

With available scenario:
![image](https://github.com/user-attachments/assets/71988d97-3395-4771-94a0-416438f8f581)

Without available scenario (e.g. scenario was deleted):
![image](https://github.com/user-attachments/assets/b99ad810-c0c9-4945-8e7b-2272ca0d03e0)
