### PR TITLE
[backend/frontend] Fix update result expectation from collectors

### DIFF
--- a/openbas-api/src/main/java/io/openbas/collectors/expectations_expiration_manager/service/ExpectationsExpirationManagerService.java
+++ b/openbas-api/src/main/java/io/openbas/collectors/expectations_expiration_manager/service/ExpectationsExpirationManagerService.java
@@ -36,7 +36,9 @@ public class ExpectationsExpirationManagerService {
 
   // -- PRIVATE --
   private void computeExpectations(@NotNull final List<InjectExpectation> expectations) {
-    expectations.forEach(
+    List<InjectExpectation> remainingExpectations =
+        expectations.stream().filter(exp -> exp.getScore() == null).toList();
+    remainingExpectations.forEach(
         expectation -> {
           if (isExpired(expectation)) {
             String result = computeFailedMessage(expectation.getType());

--- a/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
@@ -530,6 +530,7 @@ public class InjectExpectationService {
   }
 
   private boolean isSuccess(List<InjectExpectation> expectations, boolean isGroup) {
+    if (expectations.isEmpty()) return false;
     return isGroup
         ? expectations.stream().anyMatch(e -> e.getExpectedScore().equals(e.getScore()))
         : expectations.stream().allMatch(e -> e.getExpectedScore().equals(e.getScore()));

--- a/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
@@ -561,7 +561,7 @@ public class InjectExpectationService {
         sourceId,
         sourceType,
         sourceName,
-        success ? "SUCCESS" : "FAILED",
+        successScoreResult ? "SUCCESS" : "FAILED",
         successScoreResult ? finalScore : 0.0,
         null);
     expectation.setScore(finalScore);

--- a/openbas-api/src/test/java/io/openbas/rest/ExpectationApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/ExpectationApiTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jayway.jsonpath.JsonPath;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.openbas.IntegrationTest;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.*;
@@ -62,6 +63,7 @@ public class ExpectationApiTest extends IntegrationTest {
   private static Agent savedAgent1;
   private static Inject savedInject;
   private static Collector savedCollector;
+  private static Collector savedCollector2;
 
   @BeforeAll
   void beforeAll() {
@@ -96,6 +98,13 @@ public class ExpectationApiTest extends IntegrationTest {
     collector.setType(UUID.randomUUID().toString());
     collector.setExternal(true);
     savedCollector = collectorRepository.save(collector);
+
+    Collector collector2 = new Collector();
+    collector.setId(UUID.randomUUID().toString());
+    collector.setName("collector-2-name");
+    collector.setType(UUID.randomUUID().toString());
+    collector.setExternal(true);
+    savedCollector2 = collectorRepository.save(collector2);
   }
 
   @AfterAll
@@ -104,6 +113,7 @@ public class ExpectationApiTest extends IntegrationTest {
     injectRepository.deleteAll();
     endpointRepository.deleteAll();
     collectorRepository.deleteById(savedCollector.getId());
+    collectorRepository.deleteById(savedCollector2.getId());
   }
 
   @AfterEach
@@ -690,7 +700,7 @@ public class ExpectationApiTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("Update Inject expectation from collector one success and one failed")
+    @DisplayName("Update Inject expectation from collector and two agents : one success and one failed")
     void updateInjectExpectationWithOneSuccessAndOneFailed() throws Exception {
       // -- PREPARE --
       // Build and save expectations for an asset with 2 agents
@@ -859,9 +869,7 @@ public class ExpectationApiTest extends IntegrationTest {
                   .content(asJsonString(expectationUpdateInput))
                   .contentType(MediaType.APPLICATION_JSON)
                   .accept(MediaType.APPLICATION_JSON))
-          .andReturn()
-          .getResponse()
-          .getContentAsString();
+          .andExpect(status().is2xxSuccessful());
 
       // -- ASSERT --
       assertEquals(
@@ -902,9 +910,7 @@ public class ExpectationApiTest extends IntegrationTest {
                   .content(asJsonString(expectationUpdateInput))
                   .contentType(MediaType.APPLICATION_JSON)
                   .accept(MediaType.APPLICATION_JSON))
-          .andReturn()
-          .getResponse()
-          .getContentAsString();
+          .andExpect(status().is2xxSuccessful());
 
       // -- ASSERT --
       assertEquals(
@@ -933,4 +939,79 @@ public class ExpectationApiTest extends IntegrationTest {
               .getScore());
     }
   }
+    @Test
+    @DisplayName("Update Inject expectation from two collectors with one agent")
+    void updateInjectExpectationFromTwoCollectors() throws Exception {
+      // -- PREPARE --
+      // Build and save expectations for an asset with 2 agents
+      ExecutableInject executableInject =
+          new ExecutableInject(
+              false,
+              true,
+              savedInject,
+              emptyList(),
+              List.of(savedEndpoint),
+              List.of(savedAssetGroup),
+              emptyList());
+      DetectionExpectation detectionExpectationForAssetGroup =
+          ExpectationFixture.createDetectionExpectationForAssetGroup(
+              savedAssetGroup, EXPIRATION_TIME_SIX_HOURS);
+      DetectionExpectation detectionExpectationForAsset =
+          ExpectationFixture.createTechnicalDetectionExpectationForAsset(
+              savedEndpoint, EXPIRATION_TIME_SIX_HOURS);
+      DetectionExpectation detectionExpectationAgent =
+          ExpectationFixture.createTechnicalDetectionExpectation(
+              savedAgent, savedEndpoint, EXPIRATION_TIME_SIX_HOURS, emptyList());
+
+      injectExpectationService.buildAndSaveInjectExpectations(
+          executableInject,
+          List.of(
+              detectionExpectationForAssetGroup,
+              detectionExpectationForAsset,
+              detectionExpectationAgent));
+
+      // Fetch injectExpectation created for agent
+      List<InjectExpectation> injectExpectations =
+          injectExpectationRepository.findAllByInjectAndAgent(
+              savedInject.getId(), savedAgent.getId());
+      InjectExpectationUpdateInput expectationUpdateInput =
+          getInjectExpectationUpdateInput(savedCollector.getId(), "Detected", true);
+      InjectExpectationUpdateInput expectationUpdateInput2 =
+          getInjectExpectationUpdateInput(savedCollector2.getId(), "Not Detected", false);
+
+      // -- EXECUTE --
+      mvc.perform(
+              put(INJECTS_EXPECTATIONS_URI + "/" + injectExpectations.get(0).getId())
+                  .content(asJsonString(expectationUpdateInput))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().is2xxSuccessful());
+
+      mvc.perform(
+              put(INJECTS_EXPECTATIONS_URI + "/" + injectExpectations.get(0).getId())
+                  .content(asJsonString(expectationUpdateInput2))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().is2xxSuccessful());
+
+      // -- ASSERT --
+      assertEquals(
+          2,
+          injectExpectationRepository
+              .findAllByInjectAndAssetGroup(savedInject.getId(), savedAssetGroup.getId())
+              .getFirst()
+              .getResults().size());
+      assertEquals(
+          null,
+          injectExpectationRepository
+              .findAllByInjectAndAsset(savedInject.getId(), savedEndpoint.getId())
+              .getFirst()
+              .getResults());
+      assertEquals(
+          null,
+          injectExpectationRepository
+              .findAllByInjectAndAgent(savedInject.getId(), savedAgent.getId())
+              .getFirst()
+              .getResults());
+    }
 }

--- a/openbas-api/src/test/java/io/openbas/rest/ExpectationApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/ExpectationApiTest.java
@@ -12,7 +12,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jayway.jsonpath.JsonPath;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.openbas.IntegrationTest;
 import io.openbas.database.model.*;
 import io.openbas.database.repository.*;
@@ -700,7 +699,8 @@ public class ExpectationApiTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("Update Inject expectation from collector and two agents : one success and one failed")
+    @DisplayName(
+        "Update Inject expectation from collector and two agents : one success and one failed")
     void updateInjectExpectationWithOneSuccessAndOneFailed() throws Exception {
       // -- PREPARE --
       // Build and save expectations for an asset with 2 agents
@@ -939,79 +939,81 @@ public class ExpectationApiTest extends IntegrationTest {
               .getScore());
     }
   }
-    @Test
-    @DisplayName("Update Inject expectation from two collectors with one agent")
-    void updateInjectExpectationFromTwoCollectors() throws Exception {
-      // -- PREPARE --
-      // Build and save expectations for an asset with 2 agents
-      ExecutableInject executableInject =
-          new ExecutableInject(
-              false,
-              true,
-              savedInject,
-              emptyList(),
-              List.of(savedEndpoint),
-              List.of(savedAssetGroup),
-              emptyList());
-      DetectionExpectation detectionExpectationForAssetGroup =
-          ExpectationFixture.createDetectionExpectationForAssetGroup(
-              savedAssetGroup, EXPIRATION_TIME_SIX_HOURS);
-      DetectionExpectation detectionExpectationForAsset =
-          ExpectationFixture.createTechnicalDetectionExpectationForAsset(
-              savedEndpoint, EXPIRATION_TIME_SIX_HOURS);
-      DetectionExpectation detectionExpectationAgent =
-          ExpectationFixture.createTechnicalDetectionExpectation(
-              savedAgent, savedEndpoint, EXPIRATION_TIME_SIX_HOURS, emptyList());
 
-      injectExpectationService.buildAndSaveInjectExpectations(
-          executableInject,
-          List.of(
-              detectionExpectationForAssetGroup,
-              detectionExpectationForAsset,
-              detectionExpectationAgent));
+  @Test
+  @DisplayName("Update Inject expectation from two collectors with one agent")
+  void updateInjectExpectationFromTwoCollectors() throws Exception {
+    // -- PREPARE --
+    // Build and save expectations for an asset with 2 agents
+    ExecutableInject executableInject =
+        new ExecutableInject(
+            false,
+            true,
+            savedInject,
+            emptyList(),
+            List.of(savedEndpoint),
+            List.of(savedAssetGroup),
+            emptyList());
+    DetectionExpectation detectionExpectationForAssetGroup =
+        ExpectationFixture.createDetectionExpectationForAssetGroup(
+            savedAssetGroup, EXPIRATION_TIME_SIX_HOURS);
+    DetectionExpectation detectionExpectationForAsset =
+        ExpectationFixture.createTechnicalDetectionExpectationForAsset(
+            savedEndpoint, EXPIRATION_TIME_SIX_HOURS);
+    DetectionExpectation detectionExpectationAgent =
+        ExpectationFixture.createTechnicalDetectionExpectation(
+            savedAgent, savedEndpoint, EXPIRATION_TIME_SIX_HOURS, emptyList());
 
-      // Fetch injectExpectation created for agent
-      List<InjectExpectation> injectExpectations =
-          injectExpectationRepository.findAllByInjectAndAgent(
-              savedInject.getId(), savedAgent.getId());
-      InjectExpectationUpdateInput expectationUpdateInput =
-          getInjectExpectationUpdateInput(savedCollector.getId(), "Detected", true);
-      InjectExpectationUpdateInput expectationUpdateInput2 =
-          getInjectExpectationUpdateInput(savedCollector2.getId(), "Not Detected", false);
+    injectExpectationService.buildAndSaveInjectExpectations(
+        executableInject,
+        List.of(
+            detectionExpectationForAssetGroup,
+            detectionExpectationForAsset,
+            detectionExpectationAgent));
 
-      // -- EXECUTE --
-      mvc.perform(
-              put(INJECTS_EXPECTATIONS_URI + "/" + injectExpectations.get(0).getId())
-                  .content(asJsonString(expectationUpdateInput))
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().is2xxSuccessful());
+    // Fetch injectExpectation created for agent
+    List<InjectExpectation> injectExpectations =
+        injectExpectationRepository.findAllByInjectAndAgent(
+            savedInject.getId(), savedAgent.getId());
+    InjectExpectationUpdateInput expectationUpdateInput =
+        getInjectExpectationUpdateInput(savedCollector.getId(), "Detected", true);
+    InjectExpectationUpdateInput expectationUpdateInput2 =
+        getInjectExpectationUpdateInput(savedCollector2.getId(), "Not Detected", false);
 
-      mvc.perform(
-              put(INJECTS_EXPECTATIONS_URI + "/" + injectExpectations.get(0).getId())
-                  .content(asJsonString(expectationUpdateInput2))
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().is2xxSuccessful());
+    // -- EXECUTE --
+    mvc.perform(
+            put(INJECTS_EXPECTATIONS_URI + "/" + injectExpectations.get(0).getId())
+                .content(asJsonString(expectationUpdateInput))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().is2xxSuccessful());
 
-      // -- ASSERT --
-      assertEquals(
-          2,
-          injectExpectationRepository
-              .findAllByInjectAndAssetGroup(savedInject.getId(), savedAssetGroup.getId())
-              .getFirst()
-              .getResults().size());
-      assertEquals(
-          null,
-          injectExpectationRepository
-              .findAllByInjectAndAsset(savedInject.getId(), savedEndpoint.getId())
-              .getFirst()
-              .getResults());
-      assertEquals(
-          null,
-          injectExpectationRepository
-              .findAllByInjectAndAgent(savedInject.getId(), savedAgent.getId())
-              .getFirst()
-              .getResults());
-    }
+    mvc.perform(
+            put(INJECTS_EXPECTATIONS_URI + "/" + injectExpectations.get(0).getId())
+                .content(asJsonString(expectationUpdateInput2))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().is2xxSuccessful());
+
+    // -- ASSERT --
+    assertEquals(
+        2,
+        injectExpectationRepository
+            .findAllByInjectAndAssetGroup(savedInject.getId(), savedAssetGroup.getId())
+            .getFirst()
+            .getResults()
+            .size());
+    assertEquals(
+        null,
+        injectExpectationRepository
+            .findAllByInjectAndAsset(savedInject.getId(), savedEndpoint.getId())
+            .getFirst()
+            .getResults());
+    assertEquals(
+        null,
+        injectExpectationRepository
+            .findAllByInjectAndAgent(savedInject.getId(), savedAgent.getId())
+            .getFirst()
+            .getResults());
+  }
 }

--- a/openbas-api/src/test/java/io/openbas/rest/ExpectationApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/ExpectationApiTest.java
@@ -973,7 +973,6 @@ public class ExpectationApiTest extends IntegrationTest {
             detectionExpectationAgent));
 
     // Add results for created injectExpectation
-
     List<InjectExpectation> injectExpectations =
         injectExpectationRepository.findAllByInjectAndAgent(
             savedInject.getId(), savedAgent.getId());
@@ -982,7 +981,6 @@ public class ExpectationApiTest extends IntegrationTest {
     InjectExpectationUpdateInput expectationUpdateInput2 =
         getInjectExpectationUpdateInput(savedCollector2.getId(), "Not Detected", false);
 
-    // -- EXECUTE --
     mvc.perform(
             put(INJECTS_EXPECTATIONS_URI + "/" + injectExpectations.get(0).getId())
                 .content(asJsonString(expectationUpdateInput))


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Currently, we have this behavior for collector results:
Score for CS result is 100 even if result is Not Prevented
![image](https://github.com/user-attachments/assets/7efd6fae-7182-4696-b8ab-2db7d441b2aa)
Result for asset parent is Success even if result for children is Not Prevented (failed)
![image](https://github.com/user-attachments/assets/51ea91ee-9d81-406d-a3f6-cc9187d68cf1)

Ex: https://prerelease.obas.staging.filigran.io/admin/simulations/0b5e8bc0-0754-4898-9da9-7233775d9a93/injects/19b8efae-b7b5-44c7-ad44-ed6a353cfd4c


So, In this PR we **Fix** this compute result for expectation when we have different kind of collectors:
Score for every result has to be coherent with response from collectors: 
-->Prevented, detected -> ExpectedScore. 
-->Not prevented, not detected -> 0

  Results for parents (assets, asset groups) have to be coherent also with response from collectors:
  -->Prevented, Detected -> Success
  -->Not prevented, not detected -> False

Assets
![image](https://github.com/user-attachments/assets/640add38-57b6-4bbd-8b56-e3b1437583fd)
![image](https://github.com/user-attachments/assets/2df3676e-c46f-443e-bdd3-46ef020bed14)

Asset groups
![image](https://github.com/user-attachments/assets/96cc1db1-2500-4093-acf0-b673e0ff4d4f)
![image](https://github.com/user-attachments/assets/bf8c8ca0-eff0-4630-a022-4b905c43e4e2)
![image](https://github.com/user-attachments/assets/d2bbd17c-dc9a-4a1f-ad8f-8416669619be)


### Related issues

* Closes #2514 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
