### PR TITLE
Fix the regression on executing external injects  Issue/2220

### DIFF
--- a/openbas-api/src/main/java/io/openbas/execution/ExecutableInject.java
+++ b/openbas-api/src/main/java/io/openbas/execution/ExecutableInject.java
@@ -1,5 +1,7 @@
 package io.openbas.execution;
 
+import static java.util.Optional.ofNullable;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.openbas.database.model.*;
 import java.util.ArrayList;
@@ -16,7 +18,7 @@ public class ExecutableInject {
   private final boolean runtime;
   private final int documentSize;
   private final List<Team> teams;
-  private final Exercise exercise;
+  private final String exerciseId;
   private final List<Asset> assets;
   private final List<AssetGroup> assetGroups;
   private final List<ExecutionContext> users;
@@ -32,7 +34,7 @@ public class ExecutableInject {
       List<AssetGroup> assetGroups,
       List<ExecutionContext> users) {
     this.injection = injection;
-    this.exercise = injection.getExercise();
+    this.exerciseId = ofNullable(injection.getExercise()).map(Exercise::getId).orElse(null);
     this.runtime = runtime;
     this.direct = direct;
     this.users = users;

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -385,15 +385,19 @@ public class InjectService {
       @NotNull final ExecutionStatus status,
       @Nullable final InjectStatusExecution trace) {
 
+
+    //re-fetch the injectstatus here to avoid the transactional issue at the deserialization
     InjectStatus injectStatus =
         inject
             .getStatus()
+                .map(existingStatus  -> injectStatusRepository.findById(existingStatus.getId()).orElseThrow())
             .orElseGet(
                 () -> {
                   InjectStatus newStatus = new InjectStatus();
                   newStatus.setInject(inject);
                   return newStatus;
                 });
+
 
     if (trace != null) {
       injectStatus.getTraces().add(trace);

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -380,12 +380,10 @@ public class InjectService {
   }
 
   @Transactional
-  public void initializeInjectStatus(
-      @NotNull final String injectId,
+  public Inject initializeInjectStatus(
+      @NotNull Inject inject,
       @NotNull final ExecutionStatus status,
       @Nullable final InjectStatusExecution trace) {
-
-    Inject inject = this.inject(injectId);
 
     InjectStatus injectStatus =
         inject
@@ -404,6 +402,8 @@ public class InjectService {
     injectStatus.setTrackingSentDate(Instant.now());
     injectStatus.setPayloadOutput(injectUtils.getStatusPayloadFromInject(inject));
     injectStatusRepository.save(injectStatus);
+    inject.setStatus(injectStatus);
+    return inject;
   }
 
   /**

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -380,24 +380,23 @@ public class InjectService {
   }
 
   @Transactional
-  public Inject initializeInjectStatus(
-      @NotNull Inject inject,
+  public InjectStatus initializeInjectStatus(
+      @NotNull final String injectId,
       @NotNull final ExecutionStatus status,
       @Nullable final InjectStatusExecution trace) {
 
+    Inject inject = this.inject(injectId);
 
-    //re-fetch the injectstatus here to avoid the transactional issue at the deserialization
+    // re-fetch the injectstatus here to avoid the transactional issue at the deserialization
     InjectStatus injectStatus =
         inject
             .getStatus()
-                .map(existingStatus  -> injectStatusRepository.findById(existingStatus.getId()).orElseThrow())
             .orElseGet(
                 () -> {
                   InjectStatus newStatus = new InjectStatus();
                   newStatus.setInject(inject);
                   return newStatus;
                 });
-
 
     if (trace != null) {
       injectStatus.getTraces().add(trace);
@@ -406,8 +405,7 @@ public class InjectService {
     injectStatus.setTrackingSentDate(Instant.now());
     injectStatus.setPayloadOutput(injectUtils.getStatusPayloadFromInject(inject));
     injectStatusRepository.save(injectStatus);
-    inject.setStatus(injectStatus);
-    return inject;
+    return injectStatus;
   }
 
   /**

--- a/openbas-api/src/main/java/io/openbas/scheduler/jobs/InjectsExecutionJob.java
+++ b/openbas-api/src/main/java/io/openbas/scheduler/jobs/InjectsExecutionJob.java
@@ -203,12 +203,12 @@ public class InjectsExecutionJob implements Job {
               LOGGER.log(Level.INFO, "Executing inject " + inject.getInject().getTitle());
               // Executor logics
               ExecutableInject newExecutableInject = executableInject;
+              // Status
+              InjectStatus injectStatus =
+                  this.injectService.initializeInjectStatus(
+                      inject.getId(), ExecutionStatus.EXECUTING, null);
+              inject.setStatus(injectStatus);
               if (Boolean.TRUE.equals(injectorContract.getNeedsExecutor())) {
-                // Status
-                InjectStatus injectStatus =
-                    this.injectService.initializeInjectStatus(
-                        inject.getId(), ExecutionStatus.EXECUTING, null);
-                inject.setStatus(injectStatus);
                 try {
                   newExecutableInject =
                       this.executionExecutorService.launchExecutorContext(executableInject, inject);

--- a/openbas-api/src/main/java/io/openbas/scheduler/jobs/InjectsExecutionJob.java
+++ b/openbas-api/src/main/java/io/openbas/scheduler/jobs/InjectsExecutionJob.java
@@ -1,6 +1,7 @@
 package io.openbas.scheduler.jobs;
 
 import static java.time.Instant.now;
+import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.groupingBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -154,8 +155,8 @@ public class InjectsExecutionJob implements Job {
 
     // We are now checking if we depend on another inject and if it did not failed
     Optional<List<String>> errorMessages = Optional.empty();
-    if (executableInject.getExercise() != null) {
-      errorMessages = getErrorMessagesPreExecution(executableInject.getExercise().getId(), inject);
+    if (ofNullable(executableInject.getExerciseId()).isPresent()) {
+      errorMessages = getErrorMessagesPreExecution(executableInject.getExerciseId(), inject);
     }
     if (errorMessages != null && errorMessages.isPresent()) {
       InjectStatus status = new InjectStatus();

--- a/openbas-api/src/main/java/io/openbas/scheduler/jobs/InjectsExecutionJob.java
+++ b/openbas-api/src/main/java/io/openbas/scheduler/jobs/InjectsExecutionJob.java
@@ -186,8 +186,8 @@ public class InjectsExecutionJob implements Job {
             injectorContract -> {
               if (!inject.isReady()) {
                 // Status
-                this.injectService.initializeInjectStatus(
-                    inject.getId(),
+                injectService.initializeInjectStatus(
+                    inject,
                     ExecutionStatus.ERROR,
                     InjectStatusExecution.traceError(
                         "The inject is not ready to be executed (missing mandatory fields)"));
@@ -203,8 +203,7 @@ public class InjectsExecutionJob implements Job {
               ExecutableInject newExecutableInject = executableInject;
               if (Boolean.TRUE.equals(injectorContract.getNeedsExecutor())) {
                 // Status
-                this.injectService.initializeInjectStatus(
-                    inject.getId(), ExecutionStatus.EXECUTING, null);
+                this.injectService.initializeInjectStatus(inject, ExecutionStatus.EXECUTING, null);
                 try {
                   newExecutableInject =
                       this.executionExecutorService.launchExecutorContext(executableInject, inject);
@@ -227,7 +226,7 @@ public class InjectsExecutionJob implements Job {
             },
             () ->
                 this.injectService.initializeInjectStatus(
-                    inject.getId(),
+                    inject,
                     ExecutionStatus.ERROR,
                     InjectStatusExecution.traceError("Inject does not have a contract")));
   }

--- a/openbas-api/src/test/java/io/openbas/rest/exercise/ExerciseApiStatusTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/exercise/ExerciseApiStatusTest.java
@@ -223,7 +223,7 @@ public class ExerciseApiStatusTest {
         assertEquals(
             1,
             injects.stream()
-                .filter((ij) -> SCHEDULED_EXERCISE.getId().equals(ij.getExercise().getId()))
+                .filter((ij) -> SCHEDULED_EXERCISE.getId().equals(ij.getExerciseId()))
                 .toList()
                 .size());
       }

--- a/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectServiceTest.java
@@ -604,26 +604,15 @@ class InjectServiceTest {
   }
 
   @Test
-  void given_nonexisting_initializeInjectStatus_SHOULD_throw_ElementNotFoundException() {
-    ExecutionStatus executionStatus = ExecutionStatus.EXECUTING;
-    String injectId = "randomid";
-
-    assertThrows(
-        ElementNotFoundException.class,
-        () -> injectService.initializeInjectStatus(injectId, executionStatus, null));
-  }
-
-  @Test
   void given_valid_input_initializeInjectStatus_SHOULD_save_the_injectstatus() {
     ExecutionStatus executionStatus = ExecutionStatus.EXECUTING;
     String injectId = "injectid";
     Inject inject = new Inject();
     inject.setId(injectId);
     StatusPayload statusPayload = new StatusPayload();
-    when(injectRepository.findById(injectId)).thenReturn(Optional.of(inject));
     when(injectUtils.getStatusPayloadFromInject(inject)).thenReturn(statusPayload);
 
-    injectService.initializeInjectStatus(injectId, executionStatus, null);
+    injectService.initializeInjectStatus(inject, executionStatus, null);
 
     ArgumentCaptor<InjectStatus> statusCaptor = ArgumentCaptor.forClass(InjectStatus.class);
     verify(injectStatusRepository).save(statusCaptor.capture());

--- a/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectServiceTest.java
@@ -607,10 +607,17 @@ class InjectServiceTest {
   void given_valid_input_initializeInjectStatus_SHOULD_save_the_injectstatus() {
     ExecutionStatus executionStatus = ExecutionStatus.EXECUTING;
     String injectId = "injectid";
+    String injectStatusID = "injectStatusID";
+    InjectStatus injectStatus = new InjectStatus();
+    injectStatus.setId(injectStatusID);
     Inject inject = new Inject();
     inject.setId(injectId);
+    inject.setStatus(injectStatus);
+    injectStatus.setInject(inject);
     StatusPayload statusPayload = new StatusPayload();
+
     when(injectUtils.getStatusPayloadFromInject(inject)).thenReturn(statusPayload);
+    when(injectStatusRepository.findById(injectStatusID)).thenReturn(Optional.of(injectStatus));
 
     injectService.initializeInjectStatus(inject, executionStatus, null);
 

--- a/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectServiceTest.java
@@ -617,9 +617,9 @@ class InjectServiceTest {
     StatusPayload statusPayload = new StatusPayload();
 
     when(injectUtils.getStatusPayloadFromInject(inject)).thenReturn(statusPayload);
-    when(injectStatusRepository.findById(injectStatusID)).thenReturn(Optional.of(injectStatus));
+    when(injectRepository.findById(injectId)).thenReturn(Optional.of(inject));
 
-    injectService.initializeInjectStatus(inject, executionStatus, null);
+    injectService.initializeInjectStatus(inject.getId(), executionStatus, null);
 
     ArgumentCaptor<InjectStatus> statusCaptor = ArgumentCaptor.forClass(InjectStatus.class);
     verify(injectStatusRepository).save(statusCaptor.capture());


### PR DESCRIPTION
### Proposed changes

* updating the setInjectStatusAndExecuteInject method to set the status after calling initializeInjectStatus 
* moved the call to the initializeInjectStatus  ouf of the "if needsExecutor" so the status is created for the external excutors that are pulling the status from the db

### Related issues

* Closes #2220
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug -> will be done after the refactoring 

