### PR TITLE
[tests] Explicitly mock Instant.now to fix test flakiness

### DIFF
--- a/openbas-api/src/test/java/io/openbas/rest/exercise/ExerciseApiStatusTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/exercise/ExerciseApiStatusTest.java
@@ -214,8 +214,9 @@ public class ExerciseApiStatusTest {
         mockedInstant.when(Instant::now).thenReturn(instantAfterSetRun);
 
         List<ExecutableInject> injects = injectHelper.getInjectsToRun();
-        Instant nextMinute = instantBeforeSetRun.truncatedTo(MINUTES).plus(1, MINUTES);
-        assertEquals(nextMinute.toString(), JsonPath.read(response, "$.exercise_start_date"));
+        Instant expectedStartTime = instantBeforeSetRun.truncatedTo(MINUTES).plus(1, MINUTES);
+        assertEquals(
+            expectedStartTime.toString(), JsonPath.read(response, "$.exercise_start_date"));
         assertEquals(
             Arrays.asList(ExerciseStatus.CANCELED.name(), ExerciseStatus.PAUSED.name()),
             JsonPath.read(response, "$.exercise_next_possible_status"));

--- a/openbas-api/src/test/java/io/openbas/rest/exercise/ExerciseApiStatusTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/exercise/ExerciseApiStatusTest.java
@@ -9,6 +9,8 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -24,11 +26,14 @@ import io.openbas.utils.fixtures.*;
 import io.openbas.utils.mockUser.WithMockAdminUser;
 import jakarta.annotation.Resource;
 import jakarta.servlet.ServletException;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,6 +52,7 @@ public class ExerciseApiStatusTest {
   static Exercise CANCELED_EXERCISE;
   static Inject SAVED_INJECT5;
   static LessonsAnswer LESSON_ANSWER;
+  static Instant REFERENCE_TIME;
 
   @Autowired private MockMvc mvc;
 
@@ -76,11 +82,13 @@ public class ExerciseApiStatusTest {
 
   @BeforeEach
   void beforeAll() {
-    Exercise scheduledExercise = ExerciseFixture.createDefaultAttackExercise();
-    Exercise runningExercise = ExerciseFixture.createRunningAttackExercise();
-    Exercise pausedExercise = ExerciseFixture.createPausedAttackExercise();
-    Exercise canceledExercise = ExerciseFixture.createCanceledAttackExercise();
-    Exercise finishedExercise = ExerciseFixture.createFinishedAttackExercise();
+    REFERENCE_TIME =
+        Instant.now(Clock.fixed(Instant.parse("2024-12-17T10:30:45Z"), ZoneId.of("UTC")));
+    Exercise scheduledExercise = ExerciseFixture.createDefaultAttackExercise(REFERENCE_TIME);
+    Exercise runningExercise = ExerciseFixture.createRunningAttackExercise(REFERENCE_TIME);
+    Exercise pausedExercise = ExerciseFixture.createPausedAttackExercise(REFERENCE_TIME);
+    Exercise canceledExercise = ExerciseFixture.createCanceledAttackExercise(REFERENCE_TIME);
+    Exercise finishedExercise = ExerciseFixture.createFinishedAttackExercise(REFERENCE_TIME);
 
     InjectorContract injectorContract =
         this.injectorContractRepository.findById(EMAIL_DEFAULT).orElseThrow();
@@ -176,28 +184,49 @@ public class ExerciseApiStatusTest {
     // -- PREPARE--
     ExerciseUpdateStatusInput input = new ExerciseUpdateStatusInput();
     input.setStatus(ExerciseStatus.RUNNING);
+    Instant instantBeforeSetRun = REFERENCE_TIME;
+    Instant instantAfterSetRun = REFERENCE_TIME.plus(1, MINUTES);
+    Clock clock = Clock.fixed(REFERENCE_TIME, ZoneId.of("UTC"));
 
-    // -- EXECUTE --
-    String response =
-        mvc.perform(
-                put(EXERCISE_URI + "/" + SCHEDULED_EXERCISE.getId() + "/status")
-                    .content(asJsonString(input))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    try (MockedStatic<Instant> mockedInstant = mockStatic(Instant.class, CALLS_REAL_METHODS)) {
+      try (MockedStatic<Clock> mockedClock = mockStatic(Clock.class, CALLS_REAL_METHODS)) {
 
-    // -- ASSERT --
-    Thread.sleep(2000);
-    List<ExecutableInject> injects = injectHelper.getInjectsToRun();
-    Instant nextMinute = now().truncatedTo(MINUTES).plus(1, MINUTES);
-    assertEquals(nextMinute.toString(), JsonPath.read(response, "$.exercise_start_date"));
-    assertEquals(
-        Arrays.asList(ExerciseStatus.CANCELED.name(), ExerciseStatus.PAUSED.name()),
-        JsonPath.read(response, "$.exercise_next_possible_status"));
-    assertEquals(1, injects.size());
+        mockedInstant.when(Instant::now).thenReturn(instantBeforeSetRun);
+        // we need this other mock because the production code
+        // inconsistently calls Instant.now() and LocalDateTime.now()
+        mockedClock.when(Clock::systemDefaultZone).thenReturn(clock);
+
+        // -- EXECUTE --
+        String response =
+            mvc.perform(
+                    put(EXERCISE_URI + "/" + SCHEDULED_EXERCISE.getId() + "/status")
+                        .content(asJsonString(input))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        // -- ASSERT --
+
+        // NOTE: we are changing the time of Instant.now() here to fast forward in the future
+        mockedInstant.when(Instant::now).thenReturn(instantAfterSetRun);
+
+        List<ExecutableInject> injects = injectHelper.getInjectsToRun();
+        Instant nextMinute = instantBeforeSetRun.truncatedTo(MINUTES).plus(1, MINUTES);
+        assertEquals(nextMinute.toString(), JsonPath.read(response, "$.exercise_start_date"));
+        assertEquals(
+            Arrays.asList(ExerciseStatus.CANCELED.name(), ExerciseStatus.PAUSED.name()),
+            JsonPath.read(response, "$.exercise_next_possible_status"));
+        assertEquals(
+            1,
+            injects.stream()
+                .filter((ij) -> SCHEDULED_EXERCISE.getId().equals(ij.getExercise().getId()))
+                .toList()
+                .size());
+      }
+    }
   }
 
   @DisplayName("Check an exercise from canceled to scheduled")
@@ -263,37 +292,52 @@ public class ExerciseApiStatusTest {
     // --PREPARE--
     ExerciseUpdateStatusInput input = new ExerciseUpdateStatusInput();
     input.setStatus(ExerciseStatus.RUNNING);
+    Instant instantBeforeSetRun = REFERENCE_TIME;
+    Instant instantAfterSetRun = REFERENCE_TIME.plus(1, MINUTES);
+    Clock clock = Clock.fixed(REFERENCE_TIME, ZoneId.of("UTC"));
 
-    // --EXECUTE--
-    String response =
-        mvc.perform(
-                put(EXERCISE_URI + "/" + PAUSED_EXERCISE.getId() + "/status")
-                    .content(asJsonString(input))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    try (MockedStatic<Instant> mockedInstant = mockStatic(Instant.class, CALLS_REAL_METHODS)) {
+      try (MockedStatic<Clock> mockedClock = mockStatic(Clock.class, CALLS_REAL_METHODS)) {
 
-    // --ASSERT--
-    Thread.sleep(2000);
-    List<ExecutableInject> injects = injectHelper.getInjectsToRun();
-    List<Pause> pauses = pauseRepository.findAllForExercise(PAUSED_EXERCISE.getId());
-    Optional<Exercise> exercise =
-        exerciseRepository.findById(JsonPath.read(response, "$.exercise_id"));
-    if (exercise.isPresent()) {
-      Exercise responseExercise = exercise.get();
-      assertEquals(Optional.empty(), responseExercise.getCurrentPause());
+        mockedInstant.when(Instant::now).thenReturn(instantBeforeSetRun);
+        // we need this other mock because the production code
+        // inconsistently calls Instant.now() and LocalDateTime.now()
+        mockedClock.when(Clock::systemDefaultZone).thenReturn(clock);
+
+        // --EXECUTE--
+        String response =
+            mvc.perform(
+                    put(EXERCISE_URI + "/" + PAUSED_EXERCISE.getId() + "/status")
+                        .content(asJsonString(input))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        // --ASSERT--
+        // NOTE: we are changing the time of Instant.now() here to fast forward in the future
+        mockedInstant.when(Instant::now).thenReturn(instantAfterSetRun);
+
+        List<ExecutableInject> injects = injectHelper.getInjectsToRun();
+        List<Pause> pauses = pauseRepository.findAllForExercise(PAUSED_EXERCISE.getId());
+        Optional<Exercise> exercise =
+            exerciseRepository.findById(JsonPath.read(response, "$.exercise_id"));
+        if (exercise.isPresent()) {
+          Exercise responseExercise = exercise.get();
+          assertEquals(Optional.empty(), responseExercise.getCurrentPause());
+        }
+        assertEquals(1, pauses.size());
+        assertEquals(
+            Arrays.asList(ExerciseStatus.CANCELED.name(), ExerciseStatus.PAUSED.name()),
+            JsonPath.read(response, "$.exercise_next_possible_status"));
+        assertEquals(1, injects.size());
+
+        // --CLEAN--
+        pauseRepository.delete(pauses.getFirst());
+      }
     }
-    assertEquals(1, pauses.size());
-    assertEquals(
-        Arrays.asList(ExerciseStatus.CANCELED.name(), ExerciseStatus.PAUSED.name()),
-        JsonPath.read(response, "$.exercise_next_possible_status"));
-    assertEquals(1, injects.size());
-
-    // --CLEAN--
-    pauseRepository.delete(pauses.getFirst());
   }
 
   @DisplayName("Check an exercise from running to paused")

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/ExerciseFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/ExerciseFixture.java
@@ -1,6 +1,5 @@
 package io.openbas.utils.fixtures;
 
-import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.MINUTES;
 
 import io.openbas.database.model.Exercise;
@@ -37,6 +36,10 @@ public class ExerciseFixture {
   }
 
   public static Exercise createDefaultIncidentResponseExercise() {
+    return createDefaultIncidentResponseExercise(Instant.now());
+  }
+
+  public static Exercise createDefaultIncidentResponseExercise(Instant startTime) {
     Exercise exercise = new Exercise();
     exercise.setName("Incident response exercise");
     exercise.setDescription("An incident response exercise for my enterprise");
@@ -44,11 +47,15 @@ public class ExerciseFixture {
     exercise.setFrom("exercise@mail.fr");
     exercise.setCategory("incident-response");
     exercise.setStatus(ExerciseStatus.SCHEDULED);
-    exercise.setStart(Instant.now());
+    exercise.setStart(startTime);
     return exercise;
   }
 
   public static Exercise createDefaultAttackExercise() {
+    return createDefaultAttackExercise(Instant.now());
+  }
+
+  public static Exercise createDefaultAttackExercise(Instant startTime) {
     Exercise exercise = new Exercise();
     exercise.setName("Draft incident response exercise");
     exercise.setDescription("An incident response exercise for my enterprise");
@@ -57,11 +64,15 @@ public class ExerciseFixture {
     exercise.setCategory("attack-scenario");
     exercise.setMainFocus("incident-response");
     exercise.setStatus(ExerciseStatus.SCHEDULED);
-    exercise.setStart(Instant.now());
+    exercise.setStart(startTime);
     return exercise;
   }
 
   public static Exercise createRunningAttackExercise() {
+    return createRunningAttackExercise(Instant.now());
+  }
+
+  public static Exercise createRunningAttackExercise(Instant startTime) {
     Exercise exercise = new Exercise();
     exercise.setName("Draft incident response exercise");
     exercise.setDescription("An incident response exercise for my enterprise");
@@ -70,11 +81,15 @@ public class ExerciseFixture {
     exercise.setCategory("attack-scenario");
     exercise.setMainFocus("incident-response");
     exercise.setStatus(ExerciseStatus.RUNNING);
-    exercise.setStart(Instant.now());
+    exercise.setStart(startTime);
     return exercise;
   }
 
   public static Exercise createCanceledAttackExercise() {
+    return createCanceledAttackExercise(Instant.now());
+  }
+
+  public static Exercise createCanceledAttackExercise(Instant startTime) {
     Exercise exercise = new Exercise();
     exercise.setName("Draft incident response exercise");
     exercise.setDescription("An incident response exercise for my enterprise");
@@ -83,11 +98,15 @@ public class ExerciseFixture {
     exercise.setCategory("attack-scenario");
     exercise.setMainFocus("incident-response");
     exercise.setStatus(ExerciseStatus.CANCELED);
-    exercise.setStart(Instant.now());
+    exercise.setStart(startTime);
     return exercise;
   }
 
   public static Exercise createFinishedAttackExercise() {
+    return createFinishedAttackExercise(Instant.now());
+  }
+
+  public static Exercise createFinishedAttackExercise(Instant startTime) {
     Exercise exercise = new Exercise();
     exercise.setName("Draft incident response exercise");
     exercise.setDescription("An incident response exercise for my enterprise");
@@ -96,13 +115,17 @@ public class ExerciseFixture {
     exercise.setCategory("attack-scenario");
     exercise.setMainFocus("incident-response");
     exercise.setStatus(ExerciseStatus.FINISHED);
-    exercise.setStart(Instant.now());
+    exercise.setStart(startTime);
     return exercise;
   }
 
   public static Exercise createPausedAttackExercise() {
+    return createPausedAttackExercise(Instant.now());
+  }
+
+  public static Exercise createPausedAttackExercise(Instant startTime) {
     Exercise exercise = new Exercise();
-    exercise.setCurrentPause(now().truncatedTo(MINUTES).minus(1, MINUTES));
+    exercise.setCurrentPause(startTime.truncatedTo(MINUTES).minus(1, MINUTES));
     exercise.setName("Draft incident response exercise");
     exercise.setDescription("An incident response exercise for my enterprise");
     exercise.setSubtitle("An incident response exercise");
@@ -110,7 +133,7 @@ public class ExerciseFixture {
     exercise.setCategory("attack-scenario");
     exercise.setMainFocus("incident-response");
     exercise.setStatus(ExerciseStatus.PAUSED);
-    exercise.setStart(Instant.now());
+    exercise.setStart(startTime);
     return exercise;
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Mock `Instant.now` and `Clock.systemDefaultZone` to get predictable times when production code calls `Instant.now()` and `LocalDateTime.now()`

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
I only changed the tests that depended on waiting for some time and fetch back the injects (i.e. time based tests); other tests don't seem to be affected by passing time.
