### PR TITLE
[backend][frontend] Fixed an issue on injects where total number of injects was not correctly updated and bulk delete didn't refresh results

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/InjectApi.java
@@ -712,13 +712,17 @@ public class InjectApi extends RestBehavior {
   @DeleteMapping(INJECT_URI)
   @LogExecutionTime
   @Tracing(name = "Bulk delete of injects", layer = "api", operation = "DELETE")
-  public void bulkDelete(@RequestBody @Valid final InjectBulkProcessingInput input) {
+  public List<Inject> bulkDelete(@RequestBody @Valid final InjectBulkProcessingInput input) {
 
     // Control and format inputs
     List<Inject> injectsToDelete = getInjectsAndCheckInputForBulkProcessing(input);
 
+    // FIXME: This is a workaround to prevent the GUI from blocking when deleting elements
+    injectsToDelete.forEach(inject -> inject.setListened(false));
+
     // Bulk delete
-    this.injectService.deleteAllByIds(injectsToDelete.stream().map(Inject::getId).toList());
+    this.injectService.deleteAll(injectsToDelete);
+    return injectsToDelete;
   }
 
   /**

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -91,6 +91,18 @@ public class InjectService {
     }
   }
 
+  /**
+   * Delete all injects given as params
+   *
+   * @param injects the injects to delete
+   */
+  @Transactional(rollbackOn = Exception.class)
+  public void deleteAll(List<Inject> injects) {
+    if (!CollectionUtils.isEmpty(injects)) {
+      injectRepository.deleteAll(injects);
+    }
+  }
+
   public void cleanInjectsDocExercise(String exerciseId, String documentId) {
     // Delete document from all exercise injects
     List<Inject> exerciseInjects =

--- a/openbas-front/src/admin/components/common/Context.ts
+++ b/openbas-front/src/admin/components/common/Context.ts
@@ -103,7 +103,7 @@ export type InjectContextType = {
   onDeleteInject: (injectId: Inject['inject_id']) => Promise<void>;
   onImportInjectFromXls?: (importId: string, input: InjectsImportInput) => Promise<ImportTestSummary>;
   onDryImportInjectFromXls?: (importId: string, input: InjectsImportInput) => Promise<ImportTestSummary>;
-  onBulkDeleteInjects: (param: InjectBulkProcessingInput) => void;
+  onBulkDeleteInjects: (param: InjectBulkProcessingInput) => Promise<Inject[]>;
   bulkTestInjects: (param: InjectBulkProcessingInput) => Promise<{
     uri: string;
     data: InjectTestStatus[];
@@ -235,7 +235,9 @@ export const InjectContext = createContext<InjectContextType>({
     return new Promise<ImportTestSummary>(() => {
     });
   },
-  onBulkDeleteInjects(_param: InjectBulkProcessingInput): void {
+  onBulkDeleteInjects(_param: InjectBulkProcessingInput): Promise<Inject[]> {
+    return new Promise<Inject[]>(() => {
+    });
   },
   bulkTestInjects(_param: InjectBulkProcessingInput): Promise<{
     uri: string;

--- a/openbas-front/src/admin/components/scenarios/scenario/ScenarioContext.ts
+++ b/openbas-front/src/admin/components/scenarios/scenario/ScenarioContext.ts
@@ -67,7 +67,7 @@ const injectContextForScenario = (scenario: Scenario) => {
     async onDryImportInjectFromXls(importId: string, input: InjectsImportInput): Promise<ImportTestSummary> {
       return dryImportXlsForScenario(scenario.scenario_id, importId, input).then(result => result.data);
     },
-    onBulkDeleteInjects(param: InjectBulkProcessingInput): void {
+    onBulkDeleteInjects(param: InjectBulkProcessingInput): Promise<Inject[]> {
       return dispatch(bulkDeleteInjects(param));
     },
     bulkTestInjects(param: InjectBulkProcessingInput): Promise<{ uri: string; data: InjectTestStatus[] }> {

--- a/openbas-front/src/admin/components/simulations/simulation/ExerciseContext.ts
+++ b/openbas-front/src/admin/components/simulations/simulation/ExerciseContext.ts
@@ -72,7 +72,7 @@ const injectContextForExercise = (exercise: Exercise) => {
     async onDryImportInjectFromXls(importId: string, input: InjectsImportInput): Promise<ImportTestSummary> {
       return dryImportXlsForExercise(exercise.exercise_id, importId, input).then(result => result.data);
     },
-    onBulkDeleteInjects(param: InjectBulkProcessingInput): void {
+    onBulkDeleteInjects(param: InjectBulkProcessingInput): Promise<Inject[]> {
       // exercise.exercise_id
       return dispatch(bulkDeleteInjects(param));
     },

--- a/openbas-front/src/utils/Action.ts
+++ b/openbas-front/src/utils/Action.ts
@@ -200,11 +200,12 @@ export const bulkDeleteReferential = (uri: string, type: string, data: unknown) 
   dispatch({ type: Constants.DATA_FETCH_SUBMITTED });
   return api()
     .delete(buildUri(uri), { data })
-    .then(() => {
+    .then((response) => {
       dispatch({
         type: Constants.DATA_DELETE_SUCCESS,
         payload: Immutable({ type, data }),
       });
+      return response.data;
     })
     .catch((error) => {
       dispatch({ type: Constants.DATA_FETCH_ERROR, payload: error });


### PR DESCRIPTION
### Proposed changes

* [backend] feat: changed return of bulk delete to return list of deleted injects
* [frontend] fix: fixed total number of elements not being updated when creating or deleting an inject
* [frontend] fix: fixed bulk delete not being reflected in datatables without refresh

### Related issues

* Fixes some bugs from issue #1961 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
