### PR TITLE
[frontend] Change "Add teams..." dialog into "Modify teams..." and alter behaviour (#2112)

### DIFF
--- a/openbas-front/src/admin/components/common/injects/CreateInjectDetails.js
+++ b/openbas-front/src/admin/components/common/injects/CreateInjectDetails.js
@@ -83,6 +83,7 @@ const CreateInjectDetails = ({
   const [defaultValues, setDefaultValues] = useState({});
   const [injectDetailsState, setInjectDetailsState] = useState({});
 
+  const availableTeamIds = props.teamsFromExerciseOrScenario ? props.teamsFromExerciseOrScenario.map(t => t.team_id) : [];
   const { tagsMap } = useHelper(helper => ({
     tagsMap: helper.getTagsMap(),
   }));
@@ -358,6 +359,7 @@ const CreateInjectDetails = ({
                   inject_asset_groups: [],
                   inject_documents: [],
                 }}
+                availableTeamIds={availableTeamIds}
                 injectorContract={{ ...contractContent }}
                 handleClose={handleClose}
                 tagsMap={tagsMap}

--- a/openbas-front/src/admin/components/common/injects/CreateInjectDetails.js
+++ b/openbas-front/src/admin/components/common/injects/CreateInjectDetails.js
@@ -1,10 +1,11 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { ArrowDropDownOutlined, ArrowDropUpOutlined, HelpOutlined, HighlightOffOutlined } from '@mui/icons-material';
 import { Avatar, Button, Card, CardContent, CardHeader, IconButton } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import arrayMutators from 'final-form-arrays';
 import * as R from 'ramda';
-import { useContext, useState } from 'react';
-import { Form } from 'react-final-form';
+import { useContext, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 import { useFormatter } from '../../../../components/i18n';
 import { useHelper } from '../../../../store';
@@ -79,6 +80,7 @@ const CreateInjectDetails = ({
   const classes = useStyles();
   const { permissions } = useContext(PermissionsContext);
   const [openDetails, setOpenDetails] = useState(false);
+  const [defaultValues, setDefaultValues] = useState({});
   const [injectDetailsState, setInjectDetailsState] = useState({});
 
   const { tagsMap } = useHelper(helper => ({
@@ -92,21 +94,7 @@ const CreateInjectDetails = ({
       setOpenDetails(true);
     }
   };
-  const validate = (values) => {
-    const errors = {};
-    const requiredFields = [
-      'inject_title',
-      'inject_depends_duration_days',
-      'inject_depends_duration_hours',
-      'inject_depends_duration_minutes',
-    ];
-    requiredFields.forEach((field) => {
-      if (R.isNil(values[field])) {
-        errors[field] = t('This field is required.');
-      }
-    });
-    return errors;
-  };
+
   const onSubmit = async (data) => {
     if (contractContent) {
       const finalData = {};
@@ -196,96 +184,132 @@ const CreateInjectDetails = ({
     }
     handleClose();
   };
-  const initialValues = {
-    inject_title: contractContent ? tPick(contractContent.label) : '',
-    inject_tags: [],
-    inject_depends_duration_days: presetValues?.inject_depends_duration_days ?? 0,
-    inject_depends_duration_hours: presetValues?.inject_depends_duration_hours ?? 0,
-    inject_depends_duration_minutes: presetValues?.inject_depends_duration_minutes ?? 0,
-  };
-  // Enrich initialValues with default contract value
-  if (contractContent) {
-    const builtInFields = [
-      'teams',
-      'assets',
-      'assetgroups',
-      'articles',
-      'challenges',
-      'attachments',
-      'expectations',
-    ];
-    contractContent.fields
-      .filter(f => !builtInFields.includes(f.key))
-      .forEach((field) => {
-        if (!initialValues[field.key]) {
-          if (field.cardinality && field.cardinality === '1') {
-            initialValues[field.key] = R.head(field.defaultValue);
-          } else {
-            initialValues[field.key] = field.defaultValue;
-          }
-        }
-      });
-    // Specific processing for some fields
-    contractContent.fields
-      .filter(f => !builtInFields.includes(f.key))
-      .forEach((field) => {
-        if (
-          field.type === 'textarea'
-          && field.richText
-          && initialValues[field.key]
-          && initialValues[field.key].length > 0
-        ) {
-          initialValues[field.key] = initialValues[field.key]
-            .replaceAll(
-              '<#list challenges as challenge>',
-              '&lt;#list challenges as challenge&gt;',
-            )
-            .replaceAll(
-              '<#list articles as article>',
-              '&lt;#list articles as article&gt;',
-            )
-            .replaceAll('</#list>', '&lt;/#list&gt;');
-        } else if (field.type === 'tuple' && initialValues[field.key]) {
-          if (field.cardinality && field.cardinality === '1') {
-            if (
-              initialValues[field.key].value
-              && initialValues[field.key].value.includes(
-                `${field.tupleFilePrefix}`,
-              )
-            ) {
-              initialValues[field.key] = {
-                type: 'attachment',
-                key: initialValues[field.key].key,
-                value: initialValues[field.key].value.replace(
-                  `${field.tupleFilePrefix}`,
-                  '',
-                ),
-              };
+
+  const getInitialValues = () => {
+    const initialValues = {
+      inject_title: contractContent ? tPick(contractContent.label) : '',
+      inject_tags: [],
+      inject_depends_duration_days: presetValues?.inject_depends_duration_days ?? 0,
+      inject_depends_duration_hours: presetValues?.inject_depends_duration_hours ?? 0,
+      inject_depends_duration_minutes: presetValues?.inject_depends_duration_minutes ?? 0,
+    };
+    // Enrich initialValues with default contract value
+    if (contractContent) {
+      const builtInFields = [
+        'teams',
+        'assets',
+        'assetgroups',
+        'articles',
+        'challenges',
+        'attachments',
+        'expectations',
+      ];
+      contractContent.fields
+        .filter(f => !builtInFields.includes(f.key))
+        .forEach((field) => {
+          if (!initialValues[field.key]) {
+            if (field.cardinality && field.cardinality === '1') {
+              initialValues[field.key] = R.head(field.defaultValue);
             } else {
-              initialValues[field.key] = R.assoc(
-                'type',
-                'text',
-                initialValues[field.key],
-              );
+              initialValues[field.key] = field.defaultValue;
             }
-          } else {
-            initialValues[field.key] = initialValues[field.key].map((pair) => {
-              if (
-                pair.value
-                && pair.value.includes(`${field.tupleFilePrefix}`)
-              ) {
-                return {
-                  type: 'attachment',
-                  key: pair.key,
-                  value: pair.value.replace(`${field.tupleFilePrefix}`, ''),
-                };
-              }
-              return R.assoc('type', 'text', pair);
-            });
           }
-        }
-      });
-  }
+        });
+      // Specific processing for some fields
+      contractContent.fields
+        .filter(f => !builtInFields.includes(f.key))
+        .forEach((field) => {
+          if (
+            field.type === 'textarea'
+            && field.richText
+            && initialValues[field.key]
+            && initialValues[field.key].length > 0
+          ) {
+            initialValues[field.key] = initialValues[field.key]
+              .replaceAll(
+                '<#list challenges as challenge>',
+                '&lt;#list challenges as challenge&gt;',
+              )
+              .replaceAll(
+                '<#list articles as article>',
+                '&lt;#list articles as article&gt;',
+              )
+              .replaceAll('</#list>', '&lt;/#list&gt;');
+          } else if (field.type === 'tuple' && initialValues[field.key]) {
+            if (field.cardinality && field.cardinality === '1') {
+              if (
+                initialValues[field.key].value
+                && initialValues[field.key].value.includes(
+                  `${field.tupleFilePrefix}`,
+                )
+              ) {
+                initialValues[field.key] = {
+                  type: 'attachment',
+                  key: initialValues[field.key].key,
+                  value: initialValues[field.key].value.replace(
+                    `${field.tupleFilePrefix}`,
+                    '',
+                  ),
+                };
+              } else {
+                initialValues[field.key] = R.assoc(
+                  'type',
+                  'text',
+                  initialValues[field.key],
+                );
+              }
+            } else {
+              initialValues[field.key] = initialValues[field.key].map((pair) => {
+                if (
+                  pair.value
+                  && pair.value.includes(`${field.tupleFilePrefix}`)
+                ) {
+                  return {
+                    type: 'attachment',
+                    key: pair.key,
+                    value: pair.value.replace(`${field.tupleFilePrefix}`, ''),
+                  };
+                }
+                return R.assoc('type', 'text', pair);
+              });
+            }
+          }
+        });
+    }
+
+    return initialValues;
+  };
+
+  const {
+    reset,
+    control,
+    register,
+    handleSubmit,
+    getValues,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm({
+    mode: 'onTouched',
+    resolver: zodResolver(
+      z.object({
+        inject_title: z.string().min(1, { message: t('This field is required.') }),
+        inject_depends_duration_days: z.number().int().min(0, { message: t('This field is required.') }),
+        inject_depends_duration_hours: z.number().int().min(0, { message: t('This field is required.') }),
+        inject_depends_duration_minutes: z.number().int().min(0, { message: t('This field is required.') }),
+        ...Object.keys(defaultValues).reduce((acc, key) => {
+          acc[key] = z.any();
+          return acc;
+        }, {}),
+      })),
+    defaultValues: getInitialValues(),
+  });
+
+  useEffect(() => {
+    const initialValues = getInitialValues();
+    setDefaultValues(initialValues);
+    reset(initialValues, { keepDirtyValues: true });
+  }, [contractContent, presetValues]);
+
   return (
     <>
       <Card elevation={0} classes={{ root: contractContent ? classes.injectorContract : classes.injectorContractDisabled }}>
@@ -294,10 +318,10 @@ const CreateInjectDetails = ({
           avatar={contractContent ? (
             <InjectIcon
               type={
-                contract.injector_contract_payload
-                  ? contract.injector_contract_payload?.payload_collector_type
-                  || contract.injector_contract_payload?.payload_type
-                  : contract.injector_contract_injector_type
+                contract?.injector_contract_payload
+                  ? contract?.injector_contract_payload?.payload_collector_type
+                  || contract?.injector_contract_payload?.payload_type
+                  : contract?.injector_contract_injector_type
               }
               isPayload={isNotEmptyField(contract.injector_contract_payload)}
             />
@@ -315,81 +339,66 @@ const CreateInjectDetails = ({
           {contractContent ? tPick(contractContent.label) : t('Select an inject in the left panel')}
         </CardContent>
       </Card>
-      <Form
-        keepDirtyOnReinitialize={true}
-        initialValues={initialValues}
-        onSubmit={onSubmit}
-        validate={validate}
-        mutators={{
-          ...arrayMutators,
-          setValue: ([field, value], state, { changeValue }) => {
-            changeValue(state, field, () => value);
-          },
-        }}
-      >
-        {({ form, handleSubmit, submitting, values, errors }) => {
-          return (
-            <form id="injectContentForm" onSubmit={handleSubmit} style={{ marginTop: 40 }}>
-              <InjectForm form={form} values={values} disabled={!contractContent} isAtomic={isAtomic} />
-              {contractContent && (
-                <div className={classes.details}>
-                  {openDetails && (
-                    <InjectDefinition
-                      form={form}
-                      values={values}
-                      submitting={submitting}
-                      inject={{
-                        inject_injector_contract: { injector_contract_id: contractId, injector_contract_arch: contract.injector_contract_arch },
-                        inject_type: contractContent.config.type,
-                        inject_teams: [],
-                        inject_assets: [],
-                        inject_asset_groups: [],
-                        inject_documents: [],
-                      }}
-                      injectorContract={{ ...contractContent }}
-                      handleClose={handleClose}
-                      tagsMap={tagsMap}
-                      permissions={permissions}
-                      articlesFromExerciseOrScenario={[]}
-                      variablesFromExerciseOrScenario={[]}
-                      onCreateInject={onCreateInject}
-                      setInjectDetailsState={setInjectDetailsState}
-                      uriVariable=""
-                      allUsersNumber={0}
-                      usersNumber={0}
-                      teamsUsers={[]}
-                      isAtomic={isAtomic}
-                      {...props}
-                    />
-                  )}
-                  <div className={classes.openDetails} onClick={toggleInjectContent}>
-                    {openDetails ? <ArrowDropUpOutlined fontSize="large" /> : <ArrowDropDownOutlined fontSize="large" />}
-                    {t('Inject content')}
-                  </div>
-                </div>
-              )}
-              <div style={{ float: 'right', marginTop: 20 }}>
-                <Button
-                  variant="contained"
-                  onClick={handleClose}
-                  style={{ marginRight: 10 }}
-                  disabled={submitting}
-                >
-                  {t('Cancel')}
-                </Button>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  type="submit"
-                  disabled={submitting || Object.keys(errors).length > 0 || !contractContent}
-                >
-                  {t('Create')}
-                </Button>
-              </div>
-            </form>
-          );
-        }}
-      </Form>
+      <form id="injectContentForm" onSubmit={handleSubmit(onSubmit)} style={{ marginTop: 40 }}>
+        <InjectForm control={control} register={register} disabled={!contractContent} isAtomic={isAtomic} />
+        {contractContent && (
+          <div className={classes.details}>
+            {openDetails && (
+              <InjectDefinition
+                control={control}
+                register={register}
+                values={getValues()}
+                setValue={setValue}
+                submitting={isSubmitting}
+                inject={{
+                  inject_injector_contract: { injector_contract_id: contractId, injector_contract_arch: contract.injector_contract_arch },
+                  inject_type: contractContent.config.type,
+                  inject_teams: [],
+                  inject_assets: [],
+                  inject_asset_groups: [],
+                  inject_documents: [],
+                }}
+                injectorContract={{ ...contractContent }}
+                handleClose={handleClose}
+                tagsMap={tagsMap}
+                permissions={permissions}
+                articlesFromExerciseOrScenario={[]}
+                variablesFromExerciseOrScenario={[]}
+                onCreateInject={onCreateInject}
+                setInjectDetailsState={setInjectDetailsState}
+                uriVariable=""
+                allUsersNumber={0}
+                usersNumber={0}
+                teamsUsers={[]}
+                isAtomic={isAtomic}
+                {...props}
+              />
+            )}
+            <div className={classes.openDetails} onClick={toggleInjectContent}>
+              {openDetails ? <ArrowDropUpOutlined fontSize="large" /> : <ArrowDropDownOutlined fontSize="large" />}
+              {t('Inject content')}
+            </div>
+          </div>
+        )}
+        <div style={{ float: 'right', marginTop: 20 }}>
+          <Button
+            variant="contained"
+            onClick={handleClose}
+            style={{ marginRight: 10 }}
+            disabled={isSubmitting}
+          >
+            {t('Cancel')}
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            type="submit"
+            disabled={isSubmitting || Object.keys(errors).length > 0 || !contractContent}
+          >
+            {t('Create')}
+          </Button>
+        </div>
+      </form>
     </>
   );
 };

--- a/openbas-front/src/admin/components/common/injects/InjectAddTeams.tsx
+++ b/openbas-front/src/admin/components/common/injects/InjectAddTeams.tsx
@@ -13,7 +13,8 @@ import {
 import { makeStyles } from '@mui/styles';
 import { FunctionComponent, useContext, useEffect, useMemo, useState } from 'react';
 
-import { findTeams } from '../../../../actions/teams/team-actions';
+import { fetchTeams, findTeams } from '../../../../actions/teams/team-actions';
+import { TeamsHelper } from '../../../../actions/teams/team-helper';
 import PaginationComponentV2 from '../../../../components/common/queryable/pagination/PaginationComponentV2';
 import { buildSearchPagination } from '../../../../components/common/queryable/QueryableUtils';
 import { useQueryable } from '../../../../components/common/queryable/useQueryableWithLocalStorage';
@@ -22,14 +23,12 @@ import Transition from '../../../../components/common/Transition';
 import { useFormatter } from '../../../../components/i18n';
 import ItemTags from '../../../../components/ItemTags';
 import type { Theme } from '../../../../components/Theme';
+import { useHelper } from '../../../../store';
 import type { TeamOutput } from '../../../../utils/api-types';
+import { useAppDispatch } from '../../../../utils/hooks';
+import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import CreateTeam from '../../components/teams/CreateTeam';
 import { PermissionsContext, TeamContext } from '../Context';
-import { useAppDispatch } from '../../../../utils/hooks';
-import { fetchTeams } from '../../../../actions/teams/team-actions';
-import {useHelper} from "../../../../store";
-import {TeamsHelper} from "../../../../actions/teams/team-helper";
-import useDataLoader from "../../../../utils/hooks/useDataLoader";
 
 const useStyles = makeStyles((theme: Theme) => ({
   item: {
@@ -55,7 +54,7 @@ const InjectAddTeams: FunctionComponent<Props> = ({
   availableTeamIds,
 }) => {
   // Standard hooks
-  const dispatch = useAppDispatch()
+  const dispatch = useAppDispatch();
   const { t } = useFormatter();
   const classes = useStyles();
   const { permissions } = useContext(PermissionsContext);
@@ -64,7 +63,6 @@ const InjectAddTeams: FunctionComponent<Props> = ({
   const [teamValues, setTeamValues] = useState<TeamOutput[]>([]);
   const [selectedTeamValues, setSelectedTeamValues] = useState<TeamOutput[]>([]);
 
-  console.log("availableTeamIds = {}", availableTeamIds)
   const allTeams = useHelper((helper: TeamsHelper) => helper.getTeams().filter(t => availableTeamIds.length > 0 ? availableTeamIds.includes(t.team_id) : true));
   useDataLoader(() => {
     dispatch(fetchTeams()).finally(() => {

--- a/openbas-front/src/admin/components/common/injects/InjectDefinition.js
+++ b/openbas-front/src/admin/components/common/injects/InjectDefinition.js
@@ -253,6 +253,7 @@ class InjectDefinition extends Component {
     super(props);
     this.state = {
       allTeams: props.inject.inject_all_teams,
+      availableTeamIds: props.availableTeamIds || [],
       teamsIds: props.inject.inject_teams || [],
       assetIds: props.inject.inject_assets || [],
       assetGroupIds: props.inject.inject_asset_groups || [],
@@ -313,9 +314,9 @@ class InjectDefinition extends Component {
   }
 
   // Teams
-  handleAddTeams(teamsIds) {
+  handleModifyTeams(teamsIds) {
     this.setState({
-      teamsIds: [...this.state.teamsIds, ...teamsIds],
+      teamsIds: [...teamsIds],
     }, () => this.props.setInjectDetailsState(this.state));
   }
 
@@ -734,6 +735,7 @@ class InjectDefinition extends Component {
     const {
       allTeams,
       teamsIds,
+      availableTeamIds,
       assetIds,
       assetGroupIds,
       documents,
@@ -909,7 +911,8 @@ class InjectDefinition extends Component {
                   />
                   <InjectAddTeams
                     injectTeamsIds={teamsIds}
-                    handleAddTeams={this.handleAddTeams.bind(this)}
+                    availableTeamIds={availableTeamIds}
+                    handleModifyTeams={this.handleModifyTeams.bind(this)}
                   />
                 </>
               )}
@@ -1283,6 +1286,7 @@ InjectDefinition.propTypes = {
   nsdt: PropTypes.func,
   injectId: PropTypes.string,
   inject: PropTypes.object,
+  availableTeamIds: PropTypes.array,
   fetchInjectTeams: PropTypes.func,
   fetchChannels: PropTypes.func,
   fetchChallenges: PropTypes.func,

--- a/openbas-front/src/admin/components/common/injects/InjectDefinition.js
+++ b/openbas-front/src/admin/components/common/injects/InjectDefinition.js
@@ -1,6 +1,4 @@
 import {
-  ArrowDropDownOutlined,
-  ArrowDropUpOutlined,
   AttachmentOutlined,
   ControlPointOutlined,
   DeleteOutlined,
@@ -30,7 +28,6 @@ import { withStyles } from '@mui/styles';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { Component } from 'react';
-import { FieldArray } from 'react-final-form-arrays';
 import { connect } from 'react-redux';
 
 import { fetchChallenges } from '../../../../actions/Challenge';
@@ -38,11 +35,12 @@ import { fetchChannels } from '../../../../actions/channels/channel-action';
 import { fetchDocuments } from '../../../../actions/Document';
 import { fetchInjectTeams } from '../../../../actions/Inject';
 import { storeHelper } from '../../../../actions/Schema';
+import FieldArray from '../../../../components/fields/FieldArray';
 import MultipleFileLoader from '../../../../components/fields/MultipleFileLoader';
-import OldSelectField from '../../../../components/fields/OldSelectField';
-import OldTextField from '../../../../components/fields/OldTextField';
 import RichTextField from '../../../../components/fields/RichTextField';
+import SelectField from '../../../../components/fields/SelectField';
 import SwitchField from '../../../../components/fields/SwitchField';
+import TextField from '../../../../components/fields/TextField';
 import inject18n from '../../../../components/i18n';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import ItemTags from '../../../../components/ItemTags';
@@ -128,103 +126,6 @@ const styles = theme => ({
     color: theme.palette.primary.main,
   },
 });
-
-const inlineStylesHeaders = {
-  iconSort: {
-    position: 'absolute',
-    margin: '0 0 0 5px',
-    padding: 0,
-    top: '0px',
-  },
-  team_name: {
-    float: 'left',
-    width: '30%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  team_users_number: {
-    float: 'left',
-    width: '15%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  team_users_enabled_number: {
-    float: 'left',
-    width: '15%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  team_tags: {
-    float: 'left',
-    width: '30%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  article_channel_type: {
-    float: 'left',
-    width: '15%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  article_channel_name: {
-    float: 'left',
-    width: '20%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  article_name: {
-    float: 'left',
-    width: '30%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  article_author: {
-    float: 'left',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  challenge_category: {
-    float: 'left',
-    width: '20%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  challenge_name: {
-    float: 'left',
-    width: '35%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  challenge_tags: {
-    float: 'left',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  document_name: {
-    float: 'left',
-    width: '35%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  document_type: {
-    float: 'left',
-    width: '20%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  document_tags: {
-    float: 'left',
-    width: '30%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  document_attached: {
-    float: 'left',
-    width: '15%',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-};
 
 const inlineStyles = {
   team_name: {
@@ -507,113 +408,8 @@ class InjectDefinition extends Component {
     }, () => this.props.setInjectDetailsState(this.state));
   }
 
-  articlesReverseBy(field) {
-    this.setState({
-      articlesSortBy: field,
-      articlesOrderAsc: !this.state.articlesOrderAsc,
-    });
-  }
-
-  articlesSortHeader(field, label, isSortable) {
-    const { t } = this.props;
-    const { articlesSortBy, articlesOrderAsc } = this.state;
-    const sortComponent = articlesOrderAsc
-      ? (
-          <ArrowDropDownOutlined style={inlineStylesHeaders.iconSort} />
-        )
-      : (
-          <ArrowDropUpOutlined style={inlineStylesHeaders.iconSort} />
-        );
-    if (isSortable) {
-      return (
-        <div
-          style={inlineStylesHeaders[field]}
-          onClick={this.articlesReverseBy.bind(this, field)}
-        >
-          <span>{t(label)}</span>
-          {articlesSortBy === field ? sortComponent : ''}
-        </div>
-      );
-    }
-    return (
-      <div style={inlineStylesHeaders[field]}>
-        <span>{t(label)}</span>
-      </div>
-    );
-  }
-
-  challengesReverseBy(field) {
-    this.setState({
-      challengesSortBy: field,
-      challengesOrderAsc: !this.state.challengesOrderAsc,
-    });
-  }
-
-  challengesSortHeader(field, label, isSortable) {
-    const { t } = this.props;
-    const { challengesSortBy, challengesOrderAsc } = this.state;
-    const sortComponent = challengesOrderAsc
-      ? (
-          <ArrowDropDownOutlined style={inlineStylesHeaders.iconSort} />
-        )
-      : (
-          <ArrowDropUpOutlined style={inlineStylesHeaders.iconSort} />
-        );
-    if (isSortable) {
-      return (
-        <div
-          style={inlineStylesHeaders[field]}
-          onClick={this.challengesReverseBy.bind(this, field)}
-        >
-          <span>{t(label)}</span>
-          {challengesSortBy === field ? sortComponent : ''}
-        </div>
-      );
-    }
-    return (
-      <div style={inlineStylesHeaders[field]}>
-        <span>{t(label)}</span>
-      </div>
-    );
-  }
-
-  documentsReverseBy(field) {
-    this.setState({
-      documentsSortBy: field,
-      documentsOrderAsc: !this.state.documentsOrderAsc,
-    });
-  }
-
-  documentsSortHeader(field, label, isSortable) {
-    const { t } = this.props;
-    const { documentsSortBy, documentsOrderAsc } = this.state;
-    const sortComponent = documentsOrderAsc
-      ? (
-          <ArrowDropDownOutlined style={inlineStylesHeaders.iconSort} />
-        )
-      : (
-          <ArrowDropUpOutlined style={inlineStylesHeaders.iconSort} />
-        );
-    if (isSortable) {
-      return (
-        <div
-          style={inlineStylesHeaders[field]}
-          onClick={this.documentsReverseBy.bind(this, field)}
-        >
-          <span>{t(label)}</span>
-          {documentsSortBy === field ? sortComponent : ''}
-        </div>
-      );
-    }
-    return (
-      <div style={inlineStylesHeaders[field]}>
-        <span>{t(label)}</span>
-      </div>
-    );
-  }
-
   renderFields(renderedFields, values, attachedDocs) {
-    const { classes, t } = this.props;
+    const { classes, t, control, register } = this.props;
     return (
       <>
         {renderedFields.map((field) => {
@@ -630,13 +426,14 @@ class InjectDefinition extends Component {
                       disabled={this.props.permissions.readOnly || field.readOnly}
                       askAi={true}
                       inInject={true}
+                      control={control}
                     />
                   )
                 : (
-                    <OldTextField
+                    <TextField
                       variant="standard"
                       key={field.key}
-                      name={field.key}
+                      inputProps={register(field.key)}
                       fullWidth={true}
                       multiline={true}
                       rows={10}
@@ -645,19 +442,21 @@ class InjectDefinition extends Component {
                       disabled={this.props.permissions.readOnly || field.readOnly}
                       askAi={true}
                       inInject={true}
+                      control={this.props.control}
                     />
                   );
             case 'number':
               return (
-                <OldTextField
+                <TextField
                   variant="standard"
                   key={field.key}
-                  name={field.key}
+                  inputProps={register(field.key)}
                   fullWidth={true}
                   type="number"
                   label={`${t(field.label)}${field.mandatory ? '*' : ''}`}
                   style={{ marginTop: 20 }}
                   disabled={this.props.permissions.readOnly || field.readOnly}
+                  control={control}
                 />
               );
             case 'checkbox':
@@ -668,14 +467,17 @@ class InjectDefinition extends Component {
                   label={`${t(field.label)}${field.mandatory ? '*' : ''}`}
                   style={{ marginTop: 20 }}
                   disabled={this.props.permissions.readOnly || field.readOnly}
+                  control={control}
                 />
               );
-            case 'tuple':
+            case 'tuple': {
               return (
                 <div key={field.key}>
-                  <FieldArray name={field.key}>
-                    {({ fields, meta }) => (
-                      <div>
+                  <FieldArray
+                    name={field.key}
+                    control={control}
+                    renderLabel={(append) => {
+                      return (
                         <div style={{ marginTop: 20 }}>
                           <InputLabel
                             variant="standard"
@@ -685,7 +487,7 @@ class InjectDefinition extends Component {
                             {`${t(field.label)}${field.mandatory ? '*' : ''}`}
                             {field.cardinality === 'n' && (
                               <IconButton
-                                onClick={() => fields.push({
+                                onClick={() => append({
                                   type: 'text',
                                   key: '',
                                   value: '',
@@ -699,214 +501,182 @@ class InjectDefinition extends Component {
                                 <ControlPointOutlined />
                               </IconButton>
                             )}
-                            {meta.error && meta.touched && (
-                              <div className={classes.errorColor}>
-                                {meta.error}
-                              </div>
-                            )}
                           </InputLabel>
                         </div>
-                        <List style={{ marginTop: -20 }}>
-                          {fields.map((name, index) => {
-                            return (
-                              <ListItem
-                                key={`${field.key}_list_${index}`}
-                                classes={{ root: classes.tuple }}
-                                divider={false}
-                              >
-                                <OldSelectField
-                                  variant="standard"
-                                  name={`${name}.type`}
-                                  fullWidth={true}
-                                  label={t('Type')}
-                                  style={{ marginRight: 20 }}
-                                  disabled={this.props.permissions.readOnly || field.readOnly}
+                      );
+                    }}
+                    renderField={(name, index, remove) => {
+                      return (
+                        <List key={name.id} style={{ marginTop: -20 }}>
+                          <ListItem
+                            key={`${field.key}_list_${index}`}
+                            classes={{ root: classes.tuple }}
+                            divider={false}
+                          >
+                            <SelectField
+                              variant="standard"
+                              name={`${field.key}.${index}.type`}
+                              fullWidth={true}
+                              label={t('Type')}
+                              style={{ marginRight: 20 }}
+                              disabled={this.props.permissions.readOnly || field.readOnly}
+                              control={control}
+                            >
+                              <MenuItem key="text" value="text">
+                                <ListItemText>{t('Text')}</ListItemText>
+                              </MenuItem>
+                              {field.contractAttachment && (
+                                <MenuItem
+                                  key="attachment"
+                                  value="attachment"
                                 >
-                                  <MenuItem key="text" value="text">
-                                    <ListItemText>{t('Text')}</ListItemText>
-                                  </MenuItem>
-                                  {field.contractAttachment && (
-                                    <MenuItem
-                                      key="attachment"
-                                      value="attachment"
-                                    >
-                                      <ListItemText>
-                                        {t('Attachment')}
-                                      </ListItemText>
-                                    </MenuItem>
-                                  )}
-                                </OldSelectField>
-                                <OldTextField
-                                  variant="standard"
-                                  name={`${name}.key`}
-                                  fullWidth={true}
-                                  label={t('Key')}
-                                  style={{ marginRight: 20 }}
-                                  disabled={this.props.permissions.readOnly || field.readOnly}
-                                />
-                                {values
-                                && values[field.key]
-                                && values[field.key][index]
-                                && values[field.key][index].type
-                                === 'attachment' ? (
-                                      <OldSelectField
-                                        variant="standard"
-                                        name={`${name}.value`}
-                                        fullWidth={true}
-                                        label={t('Value')}
-                                        style={{ marginRight: 20 }}
-                                        disabled={this.props.permissions.readOnly || field.readOnly}
-                                      >
-                                        {attachedDocs.map(doc => (
-                                          <MenuItem
-                                            key={doc.document_id}
-                                            value={doc.document_id}
-                                          >
-                                            <ListItemText>
-                                              {doc.document_name}
-                                            </ListItemText>
-                                          </MenuItem>
-                                        ))}
-                                      </OldSelectField>
-                                    ) : (
-                                      <OldTextField
-                                        variant="standard"
-                                        name={`${name}.value`}
-                                        fullWidth={true}
-                                        label={t('Value')}
-                                        style={{ marginRight: 20 }}
-                                        disabled={this.props.permissions.readOnly || field.readOnly}
-                                      />
-                                    )}
-                                {field.cardinality === 'n' && (
-                                  <IconButton
-                                    onClick={() => fields.remove(index)}
-                                    aria-haspopup="true"
-                                    size="small"
+                                  <ListItemText>
+                                    {t('Attachment')}
+                                  </ListItemText>
+                                </MenuItem>
+                              )}
+                            </SelectField>
+                            <TextField
+                              variant="standard"
+                              fullWidth={true}
+                              label={t('Key')}
+                              style={{ marginRight: 20 }}
+                              disabled={this.props.permissions.readOnly || field.readOnly}
+                              inputProps={register(`${field.key}.${index}.key`)}
+                              control={control}
+                            />
+                            {values
+                            && values[field.key]
+                            && values[field.key][index]
+                            && values[field.key][index].type
+                            === 'attachment' ? (
+                                  <TextField
+                                    variant="standard"
+                                    fullWidth={true}
+                                    label={t('Value')}
+                                    style={{ marginRight: 20 }}
                                     disabled={this.props.permissions.readOnly || field.readOnly}
-                                    color="primary"
+                                    inputProps={register(`${field.key}.${index}.value`)}
+                                    control={control}
                                   >
-                                    <DeleteOutlined />
-                                  </IconButton>
+                                    {attachedDocs.map(doc => (
+                                      <MenuItem
+                                        key={doc.document_id}
+                                        value={doc.document_id}
+                                      >
+                                        <ListItemText>
+                                          {doc.document_name}
+                                        </ListItemText>
+                                      </MenuItem>
+                                    ))}
+                                  </TextField>
+                                ) : (
+                                  <TextField
+                                    variant="standard"
+                                    fullWidth={true}
+                                    label={t('Value')}
+                                    style={{ marginRight: 20 }}
+                                    disabled={this.props.permissions.readOnly || field.readOnly}
+                                    inputProps={register(`${field.key}.${index}.value`)}
+                                    control={control}
+                                  />
                                 )}
-                              </ListItem>
-                            );
-                          })}
+                            {field.cardinality === 'n' && (
+                              <IconButton
+                                onClick={() => remove(index)}
+                                aria-haspopup="true"
+                                size="small"
+                                disabled={this.props.permissions.readOnly || field.readOnly}
+                                color="primary"
+                              >
+                                <DeleteOutlined />
+                              </IconButton>
+                            )}
+                          </ListItem>
                         </List>
-                      </div>
-                    )}
-                  </FieldArray>
+                      );
+                    }}
+                  />
                 </div>
               );
-            case 'select':
-              return field.cardinality === 'n'
-                ? (
-                    <OldSelectField
-                      variant="standard"
-                      label={`${t(field.label)}${field.mandatory ? '*' : ''}`}
-                      key={field.key}
-                      multiple
-                      renderValue={v => v.map(a => field.choices[a]).join(', ')}
-                      name={field.key}
-                      fullWidth={true}
-                      style={{ marginTop: 20 }}
-                      disabled={this.props.permissions.readOnly || field.readOnly}
-                    >
-                      {Object.entries(field.choices)
-                        .sort((a, b) => a[1].localeCompare(b[1]))
-                        .map(([k, v]) => (
-                          <MenuItem key={k} value={k}>
-                            <ListItemText>
-                              {field.expectation ? t(v || 'Unknown') : v}
-                            </ListItemText>
-                          </MenuItem>
-                        ))}
-                    </OldSelectField>
-                  )
-                : (
-                    <OldSelectField
-                      variant="standard"
-                      label={`${t(field.label)}${field.mandatory ? '*' : ''}`}
-                      key={field.key}
-                      renderValue={v => (field.expectation
-                        ? t(field.choices[v] || 'Unknown')
-                        : field.choices[v])}
-                      name={field.key}
-                      fullWidth={true}
-                      style={{ marginTop: 20 }}
-                      disabled={this.props.permissions.readOnly}
-                    >
-                      {Object.entries(field.choices)
-                        .sort((a, b) => a[1].localeCompare(b[1]))
-                        .map(([k, v]) => (
-                          <MenuItem key={k} value={k}>
-                            <ListItemText>
-                              {field.expectation ? t(v || 'Unknown') : v}
-                            </ListItemText>
-                          </MenuItem>
-                        ))}
-                    </OldSelectField>
-                  );
-            case 'dependency-select':
-              // eslint-disable-next-line no-case-declarations
+            }
+            case 'select': {
+              const renderMultipleValuesFct = v => v.map(a => field.choices[a]).join(', ');
+              const renderSingleValueFct = v => (field.expectation
+                ? t(field.choices[v] || 'Unknown')
+                : field.choices[v]);
+              const renderValueFct = field.cardinality === 'n' ? renderMultipleValuesFct : renderSingleValueFct;
+              const multipleItemDisplayFct = v => field.expectation ? t(v || 'Unknown') : v;
+
+              return (
+                <SelectField
+                  variant="standard"
+                  label={`${t(field.label)}${field.mandatory ? '*' : ''}`}
+                  key={field.key}
+                  multiple={field.cardinality === 'n'}
+                  renderValue={v => renderValueFct(v)}
+                  name={field.key}
+                  fullWidth={true}
+                  style={{ marginTop: 20 }}
+                  control={control}
+                  disabled={this.props.permissions.readOnly || field.readOnly}
+                >
+                  {Object.entries(field.choices)
+                    .sort((a, b) => a[1].localeCompare(b[1]))
+                    .map(([k, v]) => (
+                      <MenuItem key={k} value={k}>
+                        <ListItemText>
+                          {field.cardinality === 'n' ? v : multipleItemDisplayFct(v)}
+                        </ListItemText>
+                      </MenuItem>
+                    ))}
+                </SelectField>
+              );
+            }
+            case 'dependency-select': {
               const depValue = values[field.dependencyField];
-              // eslint-disable-next-line no-case-declarations
               const choices = field.choices[depValue] ?? {};
-              return field.cardinality === 'n'
-                ? (
-                    <OldSelectField
-                      variant="standard"
-                      label={`${t(field.label)}${field.mandatory ? '*' : ''}`}
-                      key={field.key}
-                      multiple
-                      renderValue={v => v.map(a => choices[a]).join(', ')}
-                      name={field.key}
-                      fullWidth={true}
-                      style={{ marginTop: 20 }}
-                      disabled={this.props.permissions.readOnly || field.readOnly}
-                    >
-                      {Object.entries(choices)
-                        .sort((a, b) => a[1].localeCompare(b[1]))
-                        .map(([k, v]) => (
-                          <MenuItem key={k} value={k}>
-                            <ListItemText>{v}</ListItemText>
-                          </MenuItem>
-                        ))}
-                    </OldSelectField>
-                  )
-                : (
-                    <OldSelectField
-                      variant="standard"
-                      label={`${t(field.label)}${field.mandatory ? '*' : ''}`}
-                      key={field.key}
-                      renderValue={v => (field.expectation ? t(choices[v] || 'Unknown') : choices[v])}
-                      disabled={this.props.permissions.readOnly || field.readOnly}
-                      name={field.key}
-                      fullWidth={true}
-                      style={{ marginTop: 20 }}
-                    >
-                      {Object.entries(choices)
-                        .sort((a, b) => a[1].localeCompare(b[1]))
-                        .map(([k, v]) => (
-                          <MenuItem key={k} value={k}>
-                            <ListItemText>
-                              {field.expectation ? t(v || 'Unknown') : v}
-                            </ListItemText>
-                          </MenuItem>
-                        ))}
-                    </OldSelectField>
-                  );
+              const renderMultipleValuesFct = v => v.map(a => choices[a]).join(', ');
+              const renderSingleValueFct = v => (field.expectation ? t(choices[v] || 'Unknown') : choices[v]);
+              const renderValueFct = field.cardinality === 'n' ? renderMultipleValuesFct : renderSingleValueFct;
+              const multipleItemDisplayFct = v => field.expectation ? t(v || 'Unknown') : v;
+
+              return (
+                <SelectField
+                  variant="standard"
+                  label={`${t(field.label)}${field.mandatory ? '*' : ''}`}
+                  key={field.key}
+                  multiple={field.cardinality === 'n'}
+                  renderValue={v => renderValueFct(v)}
+                  disabled={this.props.permissions.readOnly || field.readOnly}
+                  name={field.key}
+                  fullWidth={true}
+                  control={control}
+                  style={{ marginTop: 20 }}
+                >
+                  {Object.entries(choices)
+                    .sort((a, b) => a[1].localeCompare(b[1]))
+                    .map(([k, v]) => (
+                      <MenuItem key={k} value={k}>
+                        <ListItemText>
+                          {field.cardinality === 'n' ? multipleItemDisplayFct(v) : v}
+                        </ListItemText>
+                      </MenuItem>
+                    ))}
+                </SelectField>
+              );
+            }
             default:
               return (
-                <OldTextField
+                <TextField
                   variant="standard"
                   key={field.key}
-                  name={field.key}
+                  inputProps={register(field.key)}
                   fullWidth={true}
                   label={`${t(field.label)}${field.mandatory ? '*' : ''}`}
                   style={{ marginTop: 20 }}
                   disabled={this.props.permissions.readOnly || field.readOnly}
-
+                  control={control}
                 />
               );
           }
@@ -915,52 +685,29 @@ class InjectDefinition extends Component {
     );
   }
 
-  resetDefaultvalues(setFieldValue, builtInFields) {
-    const { injectorContract } = this.props;
+  resetDefaultvalues(setFieldValue, builtInFields, injectorContract) {
     injectorContract.fields
       .filter(f => !builtInFields.includes(f.key) && !f.expectation)
       .forEach((field) => {
-        if (field.cardinality && field.cardinality === '1') {
-          let defaultValue = R.head(field.defaultValue);
-          if (
-            field.type === 'textarea'
-            && field.richText
-            && defaultValue
-            && defaultValue.length > 0
-          ) {
-            defaultValue = defaultValue
-              .replaceAll(
-                '<#list challenges as challenge>',
-                '&lt;#list challenges as challenge&gt;',
-              )
-              .replaceAll(
-                '<#list articles as article>',
-                '&lt;#list articles as article&gt;',
-              )
-              .replaceAll('</#list>', '&lt;/#list&gt;');
-          }
-          setFieldValue(field.key, defaultValue);
-        } else {
-          let { defaultValue } = field;
-          if (
-            field.type === 'textarea'
-            && field.richText
-            && defaultValue
-            && defaultValue.length > 0
-          ) {
-            defaultValue = defaultValue
-              .replaceAll(
-                '<#list challenges as challenge>',
-                '&lt;#list challenges as challenge&gt;',
-              )
-              .replaceAll(
-                '<#list articles as article>',
-                '&lt;#list articles as article&gt;',
-              )
-              .replaceAll('</#list>', '&lt;/#list&gt;');
-          }
-          setFieldValue(field.key, defaultValue);
+        let defaultValue = field.cardinality === '1' ? R.head(field.defaultValue) : field.defaultValue;
+        if (
+          field.type === 'textarea'
+          && field.richText
+          && defaultValue
+          && defaultValue.length > 0
+        ) {
+          defaultValue = defaultValue
+            .replaceAll(
+              '<#list challenges as challenge>',
+              '&lt;#list challenges as challenge&gt;',
+            )
+            .replaceAll(
+              '<#list articles as article>',
+              '&lt;#list articles as article&gt;',
+            )
+            .replaceAll('</#list>', '&lt;/#list&gt;');
         }
+        setFieldValue(field.key, defaultValue);
       });
   }
 
@@ -968,7 +715,7 @@ class InjectDefinition extends Component {
     const {
       t,
       classes,
-      form,
+      setValue,
       values,
       submitting,
       inject,
@@ -1092,435 +839,433 @@ class InjectDefinition extends Component {
     ];
     return (
       <>
-        <>
-          {hasTeams && (
-            <div style={{ marginTop: 25 }}>
-              <Typography variant="h5" style={{ fontWeight: 500, float: 'left' }}>
-                {t('Targeted teams')}
-              </Typography>
-              <FormGroup row={true} classes={{ root: classes.allTeams }}>
-                <FormControlLabel
-                  control={(
-                    <Switch
-                      checked={allTeams}
-                      onChange={this.toggleAll.bind(this)}
-                      color="primary"
-                      size="small"
-                      disabled={this.props.permissions.readOnly || fieldTeams.readOnly}
-                    />
-                  )}
-                  label={<strong>{t('All teams')}</strong>}
-                />
-              </FormGroup>
-              <div className="clearfix" />
-              <List>
-                {allTeams ? (
-                  <ListItem classes={{ root: classes.item }} divider={true}>
-                    <ListItemIcon>
-                      <GroupsOutlined />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={(
-                        <>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.team_name}
-                          >
-                            <i>{t('All teams')}</i>
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.team_users_number}
-                          >
-                            <strong>
-                              {this.props.allUsersNumber}
-                            </strong>
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.team_users_enabled_number}
-                          >
-                            <strong>
-                              {this.props.usersNumber}
-                            </strong>
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.team_tags}
-                          >
-                            <ItemTags variant="reduced-view" tags={[]} />
-                          </div>
-                        </>
-                      )}
-                    />
-                    <ListItemSecondaryAction> &nbsp; </ListItemSecondaryAction>
-                  </ListItem>
-                ) : (
-                  <>
-                    <InjectTeamsList
-                      teamIds={teamsIds}
-                      handleRemoveTeam={this.handleRemoveTeam.bind(this)}
-                    />
-                    <InjectAddTeams
-                      injectTeamsIds={teamsIds}
-                      handleAddTeams={this.handleAddTeams.bind(this)}
-                    />
-                  </>
-                )}
-              </List>
-            </div>
-          )}
-          {hasAssets && (
-            <>
-              <Typography variant="h5" style={{ fontWeight: 500, marginTop: hasTeams ? 20 : 0 }}>
-                {t('Targeted assets')}
-              </Typography>
-              <EndpointsList
-                endpoints={assets}
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore: Endpoint property handle by EndpointsList
-                actions={
-                  <EndpointPopover inline onRemoveEndpointFromInject={this.handleRemoveAsset.bind(this)} onDelete={this.handleRemoveAsset.bind(this)} />
-                }
-              />
-              <InjectAddEndpoints
-                endpointIds={assetIds}
-                onSubmit={this.handleAddAssets.bind(this)}
-                disabled={fieldAssets.readOnly}
-                platforms={injectorContract.platforms}
-                payloadArch={inject.inject_injector_contract?.injector_contract_arch}
-              />
-            </>
-          )}
-          {hasAssetGroups && (
-            <>
-              <Typography variant="h5" style={{ fontWeight: 500, marginTop: hasTeams || hasAssets ? 20 : 0 }}>
-                {t('Targeted asset groups')}
-              </Typography>
-              <AssetGroupsList
-                assetGroupIds={assetGroupIds}
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore: Endpoint property handle by EndpointsList
-                actions={
-                  <AssetGroupPopover inline onRemoveAssetGroupFromInject={this.handleRemoveAssetGroup.bind(this)} />
-                }
-              />
-              <InjectAddAssetGroups assetGroupIds={assetGroupIds} onSubmit={this.handleAddAssetGroups.bind(this)} />
-            </>
-          )}
-          {hasArticles && (
-            <>
-              <Typography variant="h5" style={{ fontWeight: 500, marginTop: hasTeams || hasAssets || hasAssetGroups ? 20 : 0 }}>
-                {t('Media pressure to publish')}
-              </Typography>
-              <List>
-                {sortedArticles.map(article => (
-                  <ListItem
-                    key={article.article_id}
-                    classes={{ root: classes.item }}
-                    divider={true}
-                  >
-                    <ListItemIcon>
-                      <ChannelIcon
-                        type={article.article_channel_type}
-                        variant="inline"
-                      />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={(
-                        <>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.article_channel_type}
-                          >
-                            {t(article.article_channel_type || 'Unknown')}
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.article_channel_name}
-                          >
-                            {article.article_channel_name}
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.article_name}
-                          >
-                            {article.article_name}
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.article_author}
-                          >
-                            {article.article_author}
-                          </div>
-                        </>
-                      )}
-                    />
-                    <ListItemSecondaryAction>
-                      <ArticlePopover
-                        article={article}
-                        onRemoveArticle={this.handleRemoveArticle.bind(this)}
-                        disabled={this.props.permissions.readOnly || fieldArticles.readOnly}
-                      />
-                    </ListItemSecondaryAction>
-                  </ListItem>
-                ))}
-                <InjectAddArticles
-                  articles={articlesFromExerciseOrScenario}
-                  injectArticlesIds={articlesIds}
-                  handleAddArticles={this.handleAddArticles.bind(this)}
-                />
-              </List>
-            </>
-          )}
-          {hasChallenges && (
-            <>
-              <Typography variant="h5" style={{ fontWeight: 500, marginTop: hasTeams || hasAssets || hasAssetGroups || hasArticles ? 20 : 0 }}>
-                {t('Challenges to publish')}
-              </Typography>
-              <List>
-                {sortedChallenges.map(challenge => (
-                  <ListItem
-                    key={challenge.challenge_id}
-                    classes={{ root: classes.item }}
-                    divider={true}
-                  >
-                    <ListItemIcon>
-                      <EmojiEventsOutlined />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={(
-                        <>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.challenge_category}
-                          >
-                            {t(challenge.challenge_category || 'Unknown')}
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.challenge_name}
-                          >
-                            {challenge.challenge_name}
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.challenge_tags}
-                          >
-                            <ItemTags
-                              variant="reduced-view"
-                              tags={challenge.challenge_tags}
-                            />
-                          </div>
-                        </>
-                      )}
-                    />
-                    <ListItemSecondaryAction>
-                      <ChallengePopover
-                        inline
-                        challenge={challenge}
-                        onRemoveChallenge={this.handleRemoveChallenge.bind(
-                          this,
-                        )}
-                        disabled={this.props.permissions.readOnly || fieldChallenges.readOnly}
-                      />
-                    </ListItemSecondaryAction>
-                  </ListItem>
-                ))}
-                <InjectAddChallenges
-                  injectChallengesIds={challengesIds}
-                  handleAddChallenges={this.handleAddChallenges.bind(
-                    this,
-                  )}
-                />
-              </List>
-            </>
-          )}
-          <div style={{ marginTop: hasTeams || hasAssets || hasAssetGroups || hasArticles || hasChallenges ? 24 : 0 }}>
-            <div style={{ float: 'left' }}>
-              <Typography variant="h5" style={{ fontWeight: 500 }}>{t('Inject data')}</Typography>
-            </div>
-            <div style={{ float: 'left' }}>
-              <Tooltip title={t('Reset to default values')}>
-                <IconButton
-                  color="primary"
-                  variant="outlined"
-                  disabled={submitting || this.props.permissions.readOnly}
-                  onClick={this.resetDefaultvalues.bind(this, form.mutators.setValue, builtInFields)}
-                  size="small"
-                  style={{ margin: '-12px 0 0 5px' }}
-                >
-                  <RotateLeftOutlined />
-                </IconButton>
-              </Tooltip>
-            </div>
-            <div style={{ float: 'right' }}>
-              <Button
-                color="primary"
-                variant="outlined"
-                size="small"
-                onClick={this.handleOpenVariables.bind(this)}
-                startIcon={<HelpOutlineOutlined />}
-                style={{ marginTop: -10 }}
-              >
-                {t('Available variables')}
-              </Button>
-            </div>
-            <div className="clearfix" />
-          </div>
+        {hasTeams && (
           <>
-            {this.renderFields(
-              injectorContract.fields
-                .filter(
-                  f => !builtInFields.includes(f.key) && !f.expectation,
-                )
-                .filter((f) => {
-                // Filter display if linked fields
-                  for (
-                    let index = 0;
-                    index < f.linkedFields.length;
-                    index += 1
-                  ) {
-                    const linkedField = f.linkedFields[index];
-                    if (
-                      linkedField.type === 'checkbox'
-                      && values[linkedField.key] === false
-                    ) {
-                      return false;
-                    }
-                    if (
-                      linkedField.type === 'select'
-                      && !f.linkedValues.includes(values[linkedField.key])
-                    ) {
-                      return false;
-                    }
-                  }
-                  return true;
-                }),
-              values,
-              attachedDocs,
-            )}
-          </>
-          {(hasExpectations || expectationsNotManual.length > 0) && (
-            <>
-              <Typography variant="h5" style={{ marginTop: 20, fontWeight: 500 }}>
-                {t('Inject expectations')}
-              </Typography>
-              {expectationsNotManual.length > 0 && (
-                <>
-                  <div style={{ marginTop: -15 }}>
-                    {this.renderFields(
-                      expectationsNotManual.filter((f) => {
-                      // Filter display if linked fields
-                        for (let index = 0; index < f.linkedFields.length; index += 1) {
-                          const linkedField = f.linkedFields[index];
-                          if (linkedField.type === 'checkbox' && values[linkedField.key] === false) {
-                            return false;
-                          }
-                          if (linkedField.type === 'select' && !f.linkedValues.includes(values[linkedField.key])) {
-                            return false;
-                          }
-                        }
-                        return true;
-                      }),
-                      values,
-                      attachedDocs,
+            <Typography variant="h5" style={{ fontWeight: 500, float: 'left' }}>
+              {t('Targeted teams')}
+            </Typography>
+            <FormGroup row={true} classes={{ root: classes.allTeams }}>
+              <FormControlLabel
+                control={(
+                  <Switch
+                    checked={allTeams}
+                    onChange={this.toggleAll.bind(this)}
+                    color="primary"
+                    size="small"
+                    disabled={this.props.permissions.readOnly || fieldTeams.readOnly}
+                  />
+                )}
+                label={<strong>{t('All teams')}</strong>}
+              />
+            </FormGroup>
+            <div className="clearfix" />
+            <List>
+              {allTeams ? (
+                <ListItem classes={{ root: classes.item }} divider={true}>
+                  <ListItemIcon>
+                    <GroupsOutlined />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={(
+                      <>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.team_name}
+                        >
+                          <i>{t('All teams')}</i>
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.team_users_number}
+                        >
+                          <strong>
+                            {this.props.allUsersNumber}
+                          </strong>
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.team_users_enabled_number}
+                        >
+                          <strong>
+                            {this.props.usersNumber}
+                          </strong>
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.team_tags}
+                        >
+                          <ItemTags variant="reduced-view" tags={[]} />
+                        </div>
+                      </>
                     )}
-                  </div>
+                  />
+                  <ListItemSecondaryAction> &nbsp; </ListItemSecondaryAction>
+                </ListItem>
+              ) : (
+                <>
+                  <InjectTeamsList
+                    teamIds={teamsIds}
+                    handleRemoveTeam={this.handleRemoveTeam.bind(this)}
+                  />
+                  <InjectAddTeams
+                    injectTeamsIds={teamsIds}
+                    handleAddTeams={this.handleAddTeams.bind(this)}
+                  />
                 </>
               )}
-              {hasExpectations && (
-                <InjectExpectations
-                  predefinedExpectationDatas={predefinedExpectations}
-                  expectationDatas={(expectations && expectations.length > 0) ? expectations : predefinedExpectations}
-                  handleExpectations={this.handleExpectations.bind(this)}
-                />
-              )}
-            </>
-          )}
-          {!isAtomic && (
-            <>
-              <Typography variant="h5" style={{ fontWeight: 500, marginTop: 20 }}>
-                {t('Inject documents')}
-              </Typography>
-              <List>
-                {sortedDocuments.map(document => (
-                  <ListItemButton
-                    key={document.document_id}
-                    classes={{ root: classes.item }}
-                    divider={true}
-                    component="a"
-                    href={`/api/documents/${document.document_id}/file`}
-                  >
-                    <ListItemIcon>
-                      <AttachmentOutlined />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={(
-                        <>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.document_name}
-                          >
-                            {document.document_name}
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.document_type}
-                          >
-                            <DocumentType
-                              type={document.document_type}
-                              variant="list"
-                            />
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.document_tags}
-                          >
-                            <ItemTags
-                              variant="reduced-view"
-                              tags={document.document_tags}
-                            />
-                          </div>
-                          <div
-                            className={classes.bodyItem}
-                            style={inlineStyles.document_attached}
-                          >
-                            <ItemBoolean
-                              status={hasAttachments ? document.document_attached : null}
-                              label={document.document_attached ? t('Yes') : t('No')}
-                              variant="inList"
-                              onClick={(event) => {
-                                event.preventDefault();
-                                this.toggleAttachment(document.document_id);
-                              }}
-                              disabled={this.props.permissions.readOnly || (hasAttachments && fieldAttachements.readOnly) || !hasAttachments}
-                            />
-                          </div>
-                        </>
-                      )}
+            </List>
+          </>
+        )}
+        {hasAssets && (
+          <>
+            <Typography variant="h5" style={{ fontWeight: 500, marginTop: hasTeams ? 20 : 0 }}>
+              {t('Targeted assets')}
+            </Typography>
+            <EndpointsList
+              endpoints={assets}
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore: Endpoint property handle by EndpointsList
+              actions={
+                <EndpointPopover inline onRemoveEndpointFromInject={this.handleRemoveAsset.bind(this)} onDelete={this.handleRemoveAsset.bind(this)} />
+              }
+            />
+            <InjectAddEndpoints
+              endpointIds={assetIds}
+              onSubmit={this.handleAddAssets.bind(this)}
+              disabled={fieldAssets.readOnly}
+              platforms={injectorContract.platforms}
+              payloadArch={inject.inject_injector_contract?.injector_contract_arch}
+            />
+          </>
+        )}
+        {hasAssetGroups && (
+          <>
+            <Typography variant="h5" style={{ fontWeight: 500, marginTop: hasTeams || hasAssets ? 20 : 0 }}>
+              {t('Targeted asset groups')}
+            </Typography>
+            <AssetGroupsList
+              assetGroupIds={assetGroupIds}
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore: Endpoint property handle by EndpointsList
+              actions={
+                <AssetGroupPopover inline onRemoveAssetGroupFromInject={this.handleRemoveAssetGroup.bind(this)} />
+              }
+            />
+            <InjectAddAssetGroups assetGroupIds={assetGroupIds} onSubmit={this.handleAddAssetGroups.bind(this)} />
+          </>
+        )}
+        {hasArticles && (
+          <>
+            <Typography variant="h5" style={{ fontWeight: 500, marginTop: hasTeams || hasAssets || hasAssetGroups ? 20 : 0 }}>
+              {t('Media pressure to publish')}
+            </Typography>
+            <List>
+              {sortedArticles.map(article => (
+                <ListItem
+                  key={article.article_id}
+                  classes={{ root: classes.item }}
+                  divider={true}
+                >
+                  <ListItemIcon>
+                    <ChannelIcon
+                      type={article.article_channel_type}
+                      variant="inline"
                     />
-                    <ListItemSecondaryAction>
-                      <DocumentPopover
-                        inline
-                        document={document}
-                        onRemoveDocument={this.handleRemoveDocument.bind(this)}
-                        onToggleAttach={hasAttachments ? this.toggleAttachment.bind(this) : null}
-                        attached={document.document_attached}
-                        disabled={this.props.permissions.readOnly || (hasAttachments && fieldAttachements.readOnly)}
-                      />
-                    </ListItemSecondaryAction>
-                  </ListItemButton>
-                ))}
-                <MultipleFileLoader
-                  initialDocumentIds={documents.filter(a => !a.inject_document_attached).map(d => d.document_id)}
-                  handleAddDocuments={this.handleAddDocuments.bind(this)}
-                  hasAttachments={hasAttachments}
-                />
-              </List>
-            </>
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={(
+                      <>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.article_channel_type}
+                        >
+                          {t(article.article_channel_type || 'Unknown')}
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.article_channel_name}
+                        >
+                          {article.article_channel_name}
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.article_name}
+                        >
+                          {article.article_name}
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.article_author}
+                        >
+                          {article.article_author}
+                        </div>
+                      </>
+                    )}
+                  />
+                  <ListItemSecondaryAction>
+                    <ArticlePopover
+                      article={article}
+                      onRemoveArticle={this.handleRemoveArticle.bind(this)}
+                      disabled={this.props.permissions.readOnly || fieldArticles.readOnly}
+                    />
+                  </ListItemSecondaryAction>
+                </ListItem>
+              ))}
+              <InjectAddArticles
+                articles={articlesFromExerciseOrScenario}
+                injectArticlesIds={articlesIds}
+                handleAddArticles={this.handleAddArticles.bind(this)}
+              />
+            </List>
+          </>
+        )}
+        {hasChallenges && (
+          <>
+            <Typography variant="h5" style={{ fontWeight: 500, marginTop: hasTeams || hasAssets || hasAssetGroups || hasArticles ? 20 : 0 }}>
+              {t('Challenges to publish')}
+            </Typography>
+            <List>
+              {sortedChallenges.map(challenge => (
+                <ListItem
+                  key={challenge.challenge_id}
+                  classes={{ root: classes.item }}
+                  divider={true}
+                >
+                  <ListItemIcon>
+                    <EmojiEventsOutlined />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={(
+                      <>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.challenge_category}
+                        >
+                          {t(challenge.challenge_category || 'Unknown')}
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.challenge_name}
+                        >
+                          {challenge.challenge_name}
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.challenge_tags}
+                        >
+                          <ItemTags
+                            variant="reduced-view"
+                            tags={challenge.challenge_tags}
+                          />
+                        </div>
+                      </>
+                    )}
+                  />
+                  <ListItemSecondaryAction>
+                    <ChallengePopover
+                      inline
+                      challenge={challenge}
+                      onRemoveChallenge={this.handleRemoveChallenge.bind(
+                        this,
+                      )}
+                      disabled={this.props.permissions.readOnly || fieldChallenges.readOnly}
+                    />
+                  </ListItemSecondaryAction>
+                </ListItem>
+              ))}
+              <InjectAddChallenges
+                injectChallengesIds={challengesIds}
+                handleAddChallenges={this.handleAddChallenges.bind(
+                  this,
+                )}
+              />
+            </List>
+          </>
+        )}
+        <div style={{ marginTop: hasTeams || hasAssets || hasAssetGroups || hasArticles || hasChallenges ? 24 : 0 }}>
+          <div style={{ float: 'left' }}>
+            <Typography variant="h5" style={{ fontWeight: 500 }}>{t('Inject data')}</Typography>
+          </div>
+          <div style={{ float: 'left' }}>
+            <Tooltip title={t('Reset to default values')}>
+              <IconButton
+                color="primary"
+                variant="outlined"
+                disabled={submitting || this.props.permissions.readOnly}
+                onClick={() => this.resetDefaultvalues(setValue, builtInFields, injectorContract)}
+                size="small"
+                style={{ margin: '-12px 0 0 5px' }}
+              >
+                <RotateLeftOutlined />
+              </IconButton>
+            </Tooltip>
+          </div>
+          <div style={{ float: 'right' }}>
+            <Button
+              color="primary"
+              variant="outlined"
+              size="small"
+              onClick={this.handleOpenVariables.bind(this)}
+              startIcon={<HelpOutlineOutlined />}
+              style={{ marginTop: -10 }}
+            >
+              {t('Available variables')}
+            </Button>
+          </div>
+          <div className="clearfix" />
+        </div>
+        <>
+          {this.renderFields(
+            injectorContract.fields
+              .filter(
+                f => !builtInFields.includes(f.key) && !f.expectation,
+              )
+              .filter((f) => {
+                // Filter display if linked fields
+                for (
+                  let index = 0;
+                  index < f.linkedFields.length;
+                  index += 1
+                ) {
+                  const linkedField = f.linkedFields[index];
+                  if (
+                    linkedField.type === 'checkbox'
+                    && values[linkedField.key] === false
+                  ) {
+                    return false;
+                  }
+                  if (
+                    linkedField.type === 'select'
+                    && !f.linkedValues.includes(values[linkedField.key])
+                  ) {
+                    return false;
+                  }
+                }
+                return true;
+              }),
+            values,
+            attachedDocs,
           )}
         </>
+        {(hasExpectations || expectationsNotManual.length > 0) && (
+          <>
+            <Typography variant="h5" style={{ marginTop: 20, fontWeight: 500 }}>
+              {t('Inject expectations')}
+            </Typography>
+            {expectationsNotManual.length > 0 && (
+              <>
+                <div style={{ marginTop: -15 }}>
+                  {this.renderFields(
+                    expectationsNotManual.filter((f) => {
+                      // Filter display if linked fields
+                      for (let index = 0; index < f.linkedFields.length; index += 1) {
+                        const linkedField = f.linkedFields[index];
+                        if (linkedField.type === 'checkbox' && values[linkedField.key] === false) {
+                          return false;
+                        }
+                        if (linkedField.type === 'select' && !f.linkedValues.includes(values[linkedField.key])) {
+                          return false;
+                        }
+                      }
+                      return true;
+                    }),
+                    values,
+                    attachedDocs,
+                  )}
+                </div>
+              </>
+            )}
+            {hasExpectations && (
+              <InjectExpectations
+                predefinedExpectationDatas={predefinedExpectations}
+                expectationDatas={(expectations && expectations.length > 0) ? expectations : predefinedExpectations}
+                handleExpectations={this.handleExpectations.bind(this)}
+              />
+            )}
+          </>
+        )}
+        {!isAtomic && (
+          <>
+            <Typography variant="h5" style={{ fontWeight: 500, marginTop: 20 }}>
+              {t('Inject documents')}
+            </Typography>
+            <List>
+              {sortedDocuments.map(document => (
+                <ListItemButton
+                  key={document.document_id}
+                  classes={{ root: classes.item }}
+                  divider={true}
+                  component="a"
+                  href={`/api/documents/${document.document_id}/file`}
+                >
+                  <ListItemIcon>
+                    <AttachmentOutlined />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={(
+                      <>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.document_name}
+                        >
+                          {document.document_name}
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.document_type}
+                        >
+                          <DocumentType
+                            type={document.document_type}
+                            variant="list"
+                          />
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.document_tags}
+                        >
+                          <ItemTags
+                            variant="reduced-view"
+                            tags={document.document_tags}
+                          />
+                        </div>
+                        <div
+                          className={classes.bodyItem}
+                          style={inlineStyles.document_attached}
+                        >
+                          <ItemBoolean
+                            status={hasAttachments ? document.document_attached : null}
+                            label={document.document_attached ? t('Yes') : t('No')}
+                            variant="inList"
+                            onClick={(event) => {
+                              event.preventDefault();
+                              this.toggleAttachment(document.document_id);
+                            }}
+                            disabled={this.props.permissions.readOnly || (hasAttachments && fieldAttachements.readOnly) || !hasAttachments}
+                          />
+                        </div>
+                      </>
+                    )}
+                  />
+                  <ListItemSecondaryAction>
+                    <DocumentPopover
+                      inline
+                      document={document}
+                      onRemoveDocument={this.handleRemoveDocument.bind(this)}
+                      onToggleAttach={hasAttachments ? this.toggleAttachment.bind(this) : null}
+                      attached={document.document_attached}
+                      disabled={this.props.permissions.readOnly || (hasAttachments && fieldAttachements.readOnly)}
+                    />
+                  </ListItemSecondaryAction>
+                </ListItemButton>
+              ))}
+              <MultipleFileLoader
+                initialDocumentIds={documents.filter(a => !a.inject_document_attached).map(d => d.document_id)}
+                handleAddDocuments={this.handleAddDocuments.bind(this)}
+                hasAttachments={hasAttachments}
+              />
+            </List>
+          </>
+        )}
         <AvailableVariablesDialog
           uriVariable={this.props.uriVariable}
           variables={this.props.variablesFromExerciseOrScenario}

--- a/openbas-front/src/admin/components/common/injects/InjectForm.js
+++ b/openbas-front/src/admin/components/common/injects/InjectForm.js
@@ -2,10 +2,11 @@ import { withStyles } from '@mui/styles';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { Component } from 'react';
+import { Controller } from 'react-hook-form';
 
-import OldTextField from '../../../../components/fields/OldTextField';
+import TagField from '../../../../components/fields/TagField';
+import TextField from '../../../../components/fields/TextField';
 import inject18n from '../../../../components/i18n';
-import TagField from '../../../../components/TagField';
 
 const styles = theme => ({
   duration: {
@@ -56,66 +57,77 @@ class InjectForm extends Component {
   render() {
     const {
       t,
-      values,
-      form,
+      control,
+      register,
       classes,
       disabled,
       isAtomic = false,
     } = this.props;
     return (
       <>
-        <OldTextField
+        <TextField
           variant="standard"
-          name="inject_title"
+          inputProps={register('inject_title')}
           fullWidth={true}
           label={t('Title')}
           disabled={disabled}
+          control={control}
         />
-        <OldTextField
+        <TextField
           variant="standard"
-          name="inject_description"
+          inputProps={register('inject_description')}
           fullWidth={true}
           multiline={true}
           rows={2}
           label={t('Description')}
           style={{ marginTop: 20 }}
           disabled={disabled}
+          control={control}
         />
-        <TagField
+        <Controller
+          control={control}
           name="inject_tags"
-          label={t('Tags')}
-          values={values}
-          setFieldValue={form.mutators.setValue}
-          style={{ marginTop: 20 }}
-          disabled={disabled}
+          render={({ field: { onChange, value } }) => (
+            <TagField
+              name="inject_tags"
+              label={t('Tags')}
+              fieldValue={value ?? []}
+              fieldOnChange={onChange}
+              style={{ marginTop: 20 }}
+              errors={{}}
+            />
+          )}
         />
         {!isAtomic
         && (
           <div className={disabled ? classes.durationDisabled : classes.duration}>
             <div className={disabled ? classes.triggerDisabled : classes.trigger}>{t('Trigger after')}</div>
-            <OldTextField
+            <TextField
               variant="standard"
-              name="inject_depends_duration_days"
+              inputProps={register('inject_depends_duration_days')}
               type="number"
               label={t('Days')}
               style={{ width: '20%' }}
               disabled={disabled}
+              control={control}
             />
-            <OldTextField
+            <TextField
               variant="standard"
-              name="inject_depends_duration_hours"
+              inputProps={register('inject_depends_duration_hours')}
               type="number"
               label={t('Hours')}
               style={{ width: '20%' }}
               disabled={disabled}
+              control={control}
             />
-            <OldTextField
+            <TextField
               variant="standard"
-              name="inject_depends_duration_minutes"
+              inputProps={register('inject_depends_duration_minutes')}
               type="number"
               label={t('Minutes')}
               style={{ width: '20%' }}
               disabled={disabled}
+              control={control}
             />
           </div>
         )}
@@ -125,13 +137,13 @@ class InjectForm extends Component {
 }
 
 InjectForm.propTypes = {
+  control: PropTypes.object,
+  register: PropTypes.func,
+  setValue: PropTypes.func,
+  disabled: PropTypes.bool,
+  isAtomic: PropTypes.bool,
   classes: PropTypes.object,
   t: PropTypes.func,
-  tPick: PropTypes.func,
-  handleClose: PropTypes.func,
-  editing: PropTypes.bool,
-  injectorContractsMap: PropTypes.object,
-  isAtomic: PropTypes.bool,
 };
 
 export default R.compose(inject18n, withStyles(styles))(InjectForm);

--- a/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
+++ b/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
@@ -68,10 +68,10 @@ const UpdateInject: React.FC<Props> = ({ open, handleClose, onUpdateInject, mass
     setActiveTab(newValue);
   };
 
-  const [injectorContract, setInjectorContract] = useState(null);
+  const [injectorContractContent, setInjectorContractContent] = useState(null);
   useEffect(() => {
     if (inject?.inject_injector_contract?.injector_contract_content) {
-      setInjectorContract(getInjectorContractWithEmptyPredefinedExpectations(inject.inject_injector_contract?.injector_contract_content));
+      setInjectorContractContent(getInjectorContractWithEmptyPredefinedExpectations(inject.inject_injector_contract?.injector_contract_content));
     }
   }, [inject]);
   return (
@@ -97,7 +97,7 @@ const UpdateInject: React.FC<Props> = ({ open, handleClose, onUpdateInject, mass
         {!isInjectLoading && (isAtomic || activeTab === 'Inject details') && (
           <UpdateInjectDetails
             drawerRef={drawerRef}
-            contractContent={injectorContract}
+            contractContent={injectorContractContent}
             injectId={injectId}
             inject={inject}
             handleClose={handleClose}

--- a/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
+++ b/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
@@ -13,6 +13,8 @@ import { useAppDispatch } from '../../../../utils/hooks';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import UpdateInjectDetails from './UpdateInjectDetails';
 import UpdateInjectLogicalChains from './UpdateInjectLogicalChains';
+import {ExercisesHelper} from "../../../../actions/exercises/exercise-helper";
+import {fetchExercise} from "../../../../actions/Exercise";
 
 interface Props {
   open: boolean;
@@ -57,10 +59,16 @@ const UpdateInject: React.FC<Props> = ({ open, handleClose, onUpdateInject, mass
   const { inject } = useHelper((helper: InjectHelper) => ({
     inject: helper.getInject(injectId),
   }));
+  const { simulation } = useHelper((helper: ExercisesHelper) => ({
+    simulation: helper.getExercise(inject.inject_exercise)
+  }));
+  const availableTeamIds = simulation?.exercise_teams || []
 
   useDataLoader(() => {
     setIsInjectLoading(true);
-    dispatch(fetchInject(injectId)).finally(() => setIsInjectLoading(false));
+    dispatch(fetchInject(injectId));
+    dispatch(fetchExercise(inject.inject_exercise));
+    setIsInjectLoading(false);
   });
 
   // Selection
@@ -100,6 +108,7 @@ const UpdateInject: React.FC<Props> = ({ open, handleClose, onUpdateInject, mass
             contractContent={injectorContractContent}
             injectId={injectId}
             inject={inject}
+            availableTeamIds={availableTeamIds}
             handleClose={handleClose}
             onUpdateInject={onUpdateInject}
             isAtomic={isAtomic}

--- a/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
+++ b/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
@@ -2,6 +2,8 @@ import { Tab, Tabs } from '@mui/material';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 
+import { fetchExercise } from '../../../../actions/Exercise';
+import { ExercisesHelper } from '../../../../actions/exercises/exercise-helper';
 import { fetchInject } from '../../../../actions/Inject';
 import type { InjectOutputType } from '../../../../actions/injects/Inject';
 import type { InjectHelper } from '../../../../actions/injects/inject-helper';
@@ -13,8 +15,6 @@ import { useAppDispatch } from '../../../../utils/hooks';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import UpdateInjectDetails from './UpdateInjectDetails';
 import UpdateInjectLogicalChains from './UpdateInjectLogicalChains';
-import {ExercisesHelper} from "../../../../actions/exercises/exercise-helper";
-import {fetchExercise} from "../../../../actions/Exercise";
 
 interface Props {
   open: boolean;
@@ -60,9 +60,9 @@ const UpdateInject: React.FC<Props> = ({ open, handleClose, onUpdateInject, mass
     inject: helper.getInject(injectId),
   }));
   const { simulation } = useHelper((helper: ExercisesHelper) => ({
-    simulation: helper.getExercise(inject.inject_exercise)
+    simulation: helper.getExercise(inject.inject_exercise),
   }));
-  const availableTeamIds = simulation?.exercise_teams || []
+  const availableTeamIds = simulation?.exercise_teams || [];
 
   useDataLoader(() => {
     setIsInjectLoading(true);

--- a/openbas-front/src/admin/components/common/injects/UpdateInjectDetails.js
+++ b/openbas-front/src/admin/components/common/injects/UpdateInjectDetails.js
@@ -1,10 +1,11 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { ArrowDropDownOutlined, ArrowDropUpOutlined, HelpOutlined } from '@mui/icons-material';
 import { Avatar, Button, Card, CardContent, CardHeader } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import arrayMutators from 'final-form-arrays';
 import * as R from 'ramda';
 import { useContext, useState } from 'react';
-import { Form } from 'react-final-form';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 import { useFormatter } from '../../../../components/i18n';
 import PlatformIcon from '../../../../components/PlatformIcon';
@@ -74,22 +75,7 @@ const UpdateInjectDetails = ({
       setOpenDetails(true);
     }
   };
-  const validate = (values) => {
-    const errors = {};
 
-    const requiredFields = [
-      'inject_title',
-      'inject_depends_duration_days',
-      'inject_depends_duration_hours',
-      'inject_depends_duration_minutes',
-    ];
-    requiredFields.forEach((field) => {
-      if (R.isNil(values[field])) {
-        errors[field] = t('This field is required.');
-      }
-    });
-    return errors;
-  };
   const onSubmit = async (data) => {
     if (contractContent) {
       const finalData = {};
@@ -273,12 +259,37 @@ const UpdateInjectDetails = ({
         }
       }
     });
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    getValues,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm({
+    mode: 'onTouched',
+    resolver: zodResolver(
+      z.object({
+        inject_title: z.string().min(1, { message: t('This field is required.') }),
+        inject_depends_duration_days: z.number().int().min(0, { message: t('This field is required.') }),
+        inject_depends_duration_hours: z.number().int().min(0, { message: t('This field is required.') }),
+        inject_depends_duration_minutes: z.number().int().min(0, { message: t('This field is required.') }),
+        ...Object.keys(initialValues).reduce((acc, key) => {
+          acc[key] = z.any();
+          return acc;
+        }, {}),
+      })),
+    defaultValues: initialValues,
+  });
+
   return (
     <>
       <Card elevation={0} classes={{ root: classes.injectorContract }}>
         <CardHeader
           classes={{ root: classes.injectorContractHeader }}
-          avatar={contractContent ? <Avatar sx={{ width: 24, height: 24 }} src={`/api/images/injectors/${contractContent.config.type}`} />
+          avatar={contractContent
+            ? <Avatar sx={{ width: 24, height: 24 }} src={`/api/images/injectors/${contractContent.config.type}`} />
             : <Avatar sx={{ width: 24, height: 24 }}><HelpOutlined /></Avatar>}
           title={contractContent?.contract_attack_patterns_external_ids.join(', ')}
           action={(
@@ -293,74 +304,60 @@ const UpdateInjectDetails = ({
           {contractContent !== null ? tPick(contractContent.label) : ''}
         </CardContent>
       </Card>
-      <Form
-        keepDirtyOnReinitialize={true}
-        initialValues={initialValues}
-        onSubmit={onSubmit}
-        validate={validate}
-        mutators={{
-          ...arrayMutators,
-          setValue: ([field, value], state, { changeValue }) => {
-            changeValue(state, field, () => value);
-          },
-        }}
-      >
-        {({ form, handleSubmit, submitting, values, errors }) => {
-          return (
-            <form id="injectContentForm" onSubmit={handleSubmit} style={{ marginTop: 10 }}>
-              <InjectForm form={form} values={values} disabled={!contractContent} isAtomic={isAtomic} />
-              {contractContent && (
-                <div className={classes.details}>
-                  {openDetails && (
-                    <InjectDefinition
-                      form={form}
-                      values={values}
-                      submitting={submitting}
-                      inject={initialValues}
-                      injectorContract={contractContent}
-                      handleClose={handleClose}
-                      tagsMap={tagsMap}
-                      permissions={permissions}
-                      articlesFromExerciseOrScenario={[]}
-                      variablesFromExerciseOrScenario={[]}
-                      onUpdateInject={onUpdateInject}
-                      setInjectDetailsState={setInjectDetailsState}
-                      uriVariable=""
-                      allUsersNumber={0}
-                      usersNumber={0}
-                      teamsUsers={[]}
-                      isAtomic={isAtomic}
-                      {...props}
-                    />
-                  )}
-                  <div className={classes.openDetails} onClick={toggleInjectContent}>
-                    {openDetails ? <ArrowDropUpOutlined fontSize="large" /> : <ArrowDropDownOutlined fontSize="large" />}
-                    {t('Inject content')}
-                  </div>
-                </div>
-              )}
-              <div style={{ float: 'right', marginTop: 20 }}>
-                <Button
-                  variant="contained"
-                  onClick={handleClose}
-                  style={{ marginRight: 10 }}
-                  disabled={submitting}
-                >
-                  {t('Cancel')}
-                </Button>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  type="submit"
-                  disabled={submitting || Object.keys(errors).length > 0 || !contractContent}
-                >
-                  {t('Update')}
-                </Button>
-              </div>
-            </form>
-          );
-        }}
-      </Form>
+
+      <form id="injectContentForm" onSubmit={handleSubmit(onSubmit)} style={{ marginTop: 10 }}>
+        <InjectForm control={control} disabled={!contractContent} isAtomic={isAtomic} register={register} />
+        {contractContent && (
+          <div className={classes.details}>
+            {openDetails && (
+              <InjectDefinition
+                control={control}
+                register={register}
+                values={getValues()}
+                setValue={setValue}
+                submitting={isSubmitting}
+                inject={initialValues}
+                injectorContract={contractContent}
+                handleClose={handleClose}
+                tagsMap={tagsMap}
+                permissions={permissions}
+                articlesFromExerciseOrScenario={[]}
+                variablesFromExerciseOrScenario={[]}
+                onUpdateInject={onUpdateInject}
+                setInjectDetailsState={setInjectDetailsState}
+                uriVariable=""
+                allUsersNumber={0}
+                usersNumber={0}
+                teamsUsers={[]}
+                isAtomic={isAtomic}
+                {...props}
+              />
+            )}
+            <div className={classes.openDetails} onClick={toggleInjectContent}>
+              {openDetails ? <ArrowDropUpOutlined fontSize="large" /> : <ArrowDropDownOutlined fontSize="large" />}
+              {t('Inject content')}
+            </div>
+          </div>
+        )}
+        <div style={{ float: 'right', marginTop: 20 }}>
+          <Button
+            variant="contained"
+            onClick={handleClose}
+            style={{ marginRight: 10 }}
+            disabled={isSubmitting}
+          >
+            {t('Cancel')}
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            type="submit"
+            disabled={isSubmitting || Object.keys(errors).length > 0 || !contractContent}
+          >
+            {t('Update')}
+          </Button>
+        </div>
+      </form>
     </>
   );
 };

--- a/openbas-front/src/admin/components/common/injects/UpdateInjectDetails.js
+++ b/openbas-front/src/admin/components/common/injects/UpdateInjectDetails.js
@@ -52,6 +52,7 @@ const useStyles = makeStyles(theme => ({
 const UpdateInjectDetails = ({
   contractContent,
   inject,
+  availableTeamIds,
   handleClose,
   onUpdateInject,
   isAtomic = false,
@@ -317,6 +318,7 @@ const UpdateInjectDetails = ({
                 setValue={setValue}
                 submitting={isSubmitting}
                 inject={initialValues}
+                availableTeamIds={availableTeamIds}
                 injectorContract={contractContent}
                 handleClose={handleClose}
                 tagsMap={tagsMap}

--- a/openbas-front/src/admin/components/lessons/SendLessonsForm.js
+++ b/openbas-front/src/admin/components/lessons/SendLessonsForm.js
@@ -3,8 +3,8 @@ import * as PropTypes from 'prop-types';
 import { Component } from 'react';
 import { Form } from 'react-final-form';
 
+import OldRichTextField from '../../../components/fields/OldRichTextField';
 import OldTextField from '../../../components/fields/OldTextField';
-import RichTextField from '../../../components/fields/RichTextField';
 import inject18n from '../../../components/i18n';
 
 class SendLessonsForm extends Component {
@@ -43,7 +43,7 @@ class SendLessonsForm extends Component {
               label={t('Subject')}
               style={{ marginTop: 20 }}
             />
-            <RichTextField
+            <OldRichTextField
               name="body"
               label={t('Message')}
               fullWidth

--- a/openbas-front/src/admin/components/settings/groups/GroupForm.js
+++ b/openbas-front/src/admin/components/settings/groups/GroupForm.js
@@ -4,8 +4,8 @@ import * as PropTypes from 'prop-types';
 import { Component } from 'react';
 import { Form } from 'react-final-form';
 
+import OldSwitchField from '../../../../components/fields/OldSwitchField';
 import OldTextField from '../../../../components/fields/OldTextField';
-import SwitchField from '../../../../components/fields/SwitchField';
 import inject18n from '../../../../components/i18n';
 
 class GroupForm extends Component {
@@ -50,7 +50,7 @@ class GroupForm extends Component {
             />
             <Grid container spacing={3} style={{ marginTop: 0 }}>
               <Grid item xs={12} style={{ display: 'flex' }}>
-                <SwitchField
+                <OldSwitchField
                   name="group_default_user_assign"
                   label={t('Auto assign')}
                 />
@@ -74,7 +74,7 @@ class GroupForm extends Component {
                     </Typography>
                   </Grid>
                   <Grid item xs={6} style={{ display: 'flex' }}>
-                    <SwitchField
+                    <OldSwitchField
                       name="group_default_scenario_observer"
                       label={t('Auto observer')}
                     />
@@ -91,7 +91,7 @@ class GroupForm extends Component {
                     </Tooltip>
                   </Grid>
                   <Grid item xs={6} style={{ display: 'flex' }}>
-                    <SwitchField
+                    <OldSwitchField
                       name="group_default_scenario_planner"
                       label={t('Auto planner')}
                     />
@@ -117,7 +117,7 @@ class GroupForm extends Component {
                     </Typography>
                   </Grid>
                   <Grid item xs={6} style={{ display: 'flex' }}>
-                    <SwitchField
+                    <OldSwitchField
                       name="group_default_exercise_observer"
                       label={t('Auto observer')}
                     />
@@ -134,7 +134,7 @@ class GroupForm extends Component {
                     </Tooltip>
                   </Grid>
                   <Grid item xs={6} style={{ display: 'flex' }}>
-                    <SwitchField
+                    <OldSwitchField
                       name="group_default_exercise_planner"
                       label={t('Auto planner')}
                     />

--- a/openbas-front/src/admin/components/settings/users/UserForm.js
+++ b/openbas-front/src/admin/components/settings/users/UserForm.js
@@ -2,8 +2,8 @@ import { Button } from '@mui/material';
 import * as PropTypes from 'prop-types';
 import { Form } from 'react-final-form';
 
+import OldSwitchField from '../../../../components/fields/OldSwitchField';
 import OldTextField from '../../../../components/fields/OldTextField';
-import SwitchField from '../../../../components/fields/SwitchField';
 import { useFormatter } from '../../../../components/i18n';
 import OrganizationField from '../../../../components/OrganizationField';
 import TagField from '../../../../components/TagField';
@@ -107,7 +107,7 @@ const UserForm = (props) => {
             setFieldValue={form.mutators.setValue}
             style={{ marginTop: 20 }}
           />
-          <SwitchField
+          <OldSwitchField
             name="user_admin"
             label={t('Administrator')}
             style={{ marginTop: 20 }}

--- a/openbas-front/src/admin/components/simulations/simulation/controls/ComcheckForm.js
+++ b/openbas-front/src/admin/components/simulations/simulation/controls/ComcheckForm.js
@@ -5,9 +5,9 @@ import { Component } from 'react';
 import { Form } from 'react-final-form';
 
 import DateTimePicker from '../../../../../components/DateTimePicker';
+import OldRichTextField from '../../../../../components/fields/OldRichTextField';
 import OldSelectField from '../../../../../components/fields/OldSelectField';
 import OldTextField from '../../../../../components/fields/OldTextField';
-import RichTextField from '../../../../../components/fields/RichTextField';
 import inject18n from '../../../../../components/i18n';
 
 class ComcheckForm extends Component {
@@ -98,7 +98,7 @@ class ComcheckForm extends Component {
               label={t('Subject')}
               style={{ marginTop: 20 }}
             />
-            <RichTextField
+            <OldRichTextField
               name="comcheck_message"
               label={t('Message')}
               fullWidth={true}

--- a/openbas-front/src/admin/components/simulations/simulation/injects/QuickInject.js
+++ b/openbas-front/src/admin/components/simulations/simulation/injects/QuickInject.js
@@ -235,6 +235,7 @@ class QuickInject extends Component {
     this.state = {
       allTeams: false,
       teamsIds: [],
+      availableTeamIds: this.props.exercise?.exercise_teams || [],
       documents: [],
       expectations: [],
       teamsSortBy: 'team_name',
@@ -263,9 +264,9 @@ class QuickInject extends Component {
     this.setState({ openVariables: false });
   }
 
-  handleAddTeams(teamsIds) {
+  handleModifyTeams(teamsIds) {
     this.setState({
-      teamsIds: [...this.state.teamsIds, ...teamsIds],
+      teamsIds: [...teamsIds],
     });
   }
 
@@ -809,6 +810,7 @@ class QuickInject extends Component {
     const {
       allTeams,
       teamsIds,
+      availableTeamIds,
       documents,
       expectations,
       teamsSortBy,
@@ -1146,7 +1148,8 @@ class QuickInject extends Component {
                           ))}
                           <InjectAddTeams
                             injectTeamsIds={teamsIds}
-                            handleAddTeams={this.handleAddTeams.bind(
+                            availableTeamIds={availableTeamIds}
+                            handleModifyTeams={this.handleModifyTeams.bind(
                               this,
                             )}
                           />

--- a/openbas-front/src/admin/components/simulations/simulation/injects/QuickInject.js
+++ b/openbas-front/src/admin/components/simulations/simulation/injects/QuickInject.js
@@ -39,10 +39,10 @@ import { addInjectForExercise } from '../../../../../actions/Inject';
 import { storeHelper } from '../../../../../actions/Schema';
 import { fetchVariablesForExercise } from '../../../../../actions/variables/variable-actions';
 import MultipleFileLoader from '../../../../../components/fields/MultipleFileLoader';
+import OldRichTextField from '../../../../../components/fields/OldRichTextField';
 import OldSelectField from '../../../../../components/fields/OldSelectField';
+import OldSwitchField from '../../../../../components/fields/OldSwitchField';
 import OldTextField from '../../../../../components/fields/OldTextField';
-import RichTextField from '../../../../../components/fields/RichTextField';
-import SwitchField from '../../../../../components/fields/SwitchField';
 import inject18n from '../../../../../components/i18n';
 import ItemBoolean from '../../../../../components/ItemBoolean';
 import ItemTags from '../../../../../components/ItemTags';
@@ -479,7 +479,7 @@ class QuickInject extends Component {
             case 'textarea':
               return field.richText
                 ? (
-                    <RichTextField
+                    <OldRichTextField
                       key={field.key}
                       name={field.key}
                       label={t(field.label)}
@@ -516,7 +516,7 @@ class QuickInject extends Component {
               );
             case 'checkbox':
               return (
-                <SwitchField
+                <OldSwitchField
                   key={field.key}
                   name={field.key}
                   label={t(field.label)}

--- a/openbas-front/src/admin/components/simulations/simulation/mails/CommunicationForm.js
+++ b/openbas-front/src/admin/components/simulations/simulation/mails/CommunicationForm.js
@@ -1,8 +1,8 @@
 import { Button } from '@mui/material';
 import { Form } from 'react-final-form';
 
+import OldRichTextField from '../../../../../components/fields/OldRichTextField';
 import OldTextField from '../../../../../components/fields/OldTextField';
-import RichTextField from '../../../../../components/fields/RichTextField';
 import FileField from '../../../../../components/FileField';
 import { useFormatter } from '../../../../../components/i18n';
 
@@ -41,7 +41,7 @@ const CommunicationForm = ({ onSubmit, handleClose, initialValues }) => {
             label={t('Subject')}
             disabled={true}
           />
-          <RichTextField
+          <OldRichTextField
             name="communication_content"
             label={t('Content')}
             fullWidth={true}

--- a/openbas-front/src/components/fields/FieldArray.tsx
+++ b/openbas-front/src/components/fields/FieldArray.tsx
@@ -1,0 +1,24 @@
+import { Control, FieldValues, useFieldArray, UseFieldArrayAppend, UseFieldArrayRemove } from 'react-hook-form';
+
+interface Props {
+  control: Control;
+  renderField: (field: Record<'id', string>, index: number, remove: UseFieldArrayRemove) => JSX.Element;
+  name: string;
+  renderLabel: (append: UseFieldArrayAppend<FieldValues>) => JSX.Element;
+}
+
+const FieldArray = ({ control, name, renderField, renderLabel }: Props) => {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name,
+  });
+
+  return (
+    <div>
+      {renderLabel(append)}
+      {fields.map((field, index) => (renderField(field, index, remove)))}
+    </div>
+  );
+};
+
+export default FieldArray;

--- a/openbas-front/src/components/fields/OldRichTextField.jsx
+++ b/openbas-front/src/components/fields/OldRichTextField.jsx
@@ -72,8 +72,8 @@ const RichTextFieldBase = ({
 /**
  * @deprecated The component use old form libnary react-final-form
  */
-const RichTextField = props => (
+const OldRichTextField = props => (
   <Field name={props.name} component={RichTextFieldBase} {...props} />
 );
 
-export default RichTextField;
+export default OldRichTextField;

--- a/openbas-front/src/components/fields/OldSelectField.jsx
+++ b/openbas-front/src/components/fields/OldSelectField.jsx
@@ -64,6 +64,9 @@ const renderSelectField = ({
   </FormControl>
 );
 
+/**
+ * @deprecated The component use old form library react-final-form
+ */
 const OldSelectField = props => (
   <Field name={props.name} component={renderSelectField} {...props} />
 );

--- a/openbas-front/src/components/fields/OldSwitchField.js
+++ b/openbas-front/src/components/fields/OldSwitchField.js
@@ -27,8 +27,11 @@ const renderSwitch = ({
   </FormControl>
 );
 
-const SwitchField = props => (
+/**
+ * @deprecated The component use old form library react-final-form
+ */
+const OldSwitchField = props => (
   <Field name={props.name} component={renderSwitch} {...props} />
 );
 
-export default SwitchField;
+export default OldSwitchField;

--- a/openbas-front/src/components/fields/RichTextField.tsx
+++ b/openbas-front/src/components/fields/RichTextField.tsx
@@ -1,0 +1,79 @@
+import { FormHelperText, InputLabel } from '@mui/material';
+import { CSSProperties } from 'react';
+import { Control, Controller } from 'react-hook-form';
+
+import TextFieldAskAI from '../../admin/components/common/form/TextFieldAskAI';
+import CKEditor from '../CKEditor';
+
+interface Props {
+  label: string;
+  control: Control;
+  name: string;
+  style?: CSSProperties;
+  disabled: boolean;
+  askAi: boolean;
+  inInject: boolean;
+  required?: boolean;
+}
+
+const RichTextField = ({
+  control,
+  label,
+  name,
+  style = {},
+  disabled,
+  askAi,
+  inInject,
+}: Props) => {
+  return (
+    <div style={{ ...style, position: 'relative' }}>
+      <InputLabel
+        variant="standard"
+        shrink={true}
+        disabled={disabled}
+      >
+        {label}
+      </InputLabel>
+
+      <Controller
+        name={name}
+        control={control}
+        rules={{ required: true }}
+        render={({
+          field: { onChange, onBlur, value },
+          fieldState: { invalid, error: fieldError },
+        }) => (
+          <>
+            <CKEditor
+              data={value || ''}
+              onChange={(_, editor) => {
+                onChange(editor.getData());
+              }}
+              onBlur={onBlur}
+              disabled={disabled}
+            />
+            {(invalid) && (
+              <FormHelperText error>
+                {(fieldError?.message)}
+              </FormHelperText>
+            )}
+            {askAi && (
+              <TextFieldAskAI
+                currentValue={value ?? ''}
+                setFieldValue={(val) => {
+                  onChange(val);
+                }}
+                format="html"
+                variant="ckeditor"
+                disabled={disabled}
+                inInject={inInject}
+              />
+            )}
+          </>
+        )}
+      />
+    </div>
+  );
+};
+
+export default RichTextField;

--- a/openbas-front/src/components/fields/SelectField.jsx
+++ b/openbas-front/src/components/fields/SelectField.jsx
@@ -37,7 +37,7 @@ const SelectField = (props) => {
         defaultValue={defaultValue}
         control={control}
         render={({ field }) => (
-          <MUISelect {...field} {...others}>
+          <MUISelect {...field} {...others} value={field.value ?? ''}>
             {children}
           </MUISelect>
         )}

--- a/openbas-front/src/components/fields/SliderField.js
+++ b/openbas-front/src/components/fields/SliderField.js
@@ -41,6 +41,9 @@ renderSliderField.propTypes = {
   disabled: PropTypes.bool,
 };
 
+/**
+ * @deprecated The component use old form library react-final-form
+ */
 const SliderField = props => (
   <Field component={renderSliderField} {...props} />
 );

--- a/openbas-front/src/components/fields/SwitchField.tsx
+++ b/openbas-front/src/components/fields/SwitchField.tsx
@@ -1,0 +1,29 @@
+import { FormControlLabel, Switch } from '@mui/material';
+import { CSSProperties } from 'react';
+import { Control, Controller } from 'react-hook-form';
+
+interface Props {
+  label: string;
+  control: Control;
+  name: string;
+  style?: CSSProperties;
+}
+
+const SwitchField = ({ control, label, name, style = {}, ...extraProps }: Props) => {
+  return (
+    <div style={style}>
+      <Controller
+        control={control}
+        name={name}
+        render={({ field }) => (
+          <FormControlLabel
+            control={<Switch {...field} checked={!!field?.value} {...extraProps} />}
+            label={label}
+          />
+        )}
+      />
+    </div>
+  );
+};
+
+export default SwitchField;

--- a/openbas-front/src/components/fields/TextField.js
+++ b/openbas-front/src/components/fields/TextField.js
@@ -8,6 +8,7 @@ const TextFieldBase = ({ askAi, control, setValue, ...props }) => {
   return (
     <MuiTextField
       {...props}
+      value={currentValue ?? ''}
       InputProps={{
         endAdornment: askAi && (
           <TextFieldAskAI

--- a/openbas-front/src/utils/KillChainPhaseUtils.ts
+++ b/openbas-front/src/utils/KillChainPhaseUtils.ts
@@ -1,9 +1,0 @@
-import type { KillChainPhase } from './api-types';
-
-const extractKillChainPhaseExternalId = (killChainPhase: KillChainPhase) => {
-  const start = killChainPhase.phase_external_id.indexOf('TA') + 'TA'.length;
-  const externalId = killChainPhase.phase_external_id.substring(start);
-  return parseInt(externalId, 10);
-};
-
-export default extractKillChainPhaseExternalId;

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -261,13 +261,16 @@ const i18n = {
         'Souhaitez-vous supprimer ce document ?',
       'Update the document': 'Modifier le document',
       'Inject data': 'Données du stimuli',
-      'Update teams': 'Modifier les équipe',
+      'Update teams': 'Modifier les équipes',
       'Add target teams in this inject':
         'Ajouter des équipes cibles dans ce stimuli',
+      'Modify target teams in this inject':
+          'Modifier les équipes cibles dans ce stimuli',
       'Targeted teams': 'Equipes ciblées',
       'Test the inject': 'Tester le stimuli',
       'All teams': 'Toutes les équipes',
       'Add target teams': 'Ajouter des équipes cibles',
+      'Modify target teams': 'Modifier les équipes cibles',
       'Trigger after': 'Se déclenche après',
       'Create a new inject': 'Créer un nouveau stimuli',
       'Remove from the team': 'Retirer de l\'équipe',
@@ -1699,10 +1702,13 @@ const i18n = {
       'Update teams': '编辑团队',
       'Add target teams in this inject':
         '在这个注入里添加目标团队',
+      'Modify target teams in this inject':
+          '在此注入中修改目标团队',
       'Targeted teams': '目标团队',
       'Test the inject': '测试注入',
       'All teams': '所有团队',
       'Add target teams': '添加目标团队',
+      'Modify target teams': '修改目标团队',
       'Trigger after': '在之后触发',
       'Create a new inject': '创建新注入',
       'Remove from the team': '从团队移除',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* "Add teams..." controls in Inject definitions is changed to "Modify teams"
* The Modify teams dialog allows for adding or removing teams to/from inject
* Allowed team list is scoped down to the teams added to a scenario/simulation accordingly
  *  If no teams were added to a scenario or simulation, no teams are available to add to injects

### Related issues

* Fix #2112 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
