### PR TITLE
[frontend] fix: fixed adding empty filters on datatables

### DIFF
--- a/openbas-front/src/components/common/queryable/filter/FilterChipValues.tsx
+++ b/openbas-front/src/components/common/queryable/filter/FilterChipValues.tsx
@@ -69,7 +69,7 @@ const FilterChipValues: FunctionComponent<Props> = ({
       {idx > 0 && or}
       <span>
         {' '}
-        { propertySchema?.schema_property_type.includes('instant') ? (o.label) : t(o.label)}
+        {propertySchema?.schema_property_type.includes('instant') || !o.label ? (o.label) : t(o.label)}
       </span>
     </Fragment>
   ));
@@ -100,9 +100,9 @@ const FilterChipValues: FunctionComponent<Props> = ({
         str = `${str} ${t('OR')}`;
       }
       if (propertySchema?.schema_property_type.includes('instant')) {
-        str = `${str} ${fldt(o.label)}`;
+        str = `${str} ${o.label ? fldt(o.label) : o.label}`;
       } else {
-        str = `${str} ${t(o.label)}`;
+        str = `${str} ${o.label ? t(o.label) : o.label}`;
       }
     });
     return str;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix or a bug when adding an empty filter in a datatable

### Related issues

* No issue created

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

To reproduce the bug before this fix, follow these steps:
- Go to any datatable where filters can be added (example: list of injects for a given scenario)
- Add a new filter (example: type)
- click outside the box, without setting any value
