### PR TITLE
[backend] Adding swagger documentation on Settings Api endpoints

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/settings/PlatformSettingsApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/PlatformSettingsApi.java
@@ -2,6 +2,7 @@ package io.openbas.rest.settings;
 
 import static io.openbas.database.model.User.ROLE_ADMIN;
 
+import io.openbas.aop.UserRoleDescription;
 import io.openbas.rest.helper.RestBehavior;
 import io.openbas.rest.settings.form.PolicyInput;
 import io.openbas.rest.settings.form.SettingsEnterpriseEditionUpdateInput;
@@ -10,6 +11,11 @@ import io.openbas.rest.settings.form.SettingsUpdateInput;
 import io.openbas.rest.settings.form.ThemeInput;
 import io.openbas.rest.settings.response.PlatformSettings;
 import io.openbas.service.PlatformSettingsService;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
@@ -21,6 +27,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/settings")
 @RestController
+@UserRoleDescription
+@Tag(
+    name = "Settings management",
+    description = "Endpoints to manage settings",
+    externalDocs =
+        @ExternalDocumentation(
+            description = "Documentation about settings",
+            url = "https://docs.openbas.io/latest/administration/parameters/"))
 public class PlatformSettingsApi extends RestBehavior {
 
   private PlatformSettingsService platformSettingsService;
@@ -31,12 +45,16 @@ public class PlatformSettingsApi extends RestBehavior {
   }
 
   @GetMapping()
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The list of settings")})
+  @Operation(summary = "List settings", description = "Return the settings")
   public PlatformSettings settings() {
     return platformSettingsService.findSettings();
   }
 
   @Secured(ROLE_ADMIN)
   @PutMapping()
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The updated settings")})
+  @Operation(summary = "Update settings", description = "Update the settings")
   public PlatformSettings updateBasicConfigurationSettings(
       @Valid @RequestBody SettingsUpdateInput input) {
     return platformSettingsService.updateBasicConfigurationSettings(input);
@@ -44,6 +62,8 @@ public class PlatformSettingsApi extends RestBehavior {
 
   @Secured(ROLE_ADMIN)
   @PutMapping("/enterprise_edition")
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The updated settings")})
+  @Operation(summary = "Update EE settings", description = "Update the enterprise edition settings")
   public PlatformSettings updateSettingsEnterpriseEdition(
       @Valid @RequestBody SettingsEnterpriseEditionUpdateInput input) {
     return platformSettingsService.updateSettingsEnterpriseEdition(input);
@@ -51,6 +71,8 @@ public class PlatformSettingsApi extends RestBehavior {
 
   @Secured(ROLE_ADMIN)
   @PutMapping("/platform_whitemark")
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The updated settings")})
+  @Operation(summary = "Update Whitemark settings", description = "Update the whitemark settings")
   public PlatformSettings updateSettingsPlatformWhitemark(
       @Valid @RequestBody SettingsPlatformWhitemarkUpdateInput input) {
     return platformSettingsService.updateSettingsPlatformWhitemark(input);
@@ -58,18 +80,26 @@ public class PlatformSettingsApi extends RestBehavior {
 
   @Secured(ROLE_ADMIN)
   @PutMapping("/theme/light")
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The updated settings")})
+  @Operation(
+      summary = "Update light theme settings",
+      description = "Update the light theme settings")
   public PlatformSettings updateThemeLight(@Valid @RequestBody ThemeInput input) {
     return platformSettingsService.updateThemeLight(input);
   }
 
   @Secured(ROLE_ADMIN)
   @PutMapping("/theme/dark")
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The updated settings")})
+  @Operation(summary = "Update dark theme settings", description = "Update the dark theme settings")
   public PlatformSettings updateThemeDark(@Valid @RequestBody ThemeInput input) {
     return platformSettingsService.updateThemeDark(input);
   }
 
   @Secured(ROLE_ADMIN)
   @PutMapping("/policies")
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The updated settings")})
+  @Operation(summary = "Update policies settings", description = "Update the policies settings")
   public PlatformSettings updateSettingsPolicies(@Valid @RequestBody PolicyInput input) {
     return platformSettingsService.updateSettingsPolicies(input);
   }

--- a/openbas-api/src/main/java/io/openbas/rest/settings/form/PolicyInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/form/PolicyInput.java
@@ -1,6 +1,7 @@
 package io.openbas.rest.settings.form;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,11 +10,14 @@ import lombok.Setter;
 public class PolicyInput {
 
   @JsonProperty("platform_login_message")
+  @Schema(description = "Message to show at login")
   private String loginMessage;
 
   @JsonProperty("platform_consent_message")
+  @Schema(description = "Consent message to show at login")
   private String consentMessage;
 
   @JsonProperty("platform_consent_confirm_text")
+  @Schema(description = "Consent confirmation message")
   private String consentConfirmText;
 }

--- a/openbas-api/src/main/java/io/openbas/rest/settings/form/SettingsEnterpriseEditionUpdateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/form/SettingsEnterpriseEditionUpdateInput.java
@@ -3,6 +3,7 @@ package io.openbas.rest.settings.form;
 import static io.openbas.config.AppConfig.MANDATORY_MESSAGE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,5 +13,6 @@ import lombok.Setter;
 public class SettingsEnterpriseEditionUpdateInput {
   @NotBlank(message = MANDATORY_MESSAGE)
   @JsonProperty("platform_enterprise_edition")
+  @Schema(description = "'true' if enterprise edition is activated")
   private String enterpriseEdition;
 }

--- a/openbas-api/src/main/java/io/openbas/rest/settings/form/SettingsPlatformWhitemarkUpdateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/form/SettingsPlatformWhitemarkUpdateInput.java
@@ -13,6 +13,6 @@ import lombok.Setter;
 public class SettingsPlatformWhitemarkUpdateInput {
   @NotBlank(message = MANDATORY_MESSAGE)
   @JsonProperty("platform_whitemark")
-  @Schema(description = "The whitepark of the platform")
+  @Schema(description = "The whitemark of the platform")
   private String platformWhitemark;
 }

--- a/openbas-api/src/main/java/io/openbas/rest/settings/form/SettingsPlatformWhitemarkUpdateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/form/SettingsPlatformWhitemarkUpdateInput.java
@@ -3,6 +3,7 @@ package io.openbas.rest.settings.form;
 import static io.openbas.config.AppConfig.MANDATORY_MESSAGE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,5 +13,6 @@ import lombok.Setter;
 public class SettingsPlatformWhitemarkUpdateInput {
   @NotBlank(message = MANDATORY_MESSAGE)
   @JsonProperty("platform_whitemark")
+  @Schema(description = "The whitepark of the platform")
   private String platformWhitemark;
 }

--- a/openbas-api/src/main/java/io/openbas/rest/settings/form/SettingsUpdateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/form/SettingsUpdateInput.java
@@ -3,6 +3,7 @@ package io.openbas.rest.settings.form;
 import static io.openbas.config.AppConfig.MANDATORY_MESSAGE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,13 +14,16 @@ public class SettingsUpdateInput {
 
   @NotBlank(message = MANDATORY_MESSAGE)
   @JsonProperty("platform_name")
+  @Schema(description = "Name of the platform")
   private String name;
 
   @NotBlank(message = MANDATORY_MESSAGE)
   @JsonProperty("platform_theme")
+  @Schema(description = "Theme of the platform")
   private String theme;
 
   @NotBlank(message = MANDATORY_MESSAGE)
   @JsonProperty("platform_lang")
+  @Schema(description = "Language of the platform")
   private String lang;
 }

--- a/openbas-api/src/main/java/io/openbas/rest/settings/form/ThemeInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/form/ThemeInput.java
@@ -1,6 +1,7 @@
 package io.openbas.rest.settings.form;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Setter
@@ -10,29 +11,38 @@ import lombok.*;
 public class ThemeInput {
 
   @JsonProperty("background_color")
+  @Schema(description = "Background color of the theme")
   private String backgroundColor;
 
   @JsonProperty("paper_color")
+  @Schema(description = "Paper color of the theme")
   private String paperColor;
 
   @JsonProperty("navigation_color")
+  @Schema(description = "Navigation color of the theme")
   private String NavigationColor;
 
   @JsonProperty("primary_color")
+  @Schema(description = "Primary color of the theme")
   private String primaryColor;
 
   @JsonProperty("secondary_color")
+  @Schema(description = "Secondary color of the theme")
   private String secondaryColor;
 
   @JsonProperty("accent_color")
+  @Schema(description = "Accent color of the theme")
   private String accentColor;
 
   @JsonProperty("logo_url")
+  @Schema(description = "Url of the logo")
   private String logoUrl;
 
   @JsonProperty("logo_url_collapsed")
+  @Schema(description = "'true' if the logo needs to be collapsed")
   private String logoUrlCollapsed;
 
   @JsonProperty("logo_login_url")
+  @Schema(description = "Url of the login logo")
   private String logoLoginUrl;
 }

--- a/openbas-api/src/main/java/io/openbas/rest/settings/response/PlatformSettings.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/response/PlatformSettings.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openbas.rest.settings.PreviewFeature;
 import io.openbas.rest.settings.form.PolicyInput;
 import io.openbas.rest.settings.form.ThemeInput;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -44,7 +45,7 @@ public class PlatformSettings {
   private String platformLang;
 
   @JsonProperty("platform_enterprise_edition")
-  @Schema(description = "'true' if the platform has enterprise edition activated")
+  @Schema(description = "'true' if the platform has Enterprise Edition activated")
   private String platformEnterpriseEdition;
 
   @JsonProperty("platform_whitemark")
@@ -72,11 +73,11 @@ public class PlatformSettings {
   private Boolean authLocalEnable;
 
   @JsonProperty("map_tile_server_light")
-  @Schema(description = "Url to the server containing the map tile with light theme")
+  @Schema(description = "URL of the server containing the map tile with light theme")
   private String mapTileServerLight;
 
   @JsonProperty("map_tile_server_dark")
-  @Schema(description = "Url to the server containing the map tile with dark theme")
+  @Schema(description = "URL of the server containing the map tile with dark theme")
   private String mapTileServerDark;
 
   @JsonProperty("xtm_opencti_enable")
@@ -92,15 +93,15 @@ public class PlatformSettings {
   private String platformVersion;
 
   @JsonProperty("postgre_version")
-  @Schema(description = "Current version of the PGSQL")
+  @Schema(description = "Current version of the PostgreSQL")
   private String postgreVersion;
 
   @JsonProperty("java_version")
-  @Schema(description = "Current version of the Java")
+  @Schema(description = "Current version of Java")
   private String javaVersion;
 
   @JsonProperty("rabbitmq_version")
-  @Schema(description = "Current version of the RabbitMQ")
+  @Schema(description = "Current version of RabbitMQ")
   private String rabbitMQVersion;
 
   @JsonProperty("platform_ai_enabled")
@@ -112,15 +113,21 @@ public class PlatformSettings {
   private Boolean aiHasToken;
 
   @JsonProperty("platform_ai_type")
-  @Schema(description = "Type of AI")
+  @Schema(
+      description = "Type of AI (mistralai or openai)",
+      externalDocs =
+          @ExternalDocumentation(
+              description = "How to configure AI service",
+              url =
+                  "https://docs.openbas.io/latest/deployment/configuration/?h=ai+type#ai-service"))
   private String aiType;
 
   @JsonProperty("platform_ai_model")
-  @Schema(description = "Model chosen of AI")
+  @Schema(description = "Chosen model of AI")
   private String aiModel;
 
   @JsonProperty("executor_caldera_enable")
-  @Schema(description = "True if the Caldera Executor is enabled")
+  @Schema(description = "'true' if the Caldera Executor is enabled")
   private Boolean executorCalderaEnable;
 
   @JsonProperty("executor_caldera_public_url")
@@ -128,17 +135,17 @@ public class PlatformSettings {
   private String executorCalderaPublicUrl;
 
   @JsonProperty("executor_tanium_enable")
-  @Schema(description = "True if the Tanium Executor is enabled")
+  @Schema(description = "'true' if the Tanium Executor is enabled")
   private Boolean executorTaniumEnable;
 
   // THEME
 
   @JsonProperty("platform_light_theme")
-  @Schema(description = "Description of the light theme")
+  @Schema(description = "Definition of the light theme")
   private ThemeInput themeLight;
 
   @JsonProperty("platform_dark_theme")
-  @Schema(description = "Description of the dark theme")
+  @Schema(description = "Definition of the dark theme")
   private ThemeInput themeDark;
 
   // POLICIES
@@ -203,10 +210,10 @@ public class PlatformSettings {
 
   // EMAIL CONFIG
   @JsonProperty("default_mailer")
-  @Schema(description = "Mail to use by default")
+  @Schema(description = "Sender mail to use by default for injects")
   private String defaultMailer;
 
   @JsonProperty("default_reply_to")
-  @Schema(description = "Reply to to use by default")
+  @Schema(description = "Reply to mail to use by default for injects")
   private String defaultReplyTo;
 }

--- a/openbas-api/src/main/java/io/openbas/rest/settings/response/PlatformSettings.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/response/PlatformSettings.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openbas.rest.settings.PreviewFeature;
 import io.openbas.rest.settings.form.PolicyInput;
 import io.openbas.rest.settings.form.ThemeInput;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,106 +24,140 @@ import lombok.Setter;
 public class PlatformSettings {
 
   @JsonProperty("platform_name")
+  @Schema(description = "Name of the platform")
   private String platformName;
 
   @JsonProperty("platform_base_url")
+  @Schema(description = "Base URL of the platform")
   private String platformBaseUrl;
 
   @JsonProperty("platform_agent_url")
+  @Schema(description = "Agent URL of the platform")
   private String platformAgentUrl;
 
   @JsonProperty("platform_theme")
+  @Schema(description = "Theme of the platform")
   private String platformTheme;
 
   @JsonProperty("platform_lang")
+  @Schema(description = "Language of the platform")
   private String platformLang;
 
   @JsonProperty("platform_enterprise_edition")
+  @Schema(description = "'true' if the platform has enterprise edition activated")
   private String platformEnterpriseEdition;
 
   @JsonProperty("platform_whitemark")
+  @Schema(description = "'true' if the platform has the whitemark activated")
   private String platformWhitemark;
 
   @JsonProperty("platform_openid_providers")
+  @Schema(description = "List of OpenID providers")
   private List<OAuthProvider> platformOpenIdProviders;
 
   @JsonProperty("platform_saml2_providers")
+  @Schema(description = "List of Saml2 providers")
   private List<OAuthProvider> platformSaml2Providers;
 
   @JsonProperty("auth_openid_enable")
+  @Schema(description = "True if OpenID is enabled")
   private Boolean authOpenidEnable;
 
   @JsonProperty("auth_saml2_enable")
+  @Schema(description = "True if Saml2 is enabled")
   private Boolean authSaml2Enable;
 
   @JsonProperty("auth_local_enable")
+  @Schema(description = "True if local authentication is enabled")
   private Boolean authLocalEnable;
 
   @JsonProperty("map_tile_server_light")
+  @Schema(description = "Url to the server containing the map tile with light theme")
   private String mapTileServerLight;
 
   @JsonProperty("map_tile_server_dark")
+  @Schema(description = "Url to the server containing the map tile with dark theme")
   private String mapTileServerDark;
 
   @JsonProperty("xtm_opencti_enable")
+  @Schema(description = "True if connection with OpenCTI is enabled")
   private Boolean xtmOpenctiEnable;
 
   @JsonProperty("xtm_opencti_url")
+  @Schema(description = "Url of OpenCTI")
   private String xtmOpenctiUrl;
 
   @JsonProperty("platform_version")
+  @Schema(description = "Current version of the platform")
   private String platformVersion;
 
   @JsonProperty("postgre_version")
+  @Schema(description = "Current version of the PGSQL")
   private String postgreVersion;
 
   @JsonProperty("java_version")
+  @Schema(description = "Current version of the Java")
   private String javaVersion;
 
   @JsonProperty("rabbitmq_version")
+  @Schema(description = "Current version of the RabbitMQ")
   private String rabbitMQVersion;
 
   @JsonProperty("platform_ai_enabled")
+  @Schema(description = "True if AI is enabled for the platform")
   private Boolean aiEnabled;
 
   @JsonProperty("platform_ai_has_token")
+  @Schema(description = "True if we have an AI token")
   private Boolean aiHasToken;
 
   @JsonProperty("platform_ai_type")
+  @Schema(description = "Type of AI")
   private String aiType;
 
   @JsonProperty("platform_ai_model")
+  @Schema(description = "Model chosen of AI")
   private String aiModel;
 
   @JsonProperty("executor_caldera_enable")
+  @Schema(description = "True if the Caldera Executor is enabled")
   private Boolean executorCalderaEnable;
 
   @JsonProperty("executor_caldera_public_url")
+  @Schema(description = "Url of the Caldera Executor")
   private String executorCalderaPublicUrl;
 
   @JsonProperty("executor_tanium_enable")
+  @Schema(description = "True if the Tanium Executor is enabled")
   private Boolean executorTaniumEnable;
 
   // THEME
 
   @JsonProperty("platform_light_theme")
+  @Schema(description = "Description of the light theme")
   private ThemeInput themeLight;
 
   @JsonProperty("platform_dark_theme")
+  @Schema(description = "Description of the dark theme")
   private ThemeInput themeDark;
 
   // POLICIES
 
   @JsonProperty("platform_policies")
+  @Schema(description = "Policies of the platform")
   private PolicyInput policies;
 
   // FEATURE FLAG
   @JsonProperty("enabled_dev_features")
+  @Schema(description = "List of enabled dev features")
   private List<PreviewFeature> enabledDevFeatures = new ArrayList<>();
 
   // PLATFORM MESSAGE
   @JsonProperty("platform_banner_by_level")
   @Getter(NONE)
+  @Schema(
+      description =
+          "Map of the messages to display on the screen by their level (the level available are DEBUG, INFO, WARN, ERROR, FATAL)")
   private Map<String, List<String>> platformBannerByLevel;
 
   public Map<String, List<String>> getPlatformBannerByLevel() {
@@ -138,32 +173,40 @@ public class PlatformSettings {
   // EXPECTATION
   @NotNull
   @JsonProperty("expectation_detection_expiration_time")
+  @Schema(description = "Time to wait before detection time has expired")
   private long detectionExpirationTime;
 
   @NotNull
   @JsonProperty("expectation_prevention_expiration_time")
+  @Schema(description = "Time to wait before prevention time has expired")
   private long preventionExpirationTime;
 
   @NotNull
   @JsonProperty("expectation_challenge_expiration_time")
+  @Schema(description = "Time to wait before challenge time has expired")
   private long challengeExpirationTime;
 
   @NotNull
   @JsonProperty("expectation_article_expiration_time")
+  @Schema(description = "Time to wait before article time has expired")
   private long articleExpirationTime;
 
   @NotNull
   @JsonProperty("expectation_manual_expiration_time")
+  @Schema(description = "Time to wait before manual expectation time has expired")
   private long manualExpirationTime;
 
   @NotNull
   @JsonProperty("expectation_manual_default_score_value")
+  @Schema(description = "Default score for manuel expectation")
   private int expectationDefaultScoreValue;
 
   // EMAIL CONFIG
   @JsonProperty("default_mailer")
+  @Schema(description = "Mail to use by default")
   private String defaultMailer;
 
   @JsonProperty("default_reply_to")
+  @Schema(description = "Reply to to use by default")
   private String defaultReplyTo;
 }

--- a/openbas-api/src/main/java/io/openbas/rest/settings/response/PlatformSettings.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/response/PlatformSettings.java
@@ -127,7 +127,7 @@ public class PlatformSettings {
   private String aiModel;
 
   @JsonProperty("executor_caldera_enable")
-  @Schema(description = "'true' if the Caldera Executor is enabled")
+  @Schema(description = "True if the Caldera Executor is enabled")
   private Boolean executorCalderaEnable;
 
   @JsonProperty("executor_caldera_public_url")
@@ -135,7 +135,7 @@ public class PlatformSettings {
   private String executorCalderaPublicUrl;
 
   @JsonProperty("executor_tanium_enable")
-  @Schema(description = "'true' if the Tanium Executor is enabled")
+  @Schema(description = "True if the Tanium Executor is enabled")
   private Boolean executorTaniumEnable;
 
   // THEME


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Adding swagger documentation on Settings Api endpoints
*

### Related issues

* 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
