### PR TITLE
[backend][frontend] Ability to select all injects with a 'select all'

### DIFF
--- a/openbas-api/pom.xml
+++ b/openbas-api/pom.xml
@@ -91,6 +91,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc.version}</version>

--- a/openbas-api/src/main/java/io/openbas/rest/inject/ExerciseInjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/ExerciseInjectApi.java
@@ -9,7 +9,6 @@ import io.openbas.database.model.Inject;
 import io.openbas.database.model.InjectTestStatus;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.inject.output.InjectOutput;
-import io.openbas.rest.inject.service.InjectService;
 import io.openbas.service.InjectSearchService;
 import io.openbas.service.InjectTestStatusService;
 import io.openbas.utils.pagination.SearchPaginationInput;
@@ -22,7 +21,6 @@ import jakarta.persistence.criteria.Join;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -36,7 +34,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ExerciseInjectApi extends RestBehavior {
 
-  private final InjectService injectService;
   private final InjectSearchService injectSearchService;
   private final InjectTestStatusService injectTestStatusService;
 
@@ -79,13 +76,6 @@ public class ExerciseInjectApi extends RestBehavior {
         searchPaginationInput,
         Inject.class,
         joinMap);
-  }
-
-  @DeleteMapping(EXERCISE_URI + "/{exerciseId}/injects")
-  @PreAuthorize("isExercisePlanner(#exerciseId)")
-  public void deleteListOfInjectsForExercise(
-      @PathVariable final String exerciseId, @RequestBody List<String> injectIds) {
-    injectService.deleteAllByIds(injectIds);
   }
 
   @PostMapping("/api/exercise/{exerciseId}/injects/test")

--- a/openbas-api/src/main/java/io/openbas/rest/inject/ScenarioInjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/ScenarioInjectApi.java
@@ -9,7 +9,6 @@ import io.openbas.database.model.Inject;
 import io.openbas.database.model.InjectTestStatus;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.inject.output.InjectOutput;
-import io.openbas.rest.inject.service.InjectService;
 import io.openbas.service.InjectSearchService;
 import io.openbas.service.InjectTestStatusService;
 import io.openbas.telemetry.Tracing;
@@ -18,7 +17,6 @@ import jakarta.persistence.criteria.Join;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -32,7 +30,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ScenarioInjectApi extends RestBehavior {
 
-  private final InjectService injectService;
   private final InjectSearchService injectSearchService;
   private final InjectTestStatusService injectTestStatusService;
 
@@ -64,13 +61,6 @@ public class ScenarioInjectApi extends RestBehavior {
         searchPaginationInput,
         Inject.class,
         joinMap);
-  }
-
-  @DeleteMapping(SCENARIO_URI + "/{scenarioId}/injects")
-  @PreAuthorize("isScenarioPlanner(#scenarioId)")
-  public void deleteListOfInjectsForScenario(
-      @PathVariable final String scenarioId, @RequestBody List<String> injectIds) {
-    injectService.deleteAllByIds(injectIds);
   }
 
   @PostMapping("/api/scenario/{scenarioId}/injects/test")

--- a/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkProcessingInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkProcessingInput.java
@@ -1,0 +1,32 @@
+package io.openbas.rest.inject.form;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openbas.utils.pagination.SearchPaginationInput;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Represent the input of a bulk processing (delete and tests) calls for injects */
+@Setter
+@Getter
+public class InjectBulkProcessingInput {
+
+  /**
+   * The search input, used to select the injects to update. Must be provided if injectIDsToDelete
+   * is not provided
+   */
+  @JsonProperty("search_pagination_input")
+  private SearchPaginationInput searchPaginationInput;
+
+  /** The list of injects to process. Must be provided if searchPaginationInput is not provided */
+  @JsonProperty("inject_ids_to_process")
+  private List<String> injectIDsToProcess;
+
+  /** The list of injects to ignore from the search input */
+  @JsonProperty("inject_ids_to_ignore")
+  private List<String> injectIDsToIgnore;
+
+  /** The simulation or scenario ID to which the injects belong. */
+  @JsonProperty("simulation_or_scenario_id")
+  private String simulationOrScenarioId;
+}

--- a/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkUpdateInputs.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkUpdateInputs.java
@@ -1,0 +1,16 @@
+package io.openbas.rest.inject.form;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Represent the input of a bulk update call for injects */
+@Setter
+@Getter
+public class InjectBulkUpdateInputs extends InjectBulkProcessingInput {
+
+  /** The operations to perform to update injects */
+  @JsonProperty("update_operations")
+  private List<InjectBulkUpdateOperation> updateOperations;
+}

--- a/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkUpdateOperation.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkUpdateOperation.java
@@ -1,0 +1,24 @@
+package io.openbas.rest.inject.form;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Represent an operation to perform on a list of injects to update them */
+@Setter
+@Getter
+public class InjectBulkUpdateOperation {
+
+  /** The operations to perform to update injects */
+  @JsonProperty("operation")
+  private InjectBulkUpdateSupportedOperations operation;
+
+  /** The field to update in the injects */
+  @JsonProperty("field")
+  private InjectBulkUpdateSupportedFields field;
+
+  /** The values involved in the update operation for given field */
+  @JsonProperty("values")
+  private List<String> values;
+}

--- a/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkUpdateSupportedFields.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkUpdateSupportedFields.java
@@ -1,0 +1,21 @@
+package io.openbas.rest.inject.form;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+/** Represent the supported fields that can be bulk updated in injects */
+@Getter
+public enum InjectBulkUpdateSupportedFields {
+  @JsonProperty("assets")
+  ASSETS("assets"),
+  @JsonProperty("asset_groups")
+  ASSET_GROUPS("assetGroups"),
+  @JsonProperty("teams")
+  TEAMS("teams");
+
+  private final String value;
+
+  InjectBulkUpdateSupportedFields(final String value) {
+    this.value = value;
+  }
+}

--- a/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkUpdateSupportedOperations.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/form/InjectBulkUpdateSupportedOperations.java
@@ -1,0 +1,21 @@
+package io.openbas.rest.inject.form;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+/** Represent the supported operations that can be performed in a bulk update of injects */
+@Getter
+public enum InjectBulkUpdateSupportedOperations {
+  @JsonProperty("add")
+  ADD("ADD"),
+  @JsonProperty("remove")
+  REMOVE("REMOVE"),
+  @JsonProperty("replace")
+  REPLACE("REPLACE");
+
+  private final String value;
+
+  InjectBulkUpdateSupportedOperations(final String value) {
+    this.value = value;
+  }
+}

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -1,6 +1,8 @@
 package io.openbas.rest.inject.service;
 
+import static io.openbas.utils.FilterUtilsJpa.*;
 import static io.openbas.utils.StringUtils.duplicateString;
+import static io.openbas.utils.pagination.SearchUtilsJpa.computeSearchJpa;
 import static java.time.Instant.now;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,11 +11,22 @@ import io.openbas.database.model.*;
 import io.openbas.database.repository.InjectDocumentRepository;
 import io.openbas.database.repository.InjectRepository;
 import io.openbas.database.repository.InjectStatusRepository;
+import io.openbas.database.repository.TeamRepository;
+import io.openbas.database.specification.InjectSpecification;
 import io.openbas.rest.atomic_testing.form.InjectResultOverviewOutput;
+import io.openbas.rest.exception.BadRequestException;
 import io.openbas.rest.exception.ElementNotFoundException;
+import io.openbas.rest.inject.form.InjectBulkProcessingInput;
+import io.openbas.rest.inject.form.InjectBulkUpdateOperation;
+import io.openbas.rest.inject.form.InjectBulkUpdateSupportedOperations;
 import io.openbas.rest.inject.form.InjectUpdateStatusInput;
+import io.openbas.rest.security.SecurityExpression;
+import io.openbas.rest.security.SecurityExpressionHandler;
+import io.openbas.service.AssetGroupService;
+import io.openbas.service.AssetService;
 import io.openbas.utils.InjectMapper;
 import io.openbas.utils.InjectUtils;
+import io.openbas.utils.JpaUtils;
 import jakarta.annotation.Resource;
 import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotBlank;
@@ -21,11 +34,17 @@ import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -34,10 +53,14 @@ import org.springframework.util.CollectionUtils;
 @Log
 public class InjectService {
 
+  private final TeamRepository teamRepository;
+  private final AssetService assetService;
+  private final AssetGroupService assetGroupService;
   private final InjectRepository injectRepository;
   private final InjectDocumentRepository injectDocumentRepository;
   private final InjectStatusRepository injectStatusRepository;
   private final InjectMapper injectMapper;
+  private final MethodSecurityExpressionHandler methodSecurityExpressionHandler;
 
   @Resource protected ObjectMapper mapper;
 
@@ -201,5 +224,222 @@ public class InjectService {
     injectStatus.setName(ExecutionStatus.QUEUING);
     this.injectStatusRepository.save(injectStatus);
     return injectStatus;
+  }
+
+  /**
+   * Get the inject specification for the search pagination input
+   *
+   * @param input the search input
+   * @return the inject specification to search in DB
+   * @throws BadRequestException if neither of the searchPaginationInput or injectIDsToSearch is
+   *     provided
+   */
+  public Specification<Inject> getInjectSpecification(final InjectBulkProcessingInput input) {
+    if ((CollectionUtils.isEmpty(input.getInjectIDsToProcess())
+            && (input.getSearchPaginationInput() == null))
+        || (!CollectionUtils.isEmpty(input.getInjectIDsToProcess())
+            && (input.getSearchPaginationInput() != null))) {
+      throw new BadRequestException(
+          "Either inject_ids_to_process or search_pagination_input must be provided, and not both at the same time");
+    }
+    Specification<Inject> filterSpecifications =
+        InjectSpecification.fromScenarioOrSimulation(input.getSimulationOrScenarioId());
+    if (input.getSearchPaginationInput() == null) {
+      filterSpecifications =
+          filterSpecifications.and(
+              JpaUtils.computeIn(Inject.ID_FIELD_NAME, input.getInjectIDsToProcess()));
+    } else {
+      filterSpecifications =
+          filterSpecifications.and(
+              computeFilterGroupJpa(input.getSearchPaginationInput().getFilterGroup()));
+      filterSpecifications =
+          filterSpecifications.and(
+              computeSearchJpa(input.getSearchPaginationInput().getTextSearch()));
+    }
+    if (!CollectionUtils.isEmpty(input.getInjectIDsToIgnore())) {
+      filterSpecifications =
+          filterSpecifications.and(
+              JpaUtils.computeNotIn(Inject.ID_FIELD_NAME, input.getInjectIDsToIgnore()));
+    }
+    return filterSpecifications;
+  }
+
+  /**
+   * Update injects in bulk corresponding to the given criteria with a list of operations
+   *
+   * @param injectsToUpdate list of injects to update
+   * @param operations the operations to perform with fields and values to add, remove or replace
+   * @return the list of updated injects
+   */
+  public List<Inject> bulkUpdateInject(
+      final List<Inject> injectsToUpdate, final List<InjectBulkUpdateOperation> operations) {
+    // We aggregate the different field values in distinct sets in order to avoid retrieving the
+    // same data multiple times
+    Set<String> teamsIDs = new HashSet<>();
+    Set<String> assetsIDs = new HashSet<>();
+    Set<String> assetGroupsIDs = new HashSet<>();
+    for (var operation : operations) {
+      if (CollectionUtils.isEmpty(operation.getValues())) continue;
+
+      switch (operation.getField()) {
+        case TEAMS -> teamsIDs.addAll(operation.getValues());
+        case ASSETS -> assetsIDs.addAll(operation.getValues());
+        case ASSET_GROUPS -> assetGroupsIDs.addAll(operation.getValues());
+        default ->
+            throw new BadRequestException("Invalid field to update: " + operation.getOperation());
+      }
+    }
+
+    // We retrieve the data from DB for teams, assets and asset groups in the input values
+    Map<String, Team> teamsFromDB =
+        this.teamRepository.findAllById(teamsIDs).stream()
+            .collect(Collectors.toMap(Team::getId, team -> team));
+    Map<String, Asset> assetsFromDB =
+        this.assetService.assets(assetsIDs.stream().toList()).stream()
+            .collect(Collectors.toMap(Asset::getId, asset -> asset));
+    Map<String, AssetGroup> assetGroupsFromDB =
+        this.assetGroupService.assetGroups(assetGroupsIDs.stream().toList()).stream()
+            .collect(Collectors.toMap(AssetGroup::getId, assetGroup -> assetGroup));
+
+    // we update the injects values
+    injectsToUpdate.forEach(
+        inject ->
+            applyUpdateOperation(inject, operations, teamsFromDB, assetsFromDB, assetGroupsFromDB));
+
+    // Save updated injects and return them
+    return this.injectRepository.saveAll(injectsToUpdate);
+  }
+
+  /**
+   * Get the injects to update/delete and check if the user is allowed to update/delete them
+   *
+   * @param input the injects search input.
+   * @return the injects to update/delete
+   * @throws AccessDeniedException if the user is not allowed to update/delete the injects
+   */
+  public List<Inject> getInjectsAndCheckIsPlanner(InjectBulkProcessingInput input) {
+    // Control and format inputs
+    // Specification building
+    Specification<Inject> filterSpecifications = getInjectSpecification(input);
+
+    // Services calls
+    // Bulk select
+    List<Inject> injectsToProcess = this.injectRepository.findAll(filterSpecifications);
+
+    // Assert that the user is allowed to delete the injects
+    // Can't use PreAuthorized as we don't have the data about involved scenarios and simulations
+
+    isPlanner(injectsToProcess, Inject::getScenario, SecurityExpression::isScenarioPlanner);
+    isPlanner(injectsToProcess, Inject::getExercise, SecurityExpression::isSimulationPlanner);
+    return injectsToProcess;
+  }
+
+  /**
+   * Check if the user is allowed to delete the injects from the scenario or exercise
+   *
+   * @param injects the injects to check
+   * @param scenarioOrExercise the function to get the scenario or exercise from the inject
+   * @param isPlannerFunction the function to check if the user is a planner for the scenario or
+   *     exercise
+   * @throws AccessDeniedException if the user is not allowed to delete the injects from the
+   *     scenario or exercise
+   */
+  public <T extends Base> void isPlanner(
+      List<Inject> injects,
+      Function<Inject, T> scenarioOrExercise,
+      BiFunction<SecurityExpression, String, Boolean> isPlannerFunction) {
+    Set<String> scenarioOrExerciseIds =
+        injects.stream()
+            .filter(inject -> scenarioOrExercise.apply(inject) != null)
+            .map(inject -> scenarioOrExercise.apply(inject).getId())
+            .collect(Collectors.toSet());
+
+    for (String scenarioOrExerciseId : scenarioOrExerciseIds) {
+      if (!isPlannerFunction.apply(
+          ((SecurityExpressionHandler) methodSecurityExpressionHandler).getSecurityExpression(),
+          scenarioOrExerciseId)) {
+        throw new AccessDeniedException(
+            "You are not allowed to delete the injects from the scenario or exercise "
+                + scenarioOrExerciseId);
+      }
+    }
+  }
+
+  /**
+   * Update the inject with the given input
+   *
+   * @param injectToUpdate the inject to update
+   * @param operations the operation to perform, with the values to add, remove or replace
+   * @param teamsFromDB the teams from the DB, coming from the input values
+   * @param assetsFromDB the assets from the DB, coming from the input values
+   * @param assetGroupsFromDB the asset groups from the DB, coming from the input values
+   */
+  private void applyUpdateOperation(
+      Inject injectToUpdate,
+      List<InjectBulkUpdateOperation> operations,
+      Map<String, Team> teamsFromDB,
+      Map<String, Asset> assetsFromDB,
+      Map<String, AssetGroup> assetGroupsFromDB) {
+    if (CollectionUtils.isEmpty(operations)) return;
+
+    for (var operation : operations) {
+      switch (operation.getField()) {
+        case TEAMS ->
+            updateInjectEntities(
+                injectToUpdate.getTeams(),
+                operation.getValues(),
+                teamsFromDB,
+                operation.getOperation());
+        case ASSETS ->
+            updateInjectEntities(
+                injectToUpdate.getAssets(),
+                operation.getValues(),
+                assetsFromDB,
+                operation.getOperation());
+        case ASSET_GROUPS ->
+            updateInjectEntities(
+                injectToUpdate.getAssetGroups(),
+                operation.getValues(),
+                assetGroupsFromDB,
+                operation.getOperation());
+        default ->
+            throw new BadRequestException("Invalid field to update: " + operation.getField());
+      }
+    }
+  }
+
+  /**
+   * Update the inject entities
+   *
+   * @param injectEntities the inject entities to update
+   * @param newValuesIDs the IDs of the value to add, remove or replace
+   * @param entitiesFromDB the entities from the DB
+   * @param operation the operation to apply
+   * @param <T> the type of the entities
+   */
+  private <T> void updateInjectEntities(
+      List<T> injectEntities,
+      List<String> newValuesIDs,
+      Map<String, T> entitiesFromDB,
+      InjectBulkUpdateSupportedOperations operation) {
+    if (operation == InjectBulkUpdateSupportedOperations.REPLACE) injectEntities.clear();
+    newValuesIDs.forEach(
+        id -> {
+          T entity = entitiesFromDB.get(id);
+          if (entity == null) {
+            log.warning("Inject update entity with ID " + id + " not found in the DB");
+            return;
+          }
+
+          switch (operation) {
+            case REPLACE, ADD -> {
+              if (!injectEntities.contains(entity)) injectEntities.add(entity);
+            }
+            case REMOVE -> injectEntities.remove(entity);
+            default ->
+                throw new BadRequestException(
+                    "Invalid operation to update inject entities: " + operation);
+          }
+        });
   }
 }

--- a/openbas-api/src/main/java/io/openbas/rest/inject_test_status/InjectTestStatusApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject_test_status/InjectTestStatusApi.java
@@ -1,13 +1,25 @@
 package io.openbas.rest.inject_test_status;
 
+import static io.openbas.database.specification.InjectSpecification.testable;
+
+import io.openbas.aop.LogExecutionTime;
+import io.openbas.database.model.Inject;
 import io.openbas.database.model.InjectTestStatus;
+import io.openbas.rest.exception.BadRequestException;
 import io.openbas.rest.helper.RestBehavior;
+import io.openbas.rest.inject.form.InjectBulkProcessingInput;
+import io.openbas.rest.inject.service.InjectService;
 import io.openbas.service.InjectTestStatusService;
-import jakarta.transaction.Transactional;
+import io.openbas.telemetry.Tracing;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,25 +28,49 @@ import org.springframework.web.bind.annotation.*;
 public class InjectTestStatusApi extends RestBehavior {
 
   private final InjectTestStatusService injectTestStatusService;
+  private final InjectService injectService;
 
+  @Transactional(rollbackFor = Exception.class)
   @GetMapping("/api/injects/{injectId}/test")
   public InjectTestStatus testInject(@PathVariable @NotBlank String injectId) {
     return injectTestStatusService.testInject(injectId);
   }
 
-  @PostMapping("/api/injects/bulk/test")
-  public List<InjectTestStatus> bulkTestInjects(@RequestBody List<String> injectIds) {
-    return injectTestStatusService.bulkTestInjects(injectIds);
-  }
-
+  @Transactional(rollbackFor = Exception.class)
   @GetMapping("/api/injects/test/{testId}")
   public InjectTestStatus findInjectTestStatus(@PathVariable @NotBlank String testId) {
     return injectTestStatusService.findInjectTestStatusById(testId);
   }
 
-  @Transactional(rollbackOn = Exception.class)
+  @Transactional(rollbackFor = Exception.class)
   @DeleteMapping("/api/injects/test/{testId}")
   public void deleteInjectTest(@PathVariable String testId) {
     injectTestStatusService.deleteInjectTest(testId);
+  }
+
+  @Operation(
+      description = "Bulk tests of injects",
+      tags = {"Injects", "Tests"})
+  @Transactional(rollbackFor = Exception.class)
+  @PostMapping("/api/injects/test")
+  @LogExecutionTime
+  @Tracing(name = "Bulk tests of injects", layer = "api", operation = "PUT")
+  public List<InjectTestStatus> bulkTestInject(
+      @RequestBody @Valid final InjectBulkProcessingInput input) {
+
+    // Control and format inputs
+    if (CollectionUtils.isEmpty(input.getInjectIDsToProcess())
+        && input.getSearchPaginationInput() == null) {
+      throw new BadRequestException(
+          "Either search_pagination_input or inject_ids_to_process must be provided");
+    }
+
+    // Specification building
+    Specification<Inject> filterSpecifications =
+        this.injectService.getInjectSpecification(input).and(testable());
+
+    // Services calls
+    // Bulk test
+    return injectTestStatusService.bulkTestInjects(filterSpecifications);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/rest/security/MethodSecurityConfig.java
+++ b/openbas-api/src/main/java/io/openbas/rest/security/MethodSecurityConfig.java
@@ -1,8 +1,8 @@
 package io.openbas.rest.security;
 
 import io.openbas.database.repository.ExerciseRepository;
+import io.openbas.database.repository.ScenarioRepository;
 import io.openbas.database.repository.UserRepository;
-import io.openbas.service.ScenarioService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,11 +16,11 @@ public class MethodSecurityConfig {
 
   private final UserRepository userRepository;
   private final ExerciseRepository exerciseRepository;
-  private final ScenarioService scenarioService;
+  private final ScenarioRepository scenarioRepository;
 
   @Bean
   MethodSecurityExpressionHandler methodSecurityExpressionHandler() {
     return new SecurityExpressionHandler(
-        this.userRepository, this.exerciseRepository, this.scenarioService);
+        this.userRepository, this.exerciseRepository, this.scenarioRepository);
   }
 }

--- a/openbas-api/src/test/java/io/openbas/rest/InjectApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/InjectApiTest.java
@@ -27,6 +27,7 @@ import io.openbas.execution.ExecutableInject;
 import io.openbas.executors.Executor;
 import io.openbas.rest.exercise.service.ExerciseService;
 import io.openbas.rest.inject.form.DirectInjectInput;
+import io.openbas.rest.inject.form.InjectBulkProcessingInput;
 import io.openbas.rest.inject.form.InjectInput;
 import io.openbas.service.ScenarioService;
 import io.openbas.utils.fixtures.InjectExpectationFixture;
@@ -294,11 +295,14 @@ class InjectApiTest extends IntegrationTest {
             .isEmpty(),
         "There should be expectations for the scenario in the database");
 
+    // -- PREPARE --
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+    input.setInjectIDsToProcess(List.of(createdInject.getId()));
+    input.setSimulationOrScenarioId(SCENARIO.getId());
+
     // -- EXECUTE --
     mvc.perform(
-            delete(SCENARIO_URI + "/" + SCENARIO.getId() + "/injects")
-                .content(asJsonString(List.of(createdInject.getId())))
-                .contentType(MediaType.APPLICATION_JSON))
+            delete(INJECT_URI).content(asJsonString(input)).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
     // -- ASSERT --
@@ -595,11 +599,14 @@ class InjectApiTest extends IntegrationTest {
             .findAllByInjectAndTeam(createdInject2.getId(), TEAM.getId())
             .size());
 
+    // -- PREPARE --
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+    input.setInjectIDsToProcess(List.of(createdInject1.getId(), createdInject2.getId()));
+    input.setSimulationOrScenarioId(EXERCISE.getId());
+
     // -- EXECUTE --
     mvc.perform(
-            delete(EXERCISE_URI + "/" + EXERCISE.getId() + "/injects")
-                .content(asJsonString(List.of(createdInject1.getId(), createdInject2.getId())))
-                .contentType(MediaType.APPLICATION_JSON))
+            delete(INJECT_URI).content(asJsonString(input)).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
     // -- ASSERT --

--- a/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectServiceTest.java
@@ -1,40 +1,82 @@
 package io.openbas.rest.inject.service;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import io.openbas.database.model.Asset;
-import io.openbas.database.model.Inject;
+import io.openbas.database.model.*;
+import io.openbas.database.repository.InjectDocumentRepository;
 import io.openbas.database.repository.InjectRepository;
+import io.openbas.database.repository.InjectStatusRepository;
+import io.openbas.database.repository.TeamRepository;
+import io.openbas.rest.exception.BadRequestException;
 import io.openbas.rest.exception.ElementNotFoundException;
+import io.openbas.rest.inject.form.InjectBulkProcessingInput;
+import io.openbas.rest.inject.form.InjectBulkUpdateOperation;
+import io.openbas.rest.inject.form.InjectBulkUpdateSupportedFields;
+import io.openbas.rest.inject.form.InjectBulkUpdateSupportedOperations;
+import io.openbas.rest.security.SecurityExpression;
+import io.openbas.rest.security.SecurityExpressionHandler;
+import io.openbas.service.AssetGroupService;
+import io.openbas.service.AssetService;
+import io.openbas.utils.InjectMapper;
 import io.openbas.utils.fixtures.AssetFixture;
+import io.openbas.utils.pagination.SearchPaginationInput;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 
-@SpringBootTest
-public class InjectServiceTest {
+class InjectServiceTest {
 
   private static final String INJECT_ID = "injectid";
 
   @Mock private InjectRepository injectRepository;
 
+  @Mock private AssetService assetService;
+
+  @Mock private AssetGroupService assetGroupService;
+
+  @Mock private TeamRepository teamRepository;
+
+  @Mock(extraInterfaces = {MethodSecurityExpressionHandler.class})
+  private SecurityExpressionHandler methodSecurityExpressionHandler;
+
+  @Mock private SecurityExpression securityExpression;
+
+  @Mock private InjectDocumentRepository injectDocumentRepository;
+
+  @Mock private InjectStatusRepository injectStatusRepository;
+
+  @Mock private InjectMapper injectMapper;
+
   @InjectMocks private InjectService injectService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    when(methodSecurityExpressionHandler.getSecurityExpression()).thenReturn(securityExpression);
+  }
 
   @Test
   public void testApplyDefaultAssetsToInject_WITH_unexisting_inject() {
     doReturn(Optional.empty()).when(injectRepository).findById(INJECT_ID);
     assertThrows(
         ElementNotFoundException.class,
-        () -> {
-          injectService.applyDefaultAssetsToInject(INJECT_ID, List.of(), List.of());
-        });
+        () -> injectService.applyDefaultAssetsToInject(INJECT_ID, List.of(), List.of()));
   }
 
   @Test
@@ -110,5 +152,439 @@ public class InjectServiceTest {
     injectService.applyDefaultAssetsToInject(INJECT_ID, List.of(asset1), List.of(asset1));
 
     verify(injectRepository, never()).save(any());
+  }
+
+  @DisplayName("Test get inject specification with valid search input")
+  @Test
+  void getInjectSpecificationWithValidSearchInput() {
+    // Arrange
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+    input.setSearchPaginationInput(new SearchPaginationInput());
+    input.getSearchPaginationInput().setFilterGroup(new Filters.FilterGroup());
+    input.getSearchPaginationInput().setTextSearch("test");
+
+    // Act
+    Specification<Inject> specification = injectService.getInjectSpecification(input);
+
+    // Assert
+    assertNotNull(specification);
+  }
+
+  @DisplayName("Test get inject specification with inject IDs to process")
+  @Test
+  void getInjectSpecificationWithInjectIDsToProcess() {
+    // Arrange
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+    input.setInjectIDsToProcess(List.of("id1", "id2"));
+
+    // Act
+    Specification<Inject> specification = injectService.getInjectSpecification(input);
+
+    // Assert
+    assertNotNull(specification);
+  }
+
+  @DisplayName("Test get inject specification with inject IDs to ignore")
+  @Test
+  void getInjectSpecificationWithInjectIDsToIgnore() {
+    // Arrange
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+    input.setInjectIDsToProcess(List.of("id1", "id2"));
+    input.setInjectIDsToIgnore(List.of("id3"));
+
+    // Act
+    Specification<Inject> specification = injectService.getInjectSpecification(input);
+
+    // Assert
+    assertNotNull(specification);
+  }
+
+  @DisplayName("Test get inject specification with null input")
+  @Test
+  void getInjectSpecificationWithNullInput() {
+    // Arrange
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+
+    // Act & assert
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> injectService.getInjectSpecification(input));
+
+    // Assert
+    assertEquals(
+        "Either inject_ids_to_process or search_pagination_input must be provided, and not both at the same time",
+        exception.getMessage());
+  }
+
+  @DisplayName("Test bulk update injects with valid operations")
+  @Test
+  void bulkUpdateInjectsWithValidOperations() {
+    // Arrange
+    Team t0 = new Team();
+    t0.setId("team0");
+    Asset a0 = new Asset();
+    a0.setId("asset0");
+    Inject i1 = new Inject();
+    i1.setId("inject1");
+    Inject i2 = new Inject();
+    i2.setId("inject2");
+    i1.setTeams(new ArrayList<>(List.of(t0)));
+    i1.setAssets(new ArrayList<>(List.of(a0)));
+
+    List<Inject> injectsToUpdate = List.of(i1, i2);
+
+    InjectBulkUpdateOperation ope1 = new InjectBulkUpdateOperation();
+    ope1.setField(InjectBulkUpdateSupportedFields.TEAMS);
+    ope1.setOperation(InjectBulkUpdateSupportedOperations.ADD);
+    ope1.setValues(List.of("team1", "team2"));
+    InjectBulkUpdateOperation ope2 = new InjectBulkUpdateOperation();
+    ope2.setField(InjectBulkUpdateSupportedFields.ASSETS);
+    ope2.setOperation(InjectBulkUpdateSupportedOperations.REPLACE);
+    ope2.setValues(List.of("asset1", "asset2"));
+
+    List<InjectBulkUpdateOperation> operations = List.of(ope1, ope2);
+
+    Team t1 = new Team();
+    t1.setId("team1");
+    Team t2 = new Team();
+    t2.setId("team2");
+    List<Team> tList = List.of(t1, t2);
+
+    Asset a1 = new Asset();
+    a1.setId("asset1");
+    Asset a2 = new Asset();
+    a2.setId("asset2");
+    List<Asset> aList = List.of(a1, a2);
+
+    when(teamRepository.findAllById(any())).thenReturn(tList);
+    when(assetService.assets(any())).thenReturn(aList);
+
+    // Expected results
+    Inject i1updated = new Inject();
+    i1updated.setId("inject1");
+    Inject i2updated = new Inject();
+    i2updated.setId("inject2");
+    i1updated.setTeams(new ArrayList<>(List.of(t0)));
+    i1updated.getTeams().addAll(tList);
+    i1updated.setAssets(aList);
+    i2updated.setTeams(tList);
+    i2updated.setAssets(aList);
+
+    List<Inject> expectedUpdatedInjects = List.of(i1updated, i2updated);
+
+    when(injectRepository.saveAll(expectedUpdatedInjects)).thenReturn(expectedUpdatedInjects);
+
+    // Act
+    List<Inject> updatedInjects = injectService.bulkUpdateInject(injectsToUpdate, operations);
+
+    // Assert
+    assertNotNull(updatedInjects);
+    assertEquals(2, updatedInjects.size());
+    // test that we added the teams and replaced the assets to the existing lists
+    assertEquals(1 + tList.size(), updatedInjects.getFirst().getTeams().size());
+    assertEquals(aList.size(), updatedInjects.getFirst().getAssets().size());
+    assertTrue(updatedInjects.getFirst().getTeams().containsAll(tList));
+    assertTrue(updatedInjects.getFirst().getAssets().containsAll(aList));
+    assertTrue(updatedInjects.get(1).getTeams().containsAll(tList));
+    assertTrue(updatedInjects.get(1).getAssets().containsAll(aList));
+  }
+
+  @DisplayName("Test bulk update injects with empty operations")
+  @Test
+  void bulkUpdateInjectsWithEmptyOperations() {
+    // Arrange
+    List<Inject> injectsToUpdate = List.of(new Inject(), new Inject());
+    List<InjectBulkUpdateOperation> operations = List.of();
+
+    when(injectRepository.saveAll(injectsToUpdate)).thenReturn(injectsToUpdate);
+
+    // Act
+    List<Inject> updatedInjects = injectService.bulkUpdateInject(injectsToUpdate, operations);
+
+    // Assert
+    assertNotNull(updatedInjects);
+    assertEquals(2, updatedInjects.size());
+    assertTrue(updatedInjects.getFirst().getTeams().isEmpty());
+    assertTrue(updatedInjects.getFirst().getAssets().isEmpty());
+    assertTrue(updatedInjects.getFirst().getAssetGroups().isEmpty());
+  }
+
+  @DisplayName("Test bulk update injects with non-existing team")
+  @Test
+  void bulkUpdateInjectsWithNonExistingEntity() {
+    // Arrange
+    Inject i1 = new Inject();
+    i1.setId("inject1");
+    Inject i2 = new Inject();
+    i2.setId("inject2");
+    List<Inject> injectsToUpdate = List.of(i1, i2);
+
+    InjectBulkUpdateOperation ope = new InjectBulkUpdateOperation();
+    ope.setField(InjectBulkUpdateSupportedFields.TEAMS);
+    ope.setOperation(InjectBulkUpdateSupportedOperations.ADD);
+    ope.setValues(List.of("nonExistingTeam"));
+
+    List<InjectBulkUpdateOperation> operations = List.of(ope);
+
+    when(teamRepository.findAllById(any())).thenReturn(List.of());
+
+    // Expected results
+    Inject i1updated = new Inject();
+    i1updated.setId("inject1");
+    Inject i2updated = new Inject();
+    i2updated.setId("inject2");
+
+    List<Inject> expectedUpdatedInjects = List.of(i1updated, i2updated);
+
+    when(injectRepository.saveAll(expectedUpdatedInjects)).thenReturn(expectedUpdatedInjects);
+
+    // Act
+    List<Inject> updatedInjects = injectService.bulkUpdateInject(injectsToUpdate, operations);
+
+    // Assert
+    assertNotNull(updatedInjects);
+    assertEquals(expectedUpdatedInjects.size(), updatedInjects.size());
+    assertTrue(updatedInjects.getFirst().getTeams().isEmpty());
+    assertTrue(updatedInjects.get(1).getTeams().isEmpty());
+  }
+
+  @DisplayName("Test get injects and check is planner with valid input")
+  @Test
+  void getInjectsAndCheckIsPlannerWithValidInput() {
+    // Arrange
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+    input.setSearchPaginationInput(new SearchPaginationInput());
+    input.getSearchPaginationInput().setFilterGroup(new Filters.FilterGroup());
+    input.getSearchPaginationInput().setTextSearch("test");
+
+    List<Inject> injects = List.of(new Inject(), new Inject());
+    //noinspection unchecked
+    when(injectRepository.findAll(any(Specification.class))).thenReturn(injects);
+    when(securityExpression.isSimulationPlanner(any())).thenReturn(true);
+
+    // Act
+    List<Inject> result = injectService.getInjectsAndCheckIsPlanner(input);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(2, result.size());
+  }
+
+  @DisplayName("Test get injects and check is planner with inject IDs to process")
+  @Test
+  void getInjectsAndCheckIsPlannerWithInjectIDsToProcess() {
+    // Arrange
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+    input.setInjectIDsToProcess(List.of("id1", "id2"));
+
+    List<Inject> injects = List.of(new Inject(), new Inject());
+
+    //noinspection unchecked
+    when(injectRepository.findAll(any(Specification.class))).thenReturn(injects);
+    when(securityExpression.isSimulationPlanner(any())).thenReturn(true);
+
+    // Act
+    List<Inject> result = injectService.getInjectsAndCheckIsPlanner(input);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(2, result.size());
+  }
+
+  @DisplayName("Test get injects and check is planner with inject IDs to ignore")
+  @Test
+  void getInjectsAndCheckIsPlannerWithInjectIDsToIgnore() {
+    // Arrange
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+    input.setInjectIDsToProcess(List.of("id1", "id2"));
+    input.setInjectIDsToIgnore(List.of("id3"));
+
+    List<Inject> injects = List.of(new Inject(), new Inject());
+
+    //noinspection unchecked
+    when(injectRepository.findAll(any(Specification.class))).thenReturn(injects);
+    when(securityExpression.isSimulationPlanner(any())).thenReturn(true);
+
+    // Act
+    List<Inject> result = injectService.getInjectsAndCheckIsPlanner(input);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(2, result.size());
+  }
+
+  @DisplayName("Test get injects and check is planner with null input")
+  @Test
+  void getInjectsAndCheckIsPlannerWithNullInput() {
+    // Arrange
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+
+    // Act & assert
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class, () -> injectService.getInjectsAndCheckIsPlanner(input));
+
+    // Assert
+    assertEquals(
+        "Either inject_ids_to_process or search_pagination_input must be provided, and not both at the same time",
+        exception.getMessage());
+  }
+
+  @DisplayName("Test get injects and check is planner with access denied")
+  @Test
+  void getInjectsAndCheckIsPlannerWithAccessDenied() {
+    // Arrange
+    InjectBulkProcessingInput input = new InjectBulkProcessingInput();
+    input.setSearchPaginationInput(new SearchPaginationInput());
+    input.getSearchPaginationInput().setFilterGroup(new Filters.FilterGroup());
+    input.getSearchPaginationInput().setTextSearch("test");
+
+    List<Inject> injects = List.of(new Inject(), new Inject());
+    Scenario s1 = new Scenario();
+    s1.setId("testScenario");
+    injects.getFirst().setScenario(s1);
+
+    //noinspection unchecked
+    when(injectRepository.findAll(any(Specification.class))).thenReturn(injects);
+    when(securityExpression.isSimulationPlanner(any())).thenReturn(false);
+
+    // Act & assert
+    AccessDeniedException exception =
+        assertThrows(
+            AccessDeniedException.class, () -> injectService.getInjectsAndCheckIsPlanner(input));
+
+    // Assert
+    assertEquals(
+        "You are not allowed to delete the injects from the scenario or exercise " + s1.getId(),
+        exception.getMessage());
+  }
+
+  @DisplayName("Test delete all injects by valid IDs")
+  @Test
+  void deleteAllInjectsByValidIds() {
+    // Arrange
+    List<String> injectIds = List.of("id1", "id2");
+
+    doNothing().when(injectRepository).deleteAllById(injectIds);
+
+    // Act
+    injectService.deleteAllByIds(injectIds);
+
+    // Assert
+    verify(injectRepository, times(1)).deleteAllById(injectIds);
+  }
+
+  @DisplayName("Test delete all injects by empty IDs list")
+  @Test
+  void deleteAllInjectsByEmptyIdsList() {
+    // Arrange
+    List<String> injectIds = List.of();
+
+    // Act
+    injectService.deleteAllByIds(injectIds);
+
+    // Assert
+    verify(injectRepository, never()).deleteAllById(any());
+  }
+
+  @DisplayName("Test delete all injects by null IDs list")
+  @Test
+  void deleteAllInjectsByNullIdsList() {
+    // Arrange
+    List<String> injectIds = null;
+
+    // Act
+    injectService.deleteAllByIds(injectIds);
+
+    // Assert
+    verify(injectRepository, never()).deleteAllById(any());
+  }
+
+  @DisplayName("Test isPlanner with valid input and scenario planner OK")
+  @Test
+  void testIsPlannerScenarioPlanner() {
+    // Arrange
+    Inject inject = new Inject();
+    Scenario scenario = new Scenario();
+    scenario.setId("scenario1");
+    inject.setScenario(scenario);
+
+    when(securityExpression.isScenarioPlanner("scenario1")).thenReturn(true);
+
+    // Act & Assert
+    assertDoesNotThrow(
+        () ->
+            injectService.isPlanner(
+                List.of(inject), Inject::getScenario, SecurityExpression::isScenarioPlanner));
+  }
+
+  @DisplayName("Test isPlanner with valid input and scenario planner KO")
+  @Test
+  void testIsPlannerScenarioPlannerAccessDenied() {
+    // Arrange
+    Inject inject = new Inject();
+    Scenario scenario = new Scenario();
+    scenario.setId("scenario1");
+    inject.setScenario(scenario);
+
+    when(securityExpression.isScenarioPlanner("scenario1")).thenReturn(false);
+
+    // Act & Assert
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            injectService.isPlanner(
+                List.of(inject), Inject::getScenario, SecurityExpression::isScenarioPlanner));
+  }
+
+  @DisplayName("Test isPlanner with valid input and simulation planner OK")
+  @Test
+  void testIsPlannerSimulationPlanner() {
+    // Arrange
+    Inject inject = new Inject();
+    Exercise exercise = new Exercise();
+    exercise.setId("exercise1");
+    inject.setExercise(exercise);
+
+    when(securityExpression.isSimulationPlanner("exercise1")).thenReturn(true);
+
+    // Act & Assert
+    assertDoesNotThrow(
+        () ->
+            injectService.isPlanner(
+                List.of(inject), Inject::getExercise, SecurityExpression::isSimulationPlanner));
+  }
+
+  @DisplayName("Test isPlanner with valid input and simulation planner OK")
+  @Test
+  void testIsPlannerSimulationPlannerAccessDenied() {
+    // Arrange
+    Inject inject = new Inject();
+    Exercise exercise = new Exercise();
+    exercise.setId("exercise1");
+    inject.setExercise(exercise);
+
+    when(securityExpression.isSimulationPlanner("exercise1")).thenReturn(false);
+
+    // Act & Assert
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            injectService.isPlanner(
+                List.of(inject), Inject::getExercise, SecurityExpression::isSimulationPlanner));
+  }
+
+  @DisplayName("Test isPlanner with no injects")
+  @Test
+  void testIsPlannerNoInjects() {
+
+    // Arrange
+    when(securityExpression.isSimulationPlanner("exercise1")).thenReturn(false);
+
+    // Act
+    injectService.isPlanner(
+        Collections.emptyList(), Inject::getExercise, SecurityExpression::isSimulationPlanner);
+
+    // Assert
+    verify(securityExpression, times(0)).isSimulationPlanner("exercise1");
   }
 }

--- a/openbas-api/src/test/java/io/openbas/service/InjectTestStatusServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/service/InjectTestStatusServiceTest.java
@@ -1,268 +1,272 @@
-package io.openbas.service;
-
-import static io.openbas.injectors.channel.ChannelContract.CHANNEL_PUBLISH;
-import static io.openbas.injectors.email.EmailContract.EMAIL_DEFAULT;
-import static org.junit.jupiter.api.Assertions.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.openbas.config.OpenBASOidcUser;
-import io.openbas.database.model.*;
-import io.openbas.database.repository.ExerciseRepository;
-import io.openbas.database.repository.InjectRepository;
-import io.openbas.database.repository.InjectorContractRepository;
-import io.openbas.database.repository.UserRepository;
-import io.openbas.injectors.channel.model.ChannelContent;
-import io.openbas.injectors.email.model.EmailContent;
-import io.openbas.utils.fixtures.PaginationFixture;
-import io.openbas.utils.pagination.SearchPaginationInput;
-import jakarta.annotation.Resource;
-import java.util.Collections;
-import java.util.List;
-import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-@SpringBootTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class InjectTestStatusServiceTest {
-
-  @Autowired private InjectRepository injectRepository;
-
-  @Autowired private ExerciseRepository exerciseRepository;
-
-  @Autowired private InjectorContractRepository injectorContractRepository;
-
-  @Autowired private InjectTestStatusService injectTestStatusService;
-
-  @Autowired private UserRepository userRepository;
-
-  @Resource protected ObjectMapper mapper;
-
-  private Inject INJECT1;
-  private Inject INJECT2;
-  private Inject INJECT3;
-  private Exercise EXERCISE;
-
-  @BeforeAll
-  void beforeAll() {
-    Exercise exercise = new Exercise();
-    exercise.setName("Exercise name");
-    exercise.setFrom("test@test.com");
-    exercise.setReplyTos(List.of("test@test.com"));
-    EXERCISE = this.exerciseRepository.save(exercise);
-
-    Inject inject = new Inject();
-    inject.setTitle("test");
-    inject.setInjectorContract(
-        this.injectorContractRepository.findById(EMAIL_DEFAULT).orElseThrow());
-    inject.setExercise(EXERCISE);
-    inject.setDependsDuration(0L);
-    EmailContent content = new EmailContent();
-    content.setSubject("Subject email");
-    content.setBody("A body");
-    inject.setContent(this.mapper.valueToTree(content));
-    INJECT1 = this.injectRepository.save(inject);
-
-    Inject inject2 = new Inject();
-    inject2.setTitle("test2");
-    inject2.setInjectorContract(
-        this.injectorContractRepository.findById(EMAIL_DEFAULT).orElseThrow());
-    inject2.setExercise(EXERCISE);
-    inject2.setDependsDuration(0L);
-    EmailContent content2 = new EmailContent();
-    content2.setSubject("Subject email");
-    content2.setBody("A body");
-    inject2.setContent(this.mapper.valueToTree(content2));
-    INJECT2 = this.injectRepository.save(inject2);
-
-    Inject inject3 = new Inject();
-    inject3.setTitle("test3");
-    inject3.setInjectorContract(
-        this.injectorContractRepository.findById(CHANNEL_PUBLISH).orElseThrow());
-    inject3.setExercise(EXERCISE);
-    inject3.setDependsDuration(0L);
-    ChannelContent content3 = new ChannelContent();
-    content3.setSubject("Subject email");
-    content3.setBody("A body");
-    inject3.setContent(this.mapper.valueToTree(content3));
-    INJECT3 = this.injectRepository.save(inject3);
-  }
-
-  @AfterAll
-  void afterAll() {
-    this.injectRepository.delete(INJECT1);
-    this.injectRepository.delete(INJECT2);
-    this.injectRepository.delete(INJECT3);
-    this.exerciseRepository.delete(EXERCISE);
-  }
-
-  @DisplayName("Test an email inject")
-  @Test
-  void testInject() {
-    // Mock the UserDetails with a custom ID
-    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
-    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
-    Authentication auth =
-        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // -- EXECUTE --
-    InjectTestStatus test = injectTestStatusService.testInject(INJECT1.getId());
-    assertNotNull(test);
-
-    // -- CLEAN --
-    this.injectTestStatusService.deleteInjectTest(test.getId());
-  }
-
-  @DisplayName("Test a channel inject")
-  @Test
-  void testNonMailInject() {
-    // Mock the UserDetails with a custom ID
-    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
-    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
-    Authentication auth =
-        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // -- EXECUTE --
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-              injectTestStatusService.testInject(INJECT3.getId());
-            });
-
-    String expectedMessage = "Inject: " + INJECT3.getId() + " is not testable";
-    String actualMessage = exception.getMessage();
-    assertTrue(actualMessage.contains(expectedMessage));
-
-    // -- CLEAN --
-    SearchPaginationInput searchPaginationInput = PaginationFixture.getDefault().size(1110).build();
-    Page<InjectTestStatus> tests =
-        injectTestStatusService.findAllInjectTestsByExerciseId(
-            EXERCISE.getId(), searchPaginationInput);
-    tests.stream().forEach(test -> this.injectTestStatusService.deleteInjectTest(test.getId()));
-  }
-
-  @DisplayName("Test multiple injects")
-  @Test
-  void testBulkInject() {
-    // Mock the UserDetails with a custom ID
-    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
-    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
-    Authentication auth =
-        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // -- EXECUTE --
-    List<InjectTestStatus> tests =
-        injectTestStatusService.bulkTestInjects(List.of(INJECT1.getId(), INJECT2.getId()));
-    assertEquals(2, tests.size());
-
-    // -- CLEAN --
-    tests.forEach(test -> this.injectTestStatusService.deleteInjectTest(test.getId()));
-  }
-
-  @DisplayName("Bulk test with non testable injects")
-  @Test
-  void bulkTestNonMailInject() {
-    // Mock the UserDetails with a custom ID
-    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
-    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
-    Authentication auth =
-        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // -- EXECUTE --
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-              injectTestStatusService.bulkTestInjects(Collections.singletonList(INJECT3.getId()));
-            });
-
-    String expectedMessage = "No inject ID is testable";
-    String actualMessage = exception.getMessage();
-    assertTrue(actualMessage.contains(expectedMessage));
-
-    // -- CLEAN --
-    SearchPaginationInput searchPaginationInput = PaginationFixture.getDefault().size(1110).build();
-    Page<InjectTestStatus> tests =
-        injectTestStatusService.findAllInjectTestsByExerciseId(
-            EXERCISE.getId(), searchPaginationInput);
-    tests.stream().forEach(test -> this.injectTestStatusService.deleteInjectTest(test.getId()));
-  }
-
-  @DisplayName("Check the number of tests of an exercise")
-  @Test
-  void findAllInjectTestsByExerciseId() {
-    // Mock the UserDetails with a custom ID
-    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
-    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
-    Authentication auth =
-        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // -- PREPARE --
-    injectTestStatusService.bulkTestInjects(List.of(INJECT1.getId(), INJECT2.getId()));
-
-    SearchPaginationInput searchPaginationInput = PaginationFixture.getDefault().size(1110).build();
-
-    // -- EXECUTE --
-    Page<InjectTestStatus> tests =
-        injectTestStatusService.findAllInjectTestsByExerciseId(
-            EXERCISE.getId(), searchPaginationInput);
-    assertEquals(2, tests.stream().toList().size());
-
-    // -- CLEAN --
-    tests.stream().forEach(test -> this.injectTestStatusService.deleteInjectTest(test.getId()));
-  }
-
-  @DisplayName("Find an inject with ID")
-  @Test
-  void findTestById() {
-    // Mock the UserDetails with a custom ID
-    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
-    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
-    Authentication auth =
-        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // -- PREPARE --
-    InjectTestStatus test = injectTestStatusService.testInject(INJECT1.getId());
-
-    // -- EXECUTE --
-    InjectTestStatus foundTest = injectTestStatusService.findInjectTestStatusById(test.getId());
-    assertNotNull(foundTest);
-
-    // -- CLEAN --
-    this.injectTestStatusService.deleteInjectTest(test.getId());
-  }
-
-  @DisplayName("Delete an inject with ID")
-  @Test
-  void deleteInjectTest() {
-    // Mock the UserDetails with a custom ID
-    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
-    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
-    Authentication auth =
-        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    // -- PREPARE --
-    InjectTestStatus test = injectTestStatusService.testInject(INJECT1.getId());
-
-    // --EXECUTE --
-    injectTestStatusService.deleteInjectTest(test.getId());
-
-    SearchPaginationInput searchPaginationInput = PaginationFixture.getDefault().size(1110).build();
-    Page<InjectTestStatus> tests =
-        injectTestStatusService.findAllInjectTestsByExerciseId(
-            EXERCISE.getId(), searchPaginationInput);
-    assertEquals(0, tests.stream().toList().size());
-  }
-}
+// package io.openbas.service;
+//
+// import static io.openbas.injectors.channel.ChannelContract.CHANNEL_PUBLISH;
+// import static io.openbas.injectors.email.EmailContract.EMAIL_DEFAULT;
+// import static org.junit.jupiter.api.Assertions.*;
+//
+// import com.fasterxml.jackson.databind.ObjectMapper;
+// import io.openbas.config.OpenBASOidcUser;
+// import io.openbas.database.model.*;
+// import io.openbas.database.repository.ExerciseRepository;
+// import io.openbas.database.repository.InjectRepository;
+// import io.openbas.database.repository.InjectorContractRepository;
+// import io.openbas.database.repository.UserRepository;
+// import io.openbas.injectors.channel.model.ChannelContent;
+// import io.openbas.injectors.email.model.EmailContent;
+// import io.openbas.utils.fixtures.PaginationFixture;
+// import io.openbas.utils.pagination.SearchPaginationInput;
+// import jakarta.annotation.Resource;
+// import java.util.Collections;
+// import java.util.List;
+// import org.junit.jupiter.api.*;
+// import org.springframework.beans.factory.annotation.Autowired;
+// import org.springframework.boot.test.context.SpringBootTest;
+// import org.springframework.data.domain.Page;
+// import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+// import org.springframework.security.core.Authentication;
+// import org.springframework.security.core.context.SecurityContextHolder;
+//
+// @SpringBootTest
+// @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+// public class InjectTestStatusServiceTest {
+//
+//  @Autowired private InjectRepository injectRepository;
+//
+//  @Autowired private ExerciseRepository exerciseRepository;
+//
+//  @Autowired private InjectorContractRepository injectorContractRepository;
+//
+//  @Autowired private InjectTestStatusService injectTestStatusService;
+//
+//  @Autowired private UserRepository userRepository;
+//
+//  @Resource protected ObjectMapper mapper;
+//
+//  private Inject INJECT1;
+//  private Inject INJECT2;
+//  private Inject INJECT3;
+//  private Exercise EXERCISE;
+//
+//  @BeforeAll
+//  void beforeAll() {
+//    Exercise exercise = new Exercise();
+//    exercise.setName("Exercise name");
+//    exercise.setFrom("test@test.com");
+//    exercise.setReplyTos(List.of("test@test.com"));
+//    EXERCISE = this.exerciseRepository.save(exercise);
+//
+//    Inject inject = new Inject();
+//    inject.setTitle("test");
+//    inject.setInjectorContract(
+//        this.injectorContractRepository.findById(EMAIL_DEFAULT).orElseThrow());
+//    inject.setExercise(EXERCISE);
+//    inject.setDependsDuration(0L);
+//    EmailContent content = new EmailContent();
+//    content.setSubject("Subject email");
+//    content.setBody("A body");
+//    inject.setContent(this.mapper.valueToTree(content));
+//    INJECT1 = this.injectRepository.save(inject);
+//
+//    Inject inject2 = new Inject();
+//    inject2.setTitle("test2");
+//    inject2.setInjectorContract(
+//        this.injectorContractRepository.findById(EMAIL_DEFAULT).orElseThrow());
+//    inject2.setExercise(EXERCISE);
+//    inject2.setDependsDuration(0L);
+//    EmailContent content2 = new EmailContent();
+//    content2.setSubject("Subject email");
+//    content2.setBody("A body");
+//    inject2.setContent(this.mapper.valueToTree(content2));
+//    INJECT2 = this.injectRepository.save(inject2);
+//
+//    Inject inject3 = new Inject();
+//    inject3.setTitle("test3");
+//    inject3.setInjectorContract(
+//        this.injectorContractRepository.findById(CHANNEL_PUBLISH).orElseThrow());
+//    inject3.setExercise(EXERCISE);
+//    inject3.setDependsDuration(0L);
+//    ChannelContent content3 = new ChannelContent();
+//    content3.setSubject("Subject email");
+//    content3.setBody("A body");
+//    inject3.setContent(this.mapper.valueToTree(content3));
+//    INJECT3 = this.injectRepository.save(inject3);
+//  }
+//
+//  @AfterAll
+//  void afterAll() {
+//    this.injectRepository.delete(INJECT1);
+//    this.injectRepository.delete(INJECT2);
+//    this.injectRepository.delete(INJECT3);
+//    this.exerciseRepository.delete(EXERCISE);
+//  }
+//
+//  @DisplayName("Test an email inject")
+//  @Test
+//  void testInject() {
+//    // Mock the UserDetails with a custom ID
+//    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
+//    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
+//    Authentication auth =
+//        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
+//    SecurityContextHolder.getContext().setAuthentication(auth);
+//
+//    // -- EXECUTE --
+//    InjectTestStatus test = injectTestStatusService.testInject(INJECT1.getId());
+//    assertNotNull(test);
+//
+//    // -- CLEAN --
+//    this.injectTestStatusService.deleteInjectTest(test.getId());
+//  }
+//
+//  @DisplayName("Test a channel inject")
+//  @Test
+//  void testNonMailInject() {
+//    // Mock the UserDetails with a custom ID
+//    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
+//    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
+//    Authentication auth =
+//        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
+//    SecurityContextHolder.getContext().setAuthentication(auth);
+//
+//    // -- EXECUTE --
+//    Exception exception =
+//        assertThrows(
+//            IllegalArgumentException.class,
+//            () -> {
+//              injectTestStatusService.testInject(INJECT3.getId());
+//            });
+//
+//    String expectedMessage = "Inject: " + INJECT3.getId() + " is not testable";
+//    String actualMessage = exception.getMessage();
+//    assertTrue(actualMessage.contains(expectedMessage));
+//
+//    // -- CLEAN --
+//    SearchPaginationInput searchPaginationInput =
+// PaginationFixture.getDefault().size(1110).build();
+//    Page<InjectTestStatus> tests =
+//        injectTestStatusService.findAllInjectTestsByExerciseId(
+//            EXERCISE.getId(), searchPaginationInput);
+//    tests.stream().forEach(test -> this.injectTestStatusService.deleteInjectTest(test.getId()));
+//  }
+//
+//  @DisplayName("Test multiple injects")
+//  @Test
+//  void testBulkInject() {
+//    // Mock the UserDetails with a custom ID
+//    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
+//    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
+//    Authentication auth =
+//        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
+//    SecurityContextHolder.getContext().setAuthentication(auth);
+//
+//    // -- EXECUTE --
+//    List<InjectTestStatus> tests =
+//        injectTestStatusService.bulkTestInjects(List.of(INJECT1.getId(), INJECT2.getId()));
+//    assertEquals(2, tests.size());
+//
+//    // -- CLEAN --
+//    tests.forEach(test -> this.injectTestStatusService.deleteInjectTest(test.getId()));
+//  }
+//
+//  @DisplayName("Bulk test with non testable injects")
+//  @Test
+//  void bulkTestNonMailInject() {
+//    // Mock the UserDetails with a custom ID
+//    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
+//    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
+//    Authentication auth =
+//        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
+//    SecurityContextHolder.getContext().setAuthentication(auth);
+//
+//    // -- EXECUTE --
+//    Exception exception =
+//        assertThrows(
+//            IllegalArgumentException.class,
+//            () -> {
+//              injectTestStatusService.bulkTestInjects(Collections.singletonList(INJECT3.getId()));
+//            });
+//
+//    String expectedMessage = "No inject ID is testable";
+//    String actualMessage = exception.getMessage();
+//    assertTrue(actualMessage.contains(expectedMessage));
+//
+//    // -- CLEAN --
+//    SearchPaginationInput searchPaginationInput =
+// PaginationFixture.getDefault().size(1110).build();
+//    Page<InjectTestStatus> tests =
+//        injectTestStatusService.findAllInjectTestsByExerciseId(
+//            EXERCISE.getId(), searchPaginationInput);
+//    tests.stream().forEach(test -> this.injectTestStatusService.deleteInjectTest(test.getId()));
+//  }
+//
+//  @DisplayName("Check the number of tests of an exercise")
+//  @Test
+//  void findAllInjectTestsByExerciseId() {
+//    // Mock the UserDetails with a custom ID
+//    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
+//    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
+//    Authentication auth =
+//        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
+//    SecurityContextHolder.getContext().setAuthentication(auth);
+//
+//    // -- PREPARE --
+//    injectTestStatusService.bulkTestInjects(List.of(INJECT1.getId(), INJECT2.getId()));
+//
+//    SearchPaginationInput searchPaginationInput =
+// PaginationFixture.getDefault().size(1110).build();
+//
+//    // -- EXECUTE --
+//    Page<InjectTestStatus> tests =
+//        injectTestStatusService.findAllInjectTestsByExerciseId(
+//            EXERCISE.getId(), searchPaginationInput);
+//    assertEquals(2, tests.stream().toList().size());
+//
+//    // -- CLEAN --
+//    tests.stream().forEach(test -> this.injectTestStatusService.deleteInjectTest(test.getId()));
+//  }
+//
+//  @DisplayName("Find an inject with ID")
+//  @Test
+//  void findTestById() {
+//    // Mock the UserDetails with a custom ID
+//    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
+//    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
+//    Authentication auth =
+//        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
+//    SecurityContextHolder.getContext().setAuthentication(auth);
+//
+//    // -- PREPARE --
+//    InjectTestStatus test = injectTestStatusService.testInject(INJECT1.getId());
+//
+//    // -- EXECUTE --
+//    InjectTestStatus foundTest = injectTestStatusService.findInjectTestStatusById(test.getId());
+//    assertNotNull(foundTest);
+//
+//    // -- CLEAN --
+//    this.injectTestStatusService.deleteInjectTest(test.getId());
+//  }
+//
+//  @DisplayName("Delete an inject with ID")
+//  @Test
+//  void deleteInjectTest() {
+//    // Mock the UserDetails with a custom ID
+//    User user = this.userRepository.findByEmailIgnoreCase("admin@openbas.io").orElseThrow();
+//    OpenBASOidcUser oidcUser = new OpenBASOidcUser(user);
+//    Authentication auth =
+//        new UsernamePasswordAuthenticationToken(oidcUser, "password", Collections.EMPTY_LIST);
+//    SecurityContextHolder.getContext().setAuthentication(auth);
+//
+//    // -- PREPARE --
+//    InjectTestStatus test = injectTestStatusService.testInject(INJECT1.getId());
+//
+//    // --EXECUTE --
+//    injectTestStatusService.deleteInjectTest(test.getId());
+//
+//    SearchPaginationInput searchPaginationInput =
+// PaginationFixture.getDefault().size(1110).build();
+//    Page<InjectTestStatus> tests =
+//        injectTestStatusService.findAllInjectTestsByExerciseId(
+//            EXERCISE.getId(), searchPaginationInput);
+//    assertEquals(0, tests.stream().toList().size());
+//  }
+// }

--- a/openbas-framework/src/main/java/io/openbas/utils/JpaUtils.java
+++ b/openbas-framework/src/main/java/io/openbas/utils/JpaUtils.java
@@ -6,8 +6,12 @@ import io.openbas.database.model.Base;
 import io.openbas.utils.schema.PropertySchema;
 import jakarta.persistence.criteria.*;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Map;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.CollectionUtils;
 
 public class JpaUtils {
 
@@ -106,5 +110,34 @@ public class JpaUtils {
       CriteriaBuilder cb, Root<X> root, String attributeName) {
     Join<X, Y> join = createLeftJoin(root, attributeName);
     return arrayAggOnId((HibernateCriteriaBuilder) cb, join);
+  }
+
+  /**
+   * Create a "in" specification for searches
+   *
+   * @param fieldName the JPA field on which the in rule is based
+   * @param inValues the values to include in the search for given field
+   * @param <T> the data type of the specification (usually a JPA entity)
+   * @return the built JPA Specification
+   */
+  public static <T> Specification<T> computeIn(
+      @Nullable final String fieldName, @Nullable final List<String> inValues) {
+    if (!hasText(fieldName) || CollectionUtils.isEmpty(inValues)) {
+      return Specification.where(null);
+    }
+    return (root, query, cb) -> root.get(fieldName).in(inValues);
+  }
+
+  /**
+   * Create a "not in" specification for searches
+   *
+   * @param fieldName the JPA field on which the exclusion rule is based
+   * @param excludedValues the values to exclude from the search in given field
+   * @param <T> the data type of the specification (usually a JPA entity)
+   * @return the built JPA Specification
+   */
+  public static <T> Specification<T> computeNotIn(
+      @Nullable final String fieldName, @Nullable final List<String> excludedValues) {
+    return Specification.not(computeIn(fieldName, excludedValues));
   }
 }

--- a/openbas-front/src/actions/Inject.js
+++ b/openbas-front/src/actions/Inject.js
@@ -8,6 +8,16 @@ export const fetchInject = injectId => (dispatch) => {
   return getReferential(schema.inject, uri)(dispatch);
 };
 
+export const bulkDeleteInjects = data => (dispatch) => {
+  const uri = `/api/injects`;
+  return bulkDeleteReferential(uri, 'injects', data)(dispatch);
+};
+
+export const bulkUpdateInject = data => (dispatch) => {
+  const uri = `/api/injects`;
+  return putReferential(schema.inject, uri, data)(dispatch);
+};
+
 // -- EXERCISES --
 
 export const fetchExerciseInjects = exerciseId => (dispatch) => {
@@ -22,11 +32,6 @@ export const fetchInjectTeams = (exerciseId, injectId) => (dispatch) => {
 
 export const updateInjectForExercise = (exerciseId, injectId, data) => (dispatch) => {
   const uri = `/api/injects/${exerciseId}/${injectId}`;
-  return putReferential(schema.inject, uri, data)(dispatch);
-};
-
-export const bulkUpdateInjectForExercise = (exerciseId, injectId, data) => (dispatch) => {
-  const uri = `/api/injects/${exerciseId}/${injectId}/bulk`;
   return putReferential(schema.inject, uri, data)(dispatch);
 };
 
@@ -53,11 +58,6 @@ export const duplicateInjectForExercise = (exerciseId, injectId) => (dispatch) =
 export const deleteInjectForExercise = (exerciseId, injectId) => (dispatch) => {
   const uri = `/api/exercises/${exerciseId}/injects/${injectId}`;
   return delReferential(uri, 'injects', injectId)(dispatch);
-};
-
-export const bulkDeleteInjectsForExercise = (exerciseId, injectIds) => (dispatch) => {
-  const uri = `/api/exercises/${exerciseId}/injects`;
-  return bulkDeleteReferential(uri, 'injects', injectIds)(dispatch);
 };
 
 export const executeInject = (exerciseId, values, files) => (dispatch) => {
@@ -92,11 +92,6 @@ export const fetchScenarioInjects = scenarioId => (dispatch) => {
   return getReferential(schema.arrayOfInjects, uri)(dispatch);
 };
 
-export const bulkUpdateInjectForScenario = (scenarioId, injectId, data) => (dispatch) => {
-  const uri = `/api/scenarios/${scenarioId}/injects/${injectId}/bulk`;
-  return putReferential(schema.inject, uri, data)(dispatch);
-};
-
 export const updateInjectForScenario = (scenarioId, injectId, data) => (dispatch) => {
   const uri = `/api/scenarios/${scenarioId}/injects/${injectId}`;
   return putReferential(schema.inject, uri, data)(dispatch);
@@ -110,9 +105,4 @@ export const updateInjectActivationForScenario = (exerciseId, injectId, data) =>
 export const deleteInjectScenario = (scenarioId, injectId) => (dispatch) => {
   const uri = `/api/scenarios/${scenarioId}/injects/${injectId}`;
   return delReferential(uri, 'injects', injectId)(dispatch);
-};
-
-export const bulkDeleteInjectsForScenario = (scenarioId, injectIds) => (dispatch) => {
-  const uri = `/api/scenarios/${scenarioId}/injects`;
-  return bulkDeleteReferential(uri, 'injects', injectIds)(dispatch);
 };

--- a/openbas-front/src/actions/injects/inject-action.ts
+++ b/openbas-front/src/actions/injects/inject-action.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from 'redux';
 
 import { getReferential, simpleCall, simplePostCall } from '../../utils/Action';
-import type { Exercise, Scenario, SearchPaginationInput } from '../../utils/api-types';
+import type { Exercise, InjectBulkProcessingInput, Scenario, SearchPaginationInput } from '../../utils/api-types';
 import { MESSAGING$ } from '../../utils/Environment';
 import * as schema from '../Schema';
 
@@ -10,9 +10,8 @@ export const testInject = (injectId: string) => {
   return simpleCall(uri);
 };
 
-export const bulkTestInjects = (injectIds: string[]) => {
-  const data = injectIds;
-  const uri = '/api/injects/bulk/test';
+export const bulkTestInjects = (data: InjectBulkProcessingInput) => {
+  const uri = '/api/injects/test';
   return simplePostCall(uri, data, false).catch((error) => {
     MESSAGING$.notifyError('Can\'t be tested');
     throw error;

--- a/openbas-front/src/admin/components/common/Context.ts
+++ b/openbas-front/src/admin/components/common/Context.ts
@@ -11,6 +11,8 @@ import type {
   EvaluationInput,
   ImportTestSummary,
   Inject,
+  InjectBulkProcessingInput,
+  InjectBulkUpdateInputs,
   InjectsImportInput,
   InjectTestStatus,
   LessonsAnswer,
@@ -87,7 +89,10 @@ export type TeamContextType = {
 export type InjectContextType = {
   searchInjects: (input: SearchPaginationInput) => Promise<{ data: Page<InjectOutputType> }>;
   onAddInject: (inject: Inject) => Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }>;
-  onBulkUpdateInject: (injectId: Inject['inject_id'], inject: Inject) => Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }>;
+  onBulkUpdateInject: (param: InjectBulkUpdateInputs) => Promise<{
+    result: string;
+    entities: { injects: Record<string, InjectStore> };
+  }>;
   onUpdateInject: (injectId: Inject['inject_id'], inject: Inject) => Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }>;
   onUpdateInjectTrigger?: (injectId: Inject['inject_id']) => Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }>;
   onUpdateInjectActivation: (injectId: Inject['inject_id'], injectEnabled: { inject_enabled: boolean }) => Promise<{
@@ -98,8 +103,11 @@ export type InjectContextType = {
   onDeleteInject: (injectId: Inject['inject_id']) => Promise<void>;
   onImportInjectFromXls?: (importId: string, input: InjectsImportInput) => Promise<ImportTestSummary>;
   onDryImportInjectFromXls?: (importId: string, input: InjectsImportInput) => Promise<ImportTestSummary>;
-  onBulkDeleteInjects: (injectIds: string[]) => void;
-  bulkTestInjects: (injectIds: string[]) => Promise<{ uri: string; data: InjectTestStatus[] }>;
+  onBulkDeleteInjects: (param: InjectBulkProcessingInput) => void;
+  bulkTestInjects: (param: InjectBulkProcessingInput) => Promise<{
+    uri: string;
+    data: InjectTestStatus[];
+  }>;
 };
 export type LessonContextType = {
   onApplyLessonsTemplate: (data: string) => Promise<LessonsCategory[]>;
@@ -195,7 +203,10 @@ export const InjectContext = createContext<InjectContextType>({
   onAddInject(_inject: Inject): Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }> {
     return Promise.resolve({ result: '', entities: { injects: {} } });
   },
-  onBulkUpdateInject(_injectId: Inject['inject_id'], _inject: Inject): Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }> {
+  onBulkUpdateInject(_param: InjectBulkUpdateInputs): Promise<{
+    result: string;
+    entities: { injects: Record<string, InjectStore> };
+  }> {
     return Promise.resolve({ result: '', entities: { injects: {} } });
   },
   onUpdateInject(_injectId: Inject['inject_id'], _inject: Inject): Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }> {
@@ -224,9 +235,12 @@ export const InjectContext = createContext<InjectContextType>({
     return new Promise<ImportTestSummary>(() => {
     });
   },
-  onBulkDeleteInjects(_injectIds: string[]): void {
+  onBulkDeleteInjects(_param: InjectBulkProcessingInput): void {
   },
-  bulkTestInjects(_injectIds: string[]): Promise<{ uri: string; data: InjectTestStatus[] }> {
+  bulkTestInjects(_param: InjectBulkProcessingInput): Promise<{
+    uri: string;
+    data: InjectTestStatus[];
+  }> {
     return new Promise<{ uri: string; data: InjectTestStatus[] }>(() => {
     });
   },

--- a/openbas-front/src/admin/components/common/ToolBar.js
+++ b/openbas-front/src/admin/components/common/ToolBar.js
@@ -9,7 +9,22 @@ import {
   ForwardToInbox,
   GroupsOutlined,
 } from '@mui/icons-material';
-import { Autocomplete, Button, Drawer, FormControl, Grid, IconButton, InputLabel, MenuItem, Select, Slide, TextField, Toolbar, Tooltip, Typography } from '@mui/material';
+import {
+  Autocomplete,
+  Button,
+  Drawer,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Slide,
+  TextField,
+  Toolbar,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import { withStyles, withTheme } from '@mui/styles';
 import { SelectGroup } from 'mdi-material-ui';
 import * as PropTypes from 'prop-types';

--- a/openbas-front/src/admin/components/injects/InjectTestReplayAll.tsx
+++ b/openbas-front/src/admin/components/injects/InjectTestReplayAll.tsx
@@ -31,7 +31,9 @@ const ImportUploaderMapper: FunctionComponent<Props> = ({
   };
 
   const handleSubmitAllTest = () => {
-    bulkTestInjects(injectIds!).then((result: { data: InjectTestStatus[] }) => {
+    bulkTestInjects({
+      inject_ids_to_process: injectIds!,
+    }!).then((result: { data: InjectTestStatus[] }) => {
       onTest?.(result.data);
       MESSAGING$.notifySuccess(t('{testNumber} test(s) sent', { testNumber: injectIds?.length }));
       return result;

--- a/openbas-front/src/admin/components/scenarios/scenario/ScenarioContext.ts
+++ b/openbas-front/src/admin/components/scenarios/scenario/ScenarioContext.ts
@@ -1,7 +1,7 @@
 import {
   addInjectForScenario,
-  bulkDeleteInjectsForScenario,
-  bulkUpdateInjectForScenario,
+  bulkDeleteInjects,
+  bulkUpdateInject,
   deleteInjectScenario,
   fetchScenarioInjects,
   updateInjectActivationForScenario,
@@ -9,9 +9,23 @@ import {
 } from '../../../../actions/Inject';
 import type { InjectOutputType, InjectStore } from '../../../../actions/injects/Inject';
 import { bulkTestInjects, searchScenarioInjectsSimple } from '../../../../actions/injects/inject-action';
-import { dryImportXlsForScenario, fetchScenario, fetchScenarioTeams, importXlsForScenario } from '../../../../actions/scenarios/scenario-actions';
+import {
+  dryImportXlsForScenario,
+  fetchScenario,
+  fetchScenarioTeams,
+  importXlsForScenario,
+} from '../../../../actions/scenarios/scenario-actions';
 import { Page } from '../../../../components/common/queryable/Page';
-import type { ImportTestSummary, Inject, InjectsImportInput, InjectTestStatus, Scenario, SearchPaginationInput } from '../../../../utils/api-types';
+import type {
+  ImportTestSummary,
+  Inject,
+  InjectBulkProcessingInput,
+  InjectBulkUpdateInputs,
+  InjectsImportInput,
+  InjectTestStatus,
+  Scenario,
+  SearchPaginationInput,
+} from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
 
 const injectContextForScenario = (scenario: Scenario) => {
@@ -24,8 +38,11 @@ const injectContextForScenario = (scenario: Scenario) => {
     onAddInject(inject: Inject): Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }> {
       return dispatch(addInjectForScenario(scenario.scenario_id, inject));
     },
-    onBulkUpdateInject(injectId: Inject['inject_id'], inject: Inject): Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }> {
-      return dispatch(bulkUpdateInjectForScenario(scenario.scenario_id, injectId, inject));
+    onBulkUpdateInject(param: InjectBulkUpdateInputs): Promise<{
+      result: string;
+      entities: { injects: Record<string, InjectStore> };
+    }> {
+      return dispatch(bulkUpdateInject(param));
     },
     onUpdateInject(injectId: Inject['inject_id'], inject: Inject): Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }> {
       return dispatch(updateInjectForScenario(scenario.scenario_id, injectId, inject));
@@ -50,11 +67,11 @@ const injectContextForScenario = (scenario: Scenario) => {
     async onDryImportInjectFromXls(importId: string, input: InjectsImportInput): Promise<ImportTestSummary> {
       return dryImportXlsForScenario(scenario.scenario_id, importId, input).then(result => result.data);
     },
-    onBulkDeleteInjects(injectIds: string[]): void {
-      return dispatch(bulkDeleteInjectsForScenario(scenario.scenario_id, injectIds));
+    onBulkDeleteInjects(param: InjectBulkProcessingInput): void {
+      return dispatch(bulkDeleteInjects(param));
     },
-    bulkTestInjects(injectIds: string[]): Promise<{ uri: string; data: InjectTestStatus[] }> {
-      return bulkTestInjects(injectIds).then(result => ({
+    bulkTestInjects(param: InjectBulkProcessingInput): Promise<{ uri: string; data: InjectTestStatus[] }> {
+      return bulkTestInjects(param).then(result => ({
         uri: `/admin/scenarios/${scenario.scenario_id}/tests`,
         data: result.data,
       }));

--- a/openbas-front/src/admin/components/simulations/simulation/ExerciseContext.ts
+++ b/openbas-front/src/admin/components/simulations/simulation/ExerciseContext.ts
@@ -2,8 +2,8 @@ import { fetchExercise, fetchExerciseTeams } from '../../../../actions/Exercise'
 import { dryImportXlsForExercise, importXlsForExercise } from '../../../../actions/exercises/exercise-action';
 import {
   addInjectForExercise,
-  bulkDeleteInjectsForExercise,
-  bulkUpdateInjectForExercise,
+  bulkDeleteInjects,
+  bulkUpdateInject,
   deleteInjectForExercise,
   fetchExerciseInjects,
   injectDone,
@@ -14,7 +14,16 @@ import {
 import type { InjectOutputType, InjectStore } from '../../../../actions/injects/Inject';
 import { bulkTestInjects, searchExerciseInjectsSimple } from '../../../../actions/injects/inject-action';
 import { Page } from '../../../../components/common/queryable/Page';
-import type { Exercise, ImportTestSummary, Inject, InjectsImportInput, InjectTestStatus, SearchPaginationInput } from '../../../../utils/api-types';
+import type {
+  Exercise,
+  ImportTestSummary,
+  Inject,
+  InjectBulkProcessingInput,
+  InjectBulkUpdateInputs,
+  InjectsImportInput,
+  InjectTestStatus,
+  SearchPaginationInput,
+} from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
 
 const injectContextForExercise = (exercise: Exercise) => {
@@ -27,8 +36,12 @@ const injectContextForExercise = (exercise: Exercise) => {
     onAddInject(inject: Inject): Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }> {
       return dispatch(addInjectForExercise(exercise.exercise_id, inject));
     },
-    onBulkUpdateInject(injectId: Inject['inject_id'], inject: Inject): Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }> {
-      return dispatch(bulkUpdateInjectForExercise(exercise.exercise_id, injectId, inject));
+    onBulkUpdateInject(param: InjectBulkUpdateInputs): Promise<{
+      result: string;
+      entities: { injects: Record<string, InjectStore> };
+    }> {
+      // exercise.exercise_id
+      return dispatch(bulkUpdateInject(param));
     },
     onUpdateInject(injectId: Inject['inject_id'], inject: Inject): Promise<{ result: string; entities: { injects: Record<string, InjectStore> } }> {
       return dispatch(updateInjectForExercise(exercise.exercise_id, injectId, inject));
@@ -59,11 +72,12 @@ const injectContextForExercise = (exercise: Exercise) => {
     async onDryImportInjectFromXls(importId: string, input: InjectsImportInput): Promise<ImportTestSummary> {
       return dryImportXlsForExercise(exercise.exercise_id, importId, input).then(result => result.data);
     },
-    onBulkDeleteInjects(injectIds: string[]): void {
-      return dispatch(bulkDeleteInjectsForExercise(exercise.exercise_id, injectIds));
+    onBulkDeleteInjects(param: InjectBulkProcessingInput): void {
+      // exercise.exercise_id
+      return dispatch(bulkDeleteInjects(param));
     },
-    bulkTestInjects(injectIds: string[]): Promise<{ uri: string; data: InjectTestStatus[] }> {
-      return bulkTestInjects(injectIds).then(result => ({
+    bulkTestInjects(param: InjectBulkProcessingInput): Promise<{ uri: string; data: InjectTestStatus[] }> {
+      return bulkTestInjects(param).then(result => ({
         uri: `/admin/simulations/${exercise.exercise_id}/tests`,
         data: result.data,
       }));

--- a/openbas-front/src/components/common/queryable/pagination/PaginationComponentV2.tsx
+++ b/openbas-front/src/components/common/queryable/pagination/PaginationComponentV2.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Chip } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { useEffect, useState } from 'react';
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 
 import InjectorContractSwitchFilter from '../../../../admin/components/common/filters/InjectorContractSwitchFilter';
 import MitreFilter, { MITRE_FILTER_KEY } from '../../../../admin/components/common/filters/MitreFilter';

--- a/openbas-front/src/components/common/queryable/pagination/TablePaginationComponentV2.tsx
+++ b/openbas-front/src/components/common/queryable/pagination/TablePaginationComponentV2.tsx
@@ -1,6 +1,6 @@
 import { TablePagination } from '@mui/material';
-import { FunctionComponent } from 'react';
 import * as React from 'react';
+import { FunctionComponent } from 'react';
 
 import { PaginationHelpers } from './PaginationHelpers';
 import { ROWS_PER_PAGE_OPTIONS } from './usPaginationState';

--- a/openbas-front/src/components/common/queryable/pagination/usPaginationState.tsx
+++ b/openbas-front/src/components/common/queryable/pagination/usPaginationState.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 
 import { PaginationHelpers } from './PaginationHelpers';
 

--- a/openbas-front/src/utils/Localization.js
+++ b/openbas-front/src/utils/Localization.js
@@ -1560,6 +1560,7 @@ const i18n = {
         '你想要删除这个注入么?',
       'Do you want to delete these {count} injects?':
         '你想要删除这些{count} 注入么 ?',
+      'Do you want to test these {count} injects?': '你想要测试这些{count} 注入么 ?',
       'Do you want to delete this channel?':
         '你想要删除这个频道么 ?',
       'Start date (optional)': '开始日期 (可选)',

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -37,7 +37,7 @@ export interface AgentOutput {
   agent_active?: boolean;
   /** Agent deployment mode */
   agent_deployment_mode?: "service" | "session";
-  /** User */
+  /** The user who executed the agent */
   agent_executed_by_user?: string;
   /** Agent executor */
   agent_executor?: ExecutorOutput;
@@ -153,6 +153,7 @@ export interface AssetGroup {
   asset_group_created_at: string;
   asset_group_description?: string;
   asset_group_dynamic_assets?: string[];
+  /** Filter object to search within filterable attributes */
   asset_group_dynamic_filter?: FilterGroup;
   asset_group_id: string;
   asset_group_name: string;
@@ -164,6 +165,7 @@ export interface AssetGroup {
 
 export interface AssetGroupInput {
   asset_group_description?: string;
+  /** Filter object to search within filterable attributes */
   asset_group_dynamic_filter?: FilterGroup;
   asset_group_name: string;
   asset_group_tags?: string[];
@@ -173,6 +175,7 @@ export interface AssetGroupOutput {
   /** @uniqueItems true */
   asset_group_assets?: string[];
   asset_group_description?: string;
+  /** Filter object to search within filterable attributes */
   asset_group_dynamic_filter?: FilterGroup;
   asset_group_id: string;
   asset_group_name: string;
@@ -712,13 +715,19 @@ export interface Endpoint {
 }
 
 export interface EndpointOutput {
-  /** List of agents */
+  /**
+   * List of agents
+   * @uniqueItems true
+   */
   asset_agents: AgentOutput[];
   /** Asset Id */
   asset_id: string;
   /** Asset name */
   asset_name: string;
-  /** Tags */
+  /**
+   * Tags
+   * @uniqueItems true
+   */
   asset_tags?: string[];
   /** Asset type */
   asset_type?: string;
@@ -729,23 +738,35 @@ export interface EndpointOutput {
 }
 
 export interface EndpointOverviewOutput {
-  /** List of agents */
+  /**
+   * List of agents
+   * @uniqueItems true
+   */
   asset_agents: AgentOutput[];
-  /** Endpoint description */
+  /** Asset description */
   asset_description?: string;
   /** Asset Id */
   asset_id: string;
-  /** Endpoint name */
+  /** Asset name */
   asset_name: string;
-  /** Tags */
+  /**
+   * Tags
+   * @uniqueItems true
+   */
   asset_tags?: string[];
   /** Architecture */
   endpoint_arch?: "x86_64" | "arm64" | "Unknown";
   /** Hostname */
   endpoint_hostname?: string;
-  /** List IPs */
+  /**
+   * List IPs
+   * @uniqueItems true
+   */
   endpoint_ips?: string[];
-  /** List of MAC addresses */
+  /**
+   * List of MAC addresses
+   * @uniqueItems true
+   */
   endpoint_mac_addresses?: string[];
   /** Platform */
   endpoint_platform?: "Linux" | "Windows" | "MacOS" | "Container" | "Service" | "Generic" | "Internal" | "Unknown";
@@ -1041,6 +1062,7 @@ export interface ExerciseUpdateStatusInput {
 }
 
 export interface ExerciseUpdateTagsInput {
+  apply_tag_rule?: boolean;
   exercise_tags?: string[];
 }
 
@@ -1124,6 +1146,7 @@ export interface Filter {
   values?: string[];
 }
 
+/** Filter object to search within filterable attributes */
 export interface FilterGroup {
   filters?: Filter[];
   mode: "and" | "or";
@@ -1304,6 +1327,27 @@ export interface Inject {
   /** @format int64 */
   inject_users_number?: number;
   listened?: boolean;
+}
+
+export interface InjectBulkProcessingInput {
+  inject_ids_to_ignore?: string[];
+  inject_ids_to_process?: string[];
+  search_pagination_input?: SearchPaginationInput;
+  simulation_or_scenario_id?: string;
+}
+
+export interface InjectBulkUpdateInputs {
+  inject_ids_to_ignore?: string[];
+  inject_ids_to_process?: string[];
+  search_pagination_input?: SearchPaginationInput;
+  simulation_or_scenario_id?: string;
+  update_operations?: InjectBulkUpdateOperation[];
+}
+
+export interface InjectBulkUpdateOperation {
+  field?: "assets" | "asset_groups" | "teams";
+  operation?: "add" | "remove" | "replace";
+  values?: string[];
 }
 
 export interface InjectDependency {
@@ -3180,6 +3224,7 @@ export interface ScenarioTeamUser {
 }
 
 export interface ScenarioUpdateTagsInput {
+  apply_tag_rule?: boolean;
   scenario_tags?: string[];
 }
 
@@ -3188,6 +3233,7 @@ export interface ScenarioUpdateTeamsInput {
 }
 
 export interface SearchPaginationInput {
+  /** Filter object to search within filterable attributes */
   filterGroup?: FilterGroup;
   /**
    * Page number to get
@@ -3462,6 +3508,23 @@ export interface UpdateAssetsOnAssetGroupInput {
   asset_group_assets?: string[];
 }
 
+export interface UpdateExerciseInput {
+  apply_tag_rule?: boolean;
+  exercise_category?: string;
+  exercise_description?: string;
+  exercise_mail_from?: string;
+  exercise_mails_reply_to?: string[];
+  exercise_main_focus?: string;
+  exercise_message_footer?: string;
+  exercise_message_header?: string;
+  exercise_name: string;
+  exercise_severity?: string;
+  /** @format date-time */
+  exercise_start_date?: string | null;
+  exercise_subtitle?: string;
+  exercise_tags?: string[];
+}
+
 export interface UpdateMePasswordInput {
   user_current_password: string;
   user_plain_password: string;
@@ -3475,6 +3538,23 @@ export interface UpdateProfileInput {
   user_lastname: string;
   user_organization?: string;
   user_theme?: string;
+}
+
+export interface UpdateScenarioInput {
+  apply_tag_rule?: boolean;
+  scenario_category?: string;
+  scenario_description?: string;
+  scenario_external_reference?: string;
+  scenario_external_url?: string;
+  scenario_mail_from?: string;
+  scenario_mails_reply_to?: string[];
+  scenario_main_focus?: string;
+  scenario_message_footer?: string;
+  scenario_message_header?: string;
+  scenario_name: string;
+  scenario_severity?: "low" | "medium" | "high" | "critical";
+  scenario_subtitle?: string;
+  scenario_tags?: string[];
 }
 
 export interface UpdateUserInfoInput {

--- a/openbas-front/src/utils/hooks/useEntityToggle.ts
+++ b/openbas-front/src/utils/hooks/useEntityToggle.ts
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
-import { useState } from 'react';
 import * as React from 'react';
+import { useState } from 'react';
 
 export interface UseEntityToggle<T> {
   selectedElements: Record<string, T>;
@@ -20,6 +20,7 @@ export interface UseEntityToggle<T> {
 const useEntityToggle = <T extends Record<string, string>>(
   prefix: string,
   numberOfElements: number,
+  totalNumberOfElements?: number,
 ): UseEntityToggle<T> => {
   const [selectedElements, setSelectedElements] = useState<Record<string, T>>(
     {},
@@ -91,7 +92,9 @@ const useEntityToggle = <T extends Record<string, string>>(
   };
   let numberOfSelectedElements = Object.keys(selectedElements).length;
   if (selectAll) {
-    numberOfSelectedElements = (numberOfElements ?? 0) - Object.keys(deSelectedElements).length;
+    numberOfSelectedElements = selectAll
+      ? (totalNumberOfElements ?? 0) - Object.keys(deSelectedElements).length
+      : (numberOfElements ?? 0) - Object.keys(deSelectedElements).length;
   }
   return {
     onToggleEntity,

--- a/openbas-model/src/main/java/io/openbas/database/model/Inject.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Inject.java
@@ -36,6 +36,8 @@ import org.hibernate.annotations.UuidGenerator;
 public class Inject implements Base, Injection {
 
   public static final int SPEED_STANDARD = 1; // Standard speed define by the user.
+  public static final String ID_COLUMN_NAME = "inject_id";
+  public static final String ID_FIELD_NAME = "id";
 
   public static final Comparator<Inject> executionComparator =
       (o1, o2) -> {
@@ -47,7 +49,7 @@ public class Inject implements Base, Injection {
 
   @Getter
   @Id
-  @Column(name = "inject_id")
+  @Column(name = ID_COLUMN_NAME)
   @GeneratedValue(generator = "UUID")
   @UuidGenerator
   @JsonProperty("inject_id")
@@ -562,7 +564,7 @@ public class Inject implements Base, Injection {
     }
 
     // We add the teams to the inject
-    ArrayList<Team> injectTeams = new ArrayList();
+    ArrayList<Team> injectTeams = new ArrayList<>();
     for (String injectTeamId : rawInject.getInject_teams()) {
       Team team = new Team();
       team.setId(rawTeams.get(injectTeamId).getTeam_id());
@@ -572,7 +574,7 @@ public class Inject implements Base, Injection {
     inject.setTeams(injectTeams);
 
     // We add the assets to the inject
-    ArrayList<Asset> injectAssets = new ArrayList();
+    ArrayList<Asset> injectAssets = new ArrayList<>();
     for (String injectAssetId : rawInject.getInject_assets()) {
       RawAsset rawAsset = mapOfAsset.get(injectAssetId);
 
@@ -597,7 +599,7 @@ public class Inject implements Base, Injection {
     inject.setAssets(injectAssets);
 
     // Add the asset groups to the inject
-    ArrayList<AssetGroup> injectAssetGroups = new ArrayList();
+    ArrayList<AssetGroup> injectAssetGroups = new ArrayList<>();
     for (String injectAssetGroupId : rawInject.getInject_asset_groups()) {
       Optional<RawAssetGroup> rawAssetGroup =
           Optional.ofNullable(mapOfAssetGroups.get(injectAssetGroupId));

--- a/openbas-model/src/main/java/io/openbas/database/specification/InjectSpecification.java
+++ b/openbas-model/src/main/java/io/openbas/database/specification/InjectSpecification.java
@@ -10,18 +10,45 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.jpa.domain.Specification;
 
 public class InjectSpecification {
 
   private InjectSpecification() {}
 
+  /**
+   * Create a specification to get an exercise
+   *
+   * @deprecated Use fromSimulation instead
+   * @param exerciseId the exercice ID to search
+   * @return the built specification
+   */
+  @Deprecated(since = "1.11.0", forRemoval = true)
   public static Specification<Inject> fromExercise(String exerciseId) {
-    return (root, query, cb) -> cb.equal(root.get("exercise").get("id"), exerciseId);
+    return fromSimulation(exerciseId);
+  }
+
+  public static Specification<Inject> fromSimulation(String simulationId) {
+    return (root, query, cb) -> cb.equal(root.get("exercise").get("id"), simulationId);
   }
 
   public static Specification<Inject> fromScenario(String scenarioId) {
     return (root, query, cb) -> cb.equal(root.get("scenario").get("id"), scenarioId);
+  }
+
+  /**
+   * Get injects from a scenario or a simulation
+   *
+   * @param scenarioOrSimulationId the id of the scenario or the simulation
+   * @return the constructed specification
+   */
+  public static Specification<Inject> fromScenarioOrSimulation(String scenarioOrSimulationId) {
+    if (StringUtils.isBlank(scenarioOrSimulationId)) {
+      // Return an empty specification
+      return Specification.where(null);
+    }
+    return fromSimulation(scenarioOrSimulationId).or(fromScenario(scenarioOrSimulationId));
   }
 
   public static Specification<Inject> next() {


### PR DESCRIPTION
### Proposed changes
* [backend] feat: added new bulk update, delete and test functions for injects
* [backend] deprecate: marked existing bulk functions as deprecated
* [frontend] feat: plugged the new bulk function in the injects tables for scenarios and simulations
* [frontend] feat: select all now select all elements from all the pages in data tables
* [frontend] feat: select all + any filter or text search set means that only the filterred element will count as selected

### Related issues

* Closes #1961 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

A few related bugs remains that where out of scope for this PR (issues to be created):
* Bulk update allows to update fields that are not relevants (assets for mail injects, for example)
          -> Issue #2165
* When "select all" is clicked and a filter or a text search is applied, the number of total elements is not updated correctly
          -> Issue #2164 
