### PR TITLE
[backend] Add trigger before delete injector contract no custom

### DIFF
--- a/openbas-api/src/main/java/io/openbas/migration/V3_60__Add_trigger_before_delete_injector_contract_no_custom.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_60__Add_trigger_before_delete_injector_contract_no_custom.java
@@ -1,0 +1,40 @@
+package io.openbas.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+@Component
+public class V3_60__Add_trigger_before_delete_injector_contract_no_custom extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Connection connection = context.getConnection();
+    Statement select = connection.createStatement();
+    select.execute(
+        """
+                        CREATE OR REPLACE FUNCTION fn_before_delete_injector_contract_no_custom()
+                        RETURNS TRIGGER
+                        AS
+                        $$
+                        BEGIN
+                           IF OLD.injector_contract_id IN ('2790bd39-37d4-4e39-be7e-53f3ca783f86', '138ad8f8-32f8-4a22-8114-aaa12322bd09') THEN
+                               RAISE EXCEPTION 'Deletion of contract type openbas_email from the injector_contracts table is not allowed';
+                           END IF;
+                            RETURN OLD;
+                        END;
+                        $$
+                        LANGUAGE plpgsql; 
+            """);
+    select.execute(
+        """
+                        CREATE TRIGGER check_del_injector_contract_no_custom
+                        BEFORE DELETE ON injectors_contracts
+                        FOR EACH ROW 
+                        EXECUTE PROCEDURE fn_before_delete_injector_contract_no_custom(); 
+            """);
+  }
+}

--- a/openbas-api/src/main/java/io/openbas/migration/V3_60__Add_trigger_before_delete_injector_contract_no_custom.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_60__Add_trigger_before_delete_injector_contract_no_custom.java
@@ -1,14 +1,14 @@
 package io.openbas.migration;
 
+import java.sql.Connection;
+import java.sql.Statement;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 import org.springframework.stereotype.Component;
 
-import java.sql.Connection;
-import java.sql.Statement;
-
 @Component
-public class V3_60__Add_trigger_before_delete_injector_contract_no_custom extends BaseJavaMigration {
+public class V3_60__Add_trigger_before_delete_injector_contract_no_custom
+    extends BaseJavaMigration {
 
   @Override
   public void migrate(Context context) throws Exception {
@@ -27,14 +27,14 @@ public class V3_60__Add_trigger_before_delete_injector_contract_no_custom extend
                             RETURN OLD;
                         END;
                         $$
-                        LANGUAGE plpgsql; 
+                        LANGUAGE plpgsql;
             """);
     select.execute(
         """
                         CREATE TRIGGER check_del_injector_contract_no_custom
                         BEFORE DELETE ON injectors_contracts
-                        FOR EACH ROW 
-                        EXECUTE PROCEDURE fn_before_delete_injector_contract_no_custom(); 
+                        FOR EACH ROW
+                        EXECUTE PROCEDURE fn_before_delete_injector_contract_no_custom();
             """);
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add trigger "before delete"on injector contract in order to avoid delete injector contract no custom (specifically: email)

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
