### PR TITLE
[backend] Add flyway validator to avoid same version at runtime

### DIFF
--- a/openbas-api/src/main/java/io/openbas/App.java
+++ b/openbas-api/src/main/java/io/openbas/App.java
@@ -1,5 +1,6 @@
 package io.openbas;
 
+import io.openbas.tools.FlywayMigrationValidator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class App {
 
   public static void main(String[] args) {
+    FlywayMigrationValidator.validateFlywayMigrationNames();
     SpringApplication.run(App.class, args);
   }
 }

--- a/openbas-api/src/main/java/io/openbas/tools/FlywayMigrationValidator.java
+++ b/openbas-api/src/main/java/io/openbas/tools/FlywayMigrationValidator.java
@@ -1,0 +1,66 @@
+package io.openbas.tools;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class FlywayMigrationValidator {
+
+  private FlywayMigrationValidator() {
+  }
+
+  private static final Pattern VERSION_PATTERN = Pattern.compile("^V(\\d+(?:_\\d+)*)__.*\\.class$");
+  public static final String OPENBAS_MIGRATION_PATH = "io/openbas/migration";
+
+  public static void validateFlywayMigrationNames() {
+    try {
+      Path migrationDir = Paths.get(
+          FlywayMigrationValidator.class.getProtectionDomain().getCodeSource().getLocation().toURI()
+      ).resolve(OPENBAS_MIGRATION_PATH);
+
+      if (!Files.exists(migrationDir)) {
+        return;
+      }
+
+      Map<String, List<String>> versionToFiles = new HashMap<>();
+
+      try (Stream<Path> files = Files.walk(migrationDir)) {
+        files
+            .filter(Files::isRegularFile)
+            .filter(p -> p.getFileName().toString().startsWith("V"))
+            .filter(p -> p.toString().endsWith(".class"))
+            .filter(p -> !p.getFileName().toString().contains("$")) // Ignore internal classes
+            .forEach(p -> {
+              String fileName = p.getFileName().toString();
+              Matcher matcher = VERSION_PATTERN.matcher(fileName);
+              if (matcher.matches()) {
+                String version = matcher.group(1).replace('_', '.');
+                versionToFiles
+                    .computeIfAbsent(version, k -> new ArrayList<>())
+                    .add(fileName);
+              }
+            });
+      }
+
+      versionToFiles.entrySet().stream()
+          .filter(e -> e.getValue().size() > 1)
+          .findAny()
+          .ifPresent(e -> {
+            throw new IllegalStateException("Duplicate Flyway migration version found: " +
+                e.getKey() + " → " + e.getValue());
+          });
+
+    } catch (URISyntaxException | IOException e) {
+      throw new RuntimeException("Error during Flyway migration validation", e);
+    }
+  }
+}

--- a/openbas-api/src/main/java/io/openbas/tools/FlywayMigrationValidator.java
+++ b/openbas-api/src/main/java/io/openbas/tools/FlywayMigrationValidator.java
@@ -15,17 +15,21 @@ import java.util.stream.Stream;
 
 public class FlywayMigrationValidator {
 
-  private FlywayMigrationValidator() {
-  }
+  private FlywayMigrationValidator() {}
 
   private static final Pattern VERSION_PATTERN = Pattern.compile("^V(\\d+(?:_\\d+)*)__.*\\.class$");
   public static final String OPENBAS_MIGRATION_PATH = "io/openbas/migration";
 
   public static void validateFlywayMigrationNames() {
     try {
-      Path migrationDir = Paths.get(
-          FlywayMigrationValidator.class.getProtectionDomain().getCodeSource().getLocation().toURI()
-      ).resolve(OPENBAS_MIGRATION_PATH);
+      Path migrationDir =
+          Paths.get(
+                  FlywayMigrationValidator.class
+                      .getProtectionDomain()
+                      .getCodeSource()
+                      .getLocation()
+                      .toURI())
+              .resolve(OPENBAS_MIGRATION_PATH);
 
       if (!Files.exists(migrationDir)) {
         return;
@@ -39,25 +43,28 @@ public class FlywayMigrationValidator {
             .filter(p -> p.getFileName().toString().startsWith("V"))
             .filter(p -> p.toString().endsWith(".class"))
             .filter(p -> !p.getFileName().toString().contains("$")) // Ignore internal classes
-            .forEach(p -> {
-              String fileName = p.getFileName().toString();
-              Matcher matcher = VERSION_PATTERN.matcher(fileName);
-              if (matcher.matches()) {
-                String version = matcher.group(1).replace('_', '.');
-                versionToFiles
-                    .computeIfAbsent(version, k -> new ArrayList<>())
-                    .add(fileName);
-              }
-            });
+            .forEach(
+                p -> {
+                  String fileName = p.getFileName().toString();
+                  Matcher matcher = VERSION_PATTERN.matcher(fileName);
+                  if (matcher.matches()) {
+                    String version = matcher.group(1).replace('_', '.');
+                    versionToFiles.computeIfAbsent(version, k -> new ArrayList<>()).add(fileName);
+                  }
+                });
       }
 
       versionToFiles.entrySet().stream()
           .filter(e -> e.getValue().size() > 1)
           .findAny()
-          .ifPresent(e -> {
-            throw new IllegalStateException("Duplicate Flyway migration version found: " +
-                e.getKey() + " → " + e.getValue());
-          });
+          .ifPresent(
+              e -> {
+                throw new IllegalStateException(
+                    "Duplicate Flyway migration version found: "
+                        + e.getKey()
+                        + " → "
+                        + e.getValue());
+              });
 
     } catch (URISyntaxException | IOException e) {
       throw new RuntimeException("Error during Flyway migration validation", e);


### PR DESCRIPTION
### Proposed changes

* Crash as soon as possible when we have two migrations with the same versions
* This helps provide a clearer error message on Drone