### PR TITLE
[backend] fix: Filters issue on not contains, empty and not empty

### DIFF
--- a/openbas-framework/src/main/java/io/openbas/utils/FilterUtilsJpa.java
+++ b/openbas-framework/src/main/java/io/openbas/utils/FilterUtilsJpa.java
@@ -77,7 +77,7 @@ public class FilterUtilsJpa {
   @SuppressWarnings("unchecked")
   private static <T, U> Specification<T> computeFilter(
       @Nullable final Filter filter, Map<String, Join<Base, Base>> joinMap) {
-    if (filter == null || filter.getValues() == null || filter.getValues().isEmpty()) {
+    if (filter == null) {
       return (Specification<T>) EMPTY_SPECIFICATION;
     }
     String filterKey = filter.getKey();

--- a/openbas-framework/src/main/java/io/openbas/utils/OperationUtilsJpa.java
+++ b/openbas-framework/src/main/java/io/openbas/utils/OperationUtilsJpa.java
@@ -22,20 +22,9 @@ public class OperationUtilsJpa {
     }
 
     Predicate[] predicates =
-        texts.stream()
-            .map(text -> notContainsText(paths, cb, text, type))
-            .toArray(Predicate[]::new);
+        texts.stream().map(text -> containsText(paths, cb, text, type)).toArray(Predicate[]::new);
 
-    return cb.or(predicates);
-  }
-
-  public static Predicate notContainsText(
-      Expression<String> paths, CriteriaBuilder cb, String text, Class<?> type) {
-    if (isEmpty(text)) {
-      return cb.conjunction();
-    }
-
-    return containsText(paths, cb, text, type).not();
+    return cb.or(predicates).not();
   }
 
   // -- CONTAINS --


### PR DESCRIPTION
### Proposed changes

* [backend] fix: fixed an issue where the OR was treated as an AND in filters for "not contains" operator
* [backend] fix: fixed an issue where filter's operator "empty" and "not empty" didn't work

### Related issues

* Relates to #1958 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
