### PR TITLE
[frontend] Search functionality for teams when adding a team to an inject does not work

### DIFF
--- a/openbas-front/src/admin/components/common/injects/InjectAddTeams.tsx
+++ b/openbas-front/src/admin/components/common/injects/InjectAddTeams.tsx
@@ -105,7 +105,7 @@ const InjectAddTeams: FunctionComponent<Props> = ({
 
   const paginationComponent = (
     <PaginationComponentV2
-      fetch={input => searchTeams(input, true)}
+      fetch={input => searchTeams(input, false)}
       searchPaginationInput={searchPaginationInput}
       setContent={setTeamValues}
       entityPrefix="team"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

**⚠️ This is not a bug**
The target teams functionality it’s not clear:
- In a scenario/simulation, one needs to firstly add a Team in the Team section of the Definition tab: it becomes a target team.
- Then when we add an Inject with target teams (Send individual mails for ex) , and we choose to include a target team, the team included in the Definition tab will appear.

### Proposed changes

*  Get teams from the scenario/simulation context and all the other teams


### Related issues

* Closes #N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
