### PR TITLE
[frontend] Don't add asset arch filter if payload is all archs

### DIFF
--- a/openbas-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
+++ b/openbas-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
@@ -122,7 +122,7 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
     ],
   };
   // only add an architecture filter if the payload is not compatible with all archs
-  if (quickFilter.filters && payloadArch && payloadArch != "ALL_ARCHITECTURES") {
+  if (quickFilter.filters && payloadArch && payloadArch != 'ALL_ARCHITECTURES') {
     quickFilter.filters?.push(buildFilter('endpoint_arch', [payloadArch], 'contains'));
   }
   const { queryableHelpers, searchPaginationInput } = useQueryable(buildSearchPagination({

--- a/openbas-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
+++ b/openbas-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
@@ -121,7 +121,8 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
       buildFilter('endpoint_platform', platforms ?? [], 'contains'),
     ],
   };
-  if (quickFilter.filters && payloadArch) {
+  // only add an architecture filter if the payload is not compatible with all archs
+  if (quickFilter.filters && payloadArch && payloadArch != "ALL_ARCHITECTURES") {
     quickFilter.filters?.push(buildFilter('endpoint_arch', [payloadArch], 'contains'));
   }
   const { queryableHelpers, searchPaginationInput } = useQueryable(buildSearchPagination({


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Default filters for asset selection when populating an inject should not filter by architecture if payload's architecture  is "All architectures"

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
