### PR TITLE
[frontend] Correct spacing between papers in endpoint details page (#2348)

### DIFF
--- a/openbas-front/src/admin/components/assets/endpoints/endpoint/Endpoint.tsx
+++ b/openbas-front/src/admin/components/assets/endpoints/endpoint/Endpoint.tsx
@@ -140,7 +140,7 @@ const Endpoint = () => {
             </Grid>
           </Paper>
         </Grid>
-        <Grid item xs={12} style={{ marginTop: 10 }}>
+        <Grid item xs={12}>
           <Typography variant="h4" style={{ float: 'left' }}>
             {t('Agents')}
           </Typography>


### PR DESCRIPTION
#2348
