### PR TITLE
[frontend] translate injector type name in inject form

### DIFF
--- a/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
+++ b/openbas-front/src/admin/components/common/injects/UpdateInject.tsx
@@ -107,7 +107,7 @@ const UpdateInject: React.FC<Props> = ({ open, handleClose, onUpdateInject, mass
                 )}
               </div>
             )}
-            injectHeaderTitle={injectorContract?.injector_contract_needs_executor ? cardTitle : inject?.inject_injector_contract?.injector_contract_injector_type_name}
+            injectHeaderTitle={injectorContract?.injector_contract_needs_executor ? cardTitle : t(inject?.inject_injector_contract?.injector_contract_injector_type_name)}
             disabled={!injectorContractContent}
             isAtomic={isAtomic}
             defaultInject={inject}


### PR DESCRIPTION
Missing "media pressure" translation 

After fix
![image](https://github.com/user-attachments/assets/041e1991-4e92-4c88-995e-3db048b87668)
