### PR TITLE
[tool] Release artifacts to package expanded application.properties (docs#91)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: mkdir -p release/openbas
-      - run: cp -a ./openbas-api/target/openbas-api.jar release/openbas/ && cp -a ./openbas-api/src/main/resources/application.properties release/openbas/
+      - run: cp -a ./openbas-api/target/openbas-api.jar release/openbas/ && cp -a ./openbas-api/target/classes/application.properties release/openbas/
       - run:
           working_directory: ~/openbas/release
           command: tar -zcvf "openbas-$(date '+%Y%m%d').tar.gz" openbas
@@ -158,7 +158,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: mkdir -p release/openbas
-      - run: cp -a ./openbas-api/target/openbas-api.jar release/openbas/ && cp -a ./openbas-api/src/main/resources/application.properties release/openbas/
+      - run: cp -a ./openbas-api/target/openbas-api.jar release/openbas/ && cp -a ./openbas-api/target/classes/application.properties release/openbas/
       - run:
           working_directory: ~/openbas_musl/release
           command: tar -zcvf "openbas-$(date '+%Y%m%d')_musl.tar.gz" openbas


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Release artifacts should package application.properties with expanded variables, not the placeholders

### Related issues

* Closes https://github.com/OpenBAS-Platform/docs/issues/91

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

The raw application.properties file contains placeholders to help with development (as to not disseminate the same data everywhere such as product version), but this can't be used to run a production server from a prebuilt jar.
Even though it seems unnecessary purely for running (a version of application.properties with expanded vars is embedded into the prebuilt jar), it is useful for users to have a quasi exhaustive config file to peruse possible switches and keys. It seems appropriate that the provided file would allow for running the jar with the same default values as set in the embedded version.