### PR TITLE
[backend] Account for all relevant pauses in inject start date computation (#2282)

### DIFF
--- a/openbas-api/src/test/java/io/openbas/database/model/ExerciseTest.java
+++ b/openbas-api/src/test/java/io/openbas/database/model/ExerciseTest.java
@@ -1,0 +1,51 @@
+package io.openbas.database.model;
+
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+import io.openbas.database.raw.RawExercise;
+import io.openbas.database.repository.ExerciseRepository;
+import io.openbas.utils.fixtures.ExerciseFixture;
+import io.openbas.utils.fixtures.composers.ExerciseComposer;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@TestInstance(PER_CLASS)
+@Transactional
+public class ExerciseTest {
+  @Autowired private ExerciseComposer exerciseComposer;
+  @Autowired private ExerciseRepository exerciseRepository;
+  @Autowired private EntityManager entityManager;
+
+  private final Instant exerciseStartTime = Instant.parse("2012-11-21T04:00:00Z");
+
+  @Test
+  @DisplayName("Given a persisted exercise, current pause from raw query is correctly persisted.")
+  public void GivenAnExercise_CurrentPauseFromRawQueryIsCorrectlyPersisted() {
+    Instant expectedCurrentPauseTime = Instant.parse("2012-11-21T04:05:00Z");
+    ExerciseComposer.Composer wrapper =
+        exerciseComposer
+            .forExercise(ExerciseFixture.createDefaultAttackExercise(exerciseStartTime));
+    wrapper.get().setCurrentPause(expectedCurrentPauseTime); // current pause at T+5 minutes
+
+    Exercise expected = wrapper.persist().get();
+
+    // reset JPA
+    entityManager.flush();
+    entityManager.clear();
+
+    RawExercise dbExercise = exerciseRepository.rawDetailsById(expected.getId());
+
+    Assertions.assertTrue(
+        expected.getCurrentPause().isPresent(),
+        "Current pause should be present for expected exercise");
+    Assertions.assertEquals(expected.getCurrentPause().get(), dbExercise.getExercise_pause_date());
+  }
+}

--- a/openbas-api/src/test/java/io/openbas/database/model/ExerciseTest.java
+++ b/openbas-api/src/test/java/io/openbas/database/model/ExerciseTest.java
@@ -31,8 +31,8 @@ public class ExerciseTest {
   public void GivenAnExercise_CurrentPauseFromRawQueryIsCorrectlyPersisted() {
     Instant expectedCurrentPauseTime = Instant.parse("2012-11-21T04:05:00Z");
     ExerciseComposer.Composer wrapper =
-        exerciseComposer
-            .forExercise(ExerciseFixture.createDefaultAttackExercise(exerciseStartTime));
+        exerciseComposer.forExercise(
+            ExerciseFixture.createDefaultAttackExercise(exerciseStartTime));
     wrapper.get().setCurrentPause(expectedCurrentPauseTime); // current pause at T+5 minutes
 
     Exercise expected = wrapper.persist().get();

--- a/openbas-api/src/test/java/io/openbas/database/model/InjectTest.java
+++ b/openbas-api/src/test/java/io/openbas/database/model/InjectTest.java
@@ -1,0 +1,95 @@
+package io.openbas.database.model;
+
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+import io.openbas.utils.fixtures.ExerciseFixture;
+import io.openbas.utils.fixtures.InjectFixture;
+import io.openbas.utils.fixtures.PauseFixture;
+import io.openbas.utils.fixtures.composers.ExerciseComposer;
+import io.openbas.utils.fixtures.composers.InjectComposer;
+import io.openbas.utils.fixtures.composers.PauseComposer;
+import java.time.Instant;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@TestInstance(PER_CLASS)
+@Transactional
+public class InjectTest {
+
+  @Autowired private ExerciseComposer exerciseComposer;
+  @Autowired private InjectComposer injectComposer;
+  @Autowired private PauseComposer pauseComposer;
+
+  @Nested
+  @DisplayName("Given valid exercise")
+  public class GivenValidExerciseWithTwoPauses {
+
+    private final Instant exerciseStartTime = Instant.parse("2012-11-21T04:00:00Z");
+
+    public ExerciseComposer.Composer getExerciseComposer() {
+      return exerciseComposer
+          .forExercise(ExerciseFixture.createRunningAttackExercise(exerciseStartTime))
+          .withInject(
+              injectComposer.forInject(
+                  InjectFixture.getDefaultInjectWithDuration(600L))); // run time 04:10
+    }
+
+    @Nested
+    @DisplayName("With two pauses, one of which starts after original inject time")
+    public class WithTwoPauses {
+
+      private final Instant firstPauseStartTime = Instant.parse("2012-11-21T04:02:00Z");
+      private final Instant secondPauseStartTime = Instant.parse("2012-11-21T04:15:00Z");
+
+      @Test
+      @DisplayName(
+          "When the inject was affected by both pauses its starting date should account for both pauses")
+      public void WhenInjectEffectivelyWasPausedTwice_InjectDateAccountsForBothPauses() {
+        Exercise exercise =
+            getExerciseComposer()
+                .withPause(
+                    pauseComposer.forPause(
+                        // first pause duration brings wakeup close to second pause start
+                        // so that inject does not run in between
+                        PauseFixture.createPause(firstPauseStartTime, 600L))) // wakeup 04:12
+                .withPause(
+                    pauseComposer.forPause(
+                        PauseFixture.createPause(secondPauseStartTime, 3600L))) // wakeup 05:15
+                .get();
+        Instant expected_instant = Instant.parse("2012-11-21T05:20:00Z");
+
+        Inject inject = exercise.getInjects().getFirst();
+
+        Assertions.assertTrue(inject.getDate().isPresent(), "Inject has no date.");
+        Assertions.assertEquals(expected_instant, inject.getDate().get());
+      }
+
+      @Test
+      @DisplayName(
+          "When the inject was affected by first pause only its starting date should account for first pause only")
+      public void WhenInjectEffectivelyWasPausedOnce_InjectDateAccountsForSinglePause() {
+        Exercise exercise =
+            getExerciseComposer()
+                .withPause(
+                    pauseComposer.forPause(
+                        // first pause is short enough so that inject runs before second pause
+                        // the pause will effectively delay inject by a single minute
+                        PauseFixture.createPause(
+                            firstPauseStartTime, 15L))) // wakeup 04:02:15, effective 04:03:00
+                .withPause(
+                    pauseComposer.forPause(
+                        PauseFixture.createPause(secondPauseStartTime, 3600L))) // wakeup 05:15
+                .get();
+        Instant expected_instant = Instant.parse("2012-11-21T04:11:00Z");
+
+        Inject inject = exercise.getInjects().getFirst();
+
+        Assertions.assertTrue(inject.getDate().isPresent(), "Inject has no date.");
+        Assertions.assertEquals(expected_instant, inject.getDate().get());
+      }
+    }
+  }
+}

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectFixture.java
@@ -58,6 +58,13 @@ public class InjectFixture {
     return inject;
   }
 
+  public static Inject getDefaultInjectWithDuration(long duration) {
+    Inject inject = createInjectWithDefaultTitle();
+    inject.setEnabled(true);
+    inject.setDependsDuration(duration);
+    return inject;
+  }
+
   public static Inject getInjectForEmailContract(InjectorContract injectorContract) {
     return createInject(injectorContract, INJECT_EMAIL_NAME);
   }

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/PauseFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/PauseFixture.java
@@ -1,0 +1,13 @@
+package io.openbas.utils.fixtures;
+
+import io.openbas.database.model.Pause;
+import java.time.Instant;
+
+public class PauseFixture {
+  public static Pause createPause(Instant start, long duration) {
+    Pause pause = new Pause();
+    pause.setDuration(duration);
+    pause.setDate(start);
+    return pause;
+  }
+}

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/ExerciseComposer.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/ExerciseComposer.java
@@ -23,6 +23,7 @@ public class ExerciseComposer extends ComposerBase<Exercise> {
     private final List<TagComposer.Composer> tagComposers = new ArrayList<>();
     private final List<DocumentComposer.Composer> documentComposers = new ArrayList<>();
     private final List<VariableComposer.Composer> variableComposers = new ArrayList<>();
+    private final List<PauseComposer.Composer> pauseComposers = new ArrayList<>();
 
     public Composer(Exercise exercise) {
       this.exercise = exercise;
@@ -39,6 +40,7 @@ public class ExerciseComposer extends ComposerBase<Exercise> {
     public Composer withInject(InjectComposer.Composer injectComposer) {
       injectComposers.add(injectComposer);
       List<Inject> injects = exercise.getInjects();
+      injectComposer.get().setExercise(exercise);
       injects.add(injectComposer.get());
       this.exercise.setInjects(injects);
       return this;
@@ -113,6 +115,14 @@ public class ExerciseComposer extends ComposerBase<Exercise> {
       return this;
     }
 
+    public Composer withPause(PauseComposer.Composer pauseComposer) {
+      this.pauseComposers.add(pauseComposer);
+      List<Pause> tempPauses = this.exercise.getPauses();
+      tempPauses.add(pauseComposer.get());
+      this.exercise.setPauses(tempPauses);
+      return this;
+    }
+
     public Composer withId(String id) {
       this.exercise.setId(id);
       return this;
@@ -128,6 +138,7 @@ public class ExerciseComposer extends ComposerBase<Exercise> {
       this.tagComposers.forEach(TagComposer.Composer::persist);
       this.documentComposers.forEach(DocumentComposer.Composer::persist);
       this.variableComposers.forEach(VariableComposer.Composer::persist);
+      this.pauseComposers.forEach(PauseComposer.Composer::persist);
       exerciseRepository.save(exercise);
       return this;
     }
@@ -143,6 +154,7 @@ public class ExerciseComposer extends ComposerBase<Exercise> {
       this.teamComposers.forEach(TeamComposer.Composer::delete);
       this.categoryComposers.forEach(LessonsCategoryComposer.Composer::delete);
       this.articleComposers.forEach(ArticleComposer.Composer::delete);
+      this.pauseComposers.forEach(PauseComposer.Composer::delete);
       return this;
     }
 

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/PauseComposer.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/PauseComposer.java
@@ -1,0 +1,41 @@
+package io.openbas.utils.fixtures.composers;
+
+import io.openbas.database.model.Pause;
+import io.openbas.database.repository.PauseRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PauseComposer extends ComposerBase<Pause> {
+  @Autowired private PauseRepository pauseRepository;
+
+  public class Composer extends InnerComposerBase<Pause> {
+    private final Pause pause;
+
+    public Composer(Pause pause) {
+      this.pause = pause;
+    }
+
+    @Override
+    public Composer persist() {
+      pauseRepository.save(pause);
+      return this;
+    }
+
+    @Override
+    public Composer delete() {
+      pauseRepository.delete(pause);
+      return this;
+    }
+
+    @Override
+    public Pause get() {
+      return this.pause;
+    }
+  }
+
+  public Composer forPause(Pause pause) {
+    this.generatedItems.add(pause);
+    return new Composer(pause);
+  }
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Correctly account for pause times in inject start date computation

### Related issues

* Closes #2282 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Tests are better implemented with composers hence I propose this PR to release branch. Another PR with just the code fix is going to master.

There's a drive-by fix on the schema because current pause was being persisted assuming the provided instant was local time, when in reality it was provided as UTC => the backend would compute an incorrect UTC time to persist. It was low impact but needed to be addressed.