### PR TITLE
[frontend] Fix payload info tab not visible for simulations

### DIFF
--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/Index.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/Index.tsx
@@ -11,6 +11,7 @@ import { useFormatter } from '../../../../components/i18n';
 import Loader from '../../../../components/Loader';
 import NotFound from '../../../../components/NotFound';
 import type { InjectResultOverviewOutput } from '../../../../utils/api-types';
+import isInjectWithPayloadInfo from '../../../../utils/inject/injectUtils';
 import { FIVE_SECONDS } from '../../../../utils/Time';
 import { TeamContext } from '../../common/Context';
 import { InjectResultOverviewOutputContext } from '../InjectResultOverviewOutputContext';
@@ -108,7 +109,7 @@ const Index = () => {
                 className={classes.item}
               />
               {
-                injectResultOverviewOutput.inject_type !== 'openbas_email' && injectResultOverviewOutput.inject_type !== 'openbas_ovh_sms' && injectResultOverviewOutput.inject_type !== 'openbas_mastodon' && injectResultOverviewOutput.inject_type !== 'openbas_http_query' && (
+                isInjectWithPayloadInfo(injectResultOverviewOutput) && (
                   <Tab
                     component={Link}
                     to={`/admin/atomic_testings/${injectResultOverviewOutput.inject_id}/payload_info`}

--- a/openbas-front/src/admin/components/simulations/simulation/injects/InjectIndex.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/injects/InjectIndex.tsx
@@ -18,6 +18,7 @@ import { useAppDispatch } from '../../../../../utils/hooks';
 import useDataLoader from '../../../../../utils/hooks/useDataLoader';
 import AtomicTesting from '../../../atomic_testings/atomic_testing/AtomicTesting';
 import AtomicTestingDetail from '../../../atomic_testings/atomic_testing/AtomicTestingDetail';
+import AtomicTestingPayloadInfo from '../../../atomic_testings/atomic_testing/AtomicTestingPayloadInfo';
 import { InjectResultOverviewOutputContext } from '../../../atomic_testings/InjectResultOverviewOutputContext';
 import { PermissionsContext, PermissionsContextType } from '../../../common/Context';
 import InjectHeader from '../../../injects/InjectHeader';
@@ -96,12 +97,24 @@ const InjectIndexComponent: FunctionComponent<{ exercise: ExerciseType; injectRe
               label={t('Execution details')}
               className={classes.item}
             />
+            {
+              injectResultOverviewOutput.inject_type !== 'openbas_email' && injectResultOverviewOutput.inject_type !== 'openbas_ovh_sms' && injectResultOverviewOutput.inject_type !== 'openbas_mastodon' && injectResultOverviewOutput.inject_type !== 'openbas_http_query' && (
+                <Tab
+                  component={Link}
+                  to={`/admin/simulations/${exercise.exercise_id}/injects/${injectResultOverviewOutput.inject_id}/payload_info`}
+                  value={`/admin/simulations/${exercise.exercise_id}/injects/${injectResultOverviewOutput.inject_id}/payload_info`}
+                  label={t('Payload info')}
+                  className={classes.item}
+                />
+              )
+            }
           </Tabs>
         </Box>
         <Suspense fallback={<Loader />}>
           <Routes>
             <Route path="" element={errorWrapper(AtomicTesting)()} />
             <Route path="detail" element={errorWrapper(AtomicTestingDetail)()} />
+            <Route path="payload_info" element={errorWrapper(AtomicTestingPayloadInfo)()} />
             {/* Not found */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/openbas-front/src/admin/components/simulations/simulation/injects/InjectIndex.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/injects/InjectIndex.tsx
@@ -16,6 +16,7 @@ import type { Exercise as ExerciseType, InjectResultOverviewOutput } from '../..
 import { usePermissions } from '../../../../../utils/Exercise';
 import { useAppDispatch } from '../../../../../utils/hooks';
 import useDataLoader from '../../../../../utils/hooks/useDataLoader';
+import isInjectWithPayloadInfo from '../../../../../utils/inject/injectUtils';
 import AtomicTesting from '../../../atomic_testings/atomic_testing/AtomicTesting';
 import AtomicTestingDetail from '../../../atomic_testings/atomic_testing/AtomicTestingDetail';
 import AtomicTestingPayloadInfo from '../../../atomic_testings/atomic_testing/AtomicTestingPayloadInfo';
@@ -98,7 +99,7 @@ const InjectIndexComponent: FunctionComponent<{ exercise: ExerciseType; injectRe
               className={classes.item}
             />
             {
-              injectResultOverviewOutput.inject_type !== 'openbas_email' && injectResultOverviewOutput.inject_type !== 'openbas_ovh_sms' && injectResultOverviewOutput.inject_type !== 'openbas_mastodon' && injectResultOverviewOutput.inject_type !== 'openbas_http_query' && (
+              isInjectWithPayloadInfo(injectResultOverviewOutput) && (
                 <Tab
                   component={Link}
                   to={`/admin/simulations/${exercise.exercise_id}/injects/${injectResultOverviewOutput.inject_id}/payload_info`}

--- a/openbas-front/src/utils/inject/injectUtils.ts
+++ b/openbas-front/src/utils/inject/injectUtils.ts
@@ -1,0 +1,7 @@
+import type { InjectResultOverviewOutput } from '../api-types';
+
+const isInjectWithPayloadInfo = (injectResultOverviewOutput: InjectResultOverviewOutput) => {
+  return injectResultOverviewOutput.inject_type !== undefined && !['openbas_email', 'openbas_ovh_sms', 'openbas_mastodon', 'openbas_http_query'].includes(injectResultOverviewOutput.inject_type);
+};
+
+export default isInjectWithPayloadInfo;


### PR DESCRIPTION
### Proposed changes

* New payload info tab was visible for "Atomic Testing" but not for "Simulation"

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
