### PR TITLE
[frontend] replace deprecated ListItemSecondaryAction component

### DIFF
--- a/openbas-front/src/admin/components/lessons/exercises/LessonsObjectives.js
+++ b/openbas-front/src/admin/components/lessons/exercises/LessonsObjectives.js
@@ -4,9 +4,9 @@ import {
   Grid,
   LinearProgress,
   List,
+  ListItem,
   ListItemButton,
   ListItemIcon,
-  ListItemSecondaryAction,
   ListItemText,
   Paper,
   Typography,
@@ -84,50 +84,52 @@ const LessonsObjectives = ({
           {sortedObjectives.length > 0 ? (
             <List style={{ padding: 0 }}>
               {sortedObjectives.map(objective => (
-                <ListItemButton
+                <ListItem
                   key={objective.objective_id}
-                  divider
-                  onClick={() => setSelectedObjective
-                    && setSelectedObjective(objective.objective_id)}
-                >
-                  <ListItemIcon>
-                    <FlagOutlined />
-                  </ListItemIcon>
-                  <ListItemText
-                    style={{ width: '50%' }}
-                    primary={objective.objective_title}
-                    secondary={objective.objective_description}
-                  />
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      width: '30%',
-                      marginRight: 1,
-                    }}
-                  >
-                    <Box sx={{ width: '100%', mr: 1 }}>
-                      <LinearProgress
-                        variant="determinate"
-                        value={objective.objective_score}
-                      />
-                    </Box>
-                    <Box sx={{ minWidth: 35 }}>
-                      <Typography variant="body2" color="text.secondary">
-                        {objective.objective_score}
-                        %
-                      </Typography>
-                    </Box>
-                  </Box>
-                  {!isReport && (
-                    <ListItemSecondaryAction>
-                      <ObjectivePopover
-                        isReadOnly={source.isReadOnly}
-                        objective={objective}
-                      />
-                    </ListItemSecondaryAction>
+                  secondaryAction={!isReport && (
+                    <ObjectivePopover
+                      isReadOnly={source.isReadOnly}
+                      objective={objective}
+                    />
                   )}
-                </ListItemButton>
+                >
+                  <ListItemButton
+                    divider
+                    onClick={() => setSelectedObjective
+                      && setSelectedObjective(objective.objective_id)}
+                  >
+                    <ListItemIcon>
+                      <FlagOutlined />
+                    </ListItemIcon>
+                    <ListItemText
+                      style={{ width: '50%' }}
+                      primary={objective.objective_title}
+                      secondary={objective.objective_description}
+                    />
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        width: '30%',
+                        marginRight: 1,
+                      }}
+                    >
+                      <Box sx={{ width: '100%', mr: 1 }}>
+                        <LinearProgress
+                          variant="determinate"
+                          value={objective.objective_score}
+                        />
+                      </Box>
+                      <Box sx={{ minWidth: 35 }}>
+                        <Typography variant="body2" color="text.secondary">
+                          {objective.objective_score}
+                          %
+                        </Typography>
+                      </Box>
+                    </Box>
+                  </ListItemButton>
+                </ListItem>
+
               ))}
             </List>
           ) : (

--- a/openbas-front/src/admin/components/lessons/scenarios/LessonsObjectives.js
+++ b/openbas-front/src/admin/components/lessons/scenarios/LessonsObjectives.js
@@ -3,10 +3,9 @@ import {
   Box,
   Grid,
   LinearProgress,
-  List,
+  List, ListItem,
   ListItemButton,
   ListItemIcon,
-  ListItemSecondaryAction,
   ListItemText,
   Paper,
   Typography,
@@ -53,50 +52,52 @@ const LessonsObjectives = ({
           {sortedObjectives.length > 0 ? (
             <List style={{ padding: 0 }}>
               {sortedObjectives.map(objective => (
-                <ListItemButton
+                <ListItem
                   key={objective.objective_id}
-                  divider
-                  onClick={() => setSelectedObjective
-                    && setSelectedObjective(objective.objective_id)}
-                >
-                  <ListItemIcon>
-                    <FlagOutlined />
-                  </ListItemIcon>
-                  <ListItemText
-                    style={{ width: '50%' }}
-                    primary={objective.objective_title}
-                    secondary={objective.objective_description}
-                  />
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      width: '30%',
-                      marginRight: 1,
-                    }}
-                  >
-                    <Box sx={{ width: '100%', mr: 1 }}>
-                      <LinearProgress
-                        variant="determinate"
-                        value={objective.objective_score}
-                      />
-                    </Box>
-                    <Box sx={{ minWidth: 35 }}>
-                      <Typography variant="body2" color="text.secondary">
-                        {objective.objective_score}
-                        %
-                      </Typography>
-                    </Box>
-                  </Box>
-                  {!isReport && (
-                    <ListItemSecondaryAction>
-                      <ObjectivePopover
-                        isReadOnly={source.isReadOnly}
-                        objective={objective}
-                      />
-                    </ListItemSecondaryAction>
+                  secondaryAction={!isReport && (
+                    <ObjectivePopover
+                      isReadOnly={source.isReadOnly}
+                      objective={objective}
+                    />
                   )}
-                </ListItemButton>
+                >
+                  <ListItemButton
+                    divider
+                    onClick={() => setSelectedObjective
+                      && setSelectedObjective(objective.objective_id)}
+                  >
+                    <ListItemIcon>
+                      <FlagOutlined />
+                    </ListItemIcon>
+                    <ListItemText
+                      style={{ width: '50%' }}
+                      primary={objective.objective_title}
+                      secondary={objective.objective_description}
+                    />
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        width: '30%',
+                        marginRight: 1,
+                      }}
+                    >
+                      <Box sx={{ width: '100%', mr: 1 }}>
+                        <LinearProgress
+                          variant="determinate"
+                          value={objective.objective_score}
+                        />
+                      </Box>
+                      <Box sx={{ minWidth: 35 }}>
+                        <Typography variant="body2" color="text.secondary">
+                          {objective.objective_score}
+                          %
+                        </Typography>
+                      </Box>
+                    </Box>
+                  </ListItemButton>
+                </ListItem>
+
               ))}
             </List>
           ) : (


### PR DESCRIPTION
### Proposed changes

* Replace deprecated ListItemSecondaryAction component by arguments secondaryAction on ListItem component

### Related issues

https://www.notion.so/filigran/15b8fce17f2a81e2a723e47c0cfd7c0f?v=15b8fce17f2a81df958f000ca602ba74&p=15b8fce17f2a8112aec1f245aad6ebe0&pm=s

