### PR TITLE
[backend] Set inject status to MAYBE_PREVENTED when agent cleans a job

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/asset/endpoint/EndpointApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/asset/endpoint/EndpointApi.java
@@ -9,6 +9,7 @@ import io.openbas.aop.LogExecutionTime;
 import io.openbas.database.model.Agent;
 import io.openbas.database.model.AssetAgentJob;
 import io.openbas.database.model.Endpoint;
+import io.openbas.database.model.ExecutionStatus;
 import io.openbas.database.repository.AssetAgentJobRepository;
 import io.openbas.database.repository.EndpointRepository;
 import io.openbas.database.specification.AssetAgentJobSpecification;
@@ -18,6 +19,8 @@ import io.openbas.rest.asset.endpoint.form.EndpointOverviewOutput;
 import io.openbas.rest.asset.endpoint.form.EndpointRegisterInput;
 import io.openbas.rest.asset.endpoint.form.EndpointUpdateInput;
 import io.openbas.rest.helper.RestBehavior;
+import io.openbas.rest.inject.form.InjectUpdateStatusInput;
+import io.openbas.rest.inject.service.InjectStatusService;
 import io.openbas.service.EndpointService;
 import io.openbas.utils.EndpointMapper;
 import io.openbas.utils.FilterUtilsJpa;
@@ -47,6 +50,7 @@ public class EndpointApi extends RestBehavior {
   private final EndpointService endpointService;
   private final EndpointRepository endpointRepository;
   private final AssetAgentJobRepository assetAgentJobRepository;
+  private final InjectStatusService injectStatusService;
 
   private final EndpointMapper endpointMapper;
 
@@ -89,6 +93,10 @@ public class EndpointApi extends RestBehavior {
   @PreAuthorize("isPlanner()")
   @Transactional(rollbackFor = Exception.class)
   public void cleanupAssetAgentJob(@PathVariable @NotBlank final String assetAgentJobId) {
+    AssetAgentJob assetAgentJob = this.assetAgentJobRepository.findById(assetAgentJobId).orElseThrow();
+    InjectUpdateStatusInput injectUpdateStatusInput =  new InjectUpdateStatusInput();
+    injectUpdateStatusInput.setStatus(ExecutionStatus.MAYBE_PREVENTED.name());
+    this.injectStatusService.updateInjectStatus(assetAgentJob.getInject().getId(), injectUpdateStatusInput);
     this.assetAgentJobRepository.deleteById(assetAgentJobId);
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Set the inject status to `MAYBE_PREVENTED` when an agent sends a request to clean (delete) a job

### Related issues

* Closes #2801 as an agreed upon solution there

### Test instructions

I couldn't see any test cases covering the agent jobs API (other than agent or "endpoint" registration?) so I tested this manually:

See below testing instructions (given as mix of curl commands and instructions) 

```shell
# 1. Go to OpenBAS UI /admin/agents and get the token from instructions to add a new agent (I chose Linux)
export OPENBAS_TMP_TEST_TOKEN=AGENTTOKENGOESHERE

curl -XPOST -H "Authorization: Bearer $OPENBAS_TMP_TEST_TOKEN" http://localhost:3001/api/endpoints/register --json '{"asset_name": "test","asset_external_reference": "test","endpoint_agent_version": "1.15.0","endpoint_ips":["127.0.0.2"],"endpoint_platform": "Linux","endpoint_arch": "x86_64","endpoint_mac_addresses": ["00:AA:AA:AA:AA:00"],"endpoint_hostname": "test","agent_is_service": true,"agent_is_elevated": true,"agent_executed_by_user": "ruby","agent_installation_mode": "test"}'

# 2. As long as results indicate success (listened: true etc...), proceed to create some kind of inject
# in the UI (I just made a whoami command payload and an atomic test of that) targeted at the agent
# you just registered. Launch it and wait until status becomes pending. Then get "asset_agent_id" for
# the job with curl call

curl -XPOST -H "Authorization: Bearer $OPENBAS_TMP_TEST_TOKEN" http://localhost:3001/api/endpoints/jobs --json '{"asset_external_reference": "test","agent_is_service": true,"agent_is_elevated": true,"agent_executed_by_user": "ruby"}'

# 3. Then delete it like the agent would
export OPENBAS_TMP_JOB_ID=JOBIDGOESHEREFROMSTEPTWO
curl -XDELETE -H "Authorization: Bearer $OPENBAS_TMP_TEST_TOKEN" "http://localhost:3001/api/endpoints/jobs/$OPENBAS_TMP_JOB_ID"

# 4. Check the status in the UI is updated to MAYBE_PREVENTED
```

<img width="1301" alt="MAYBE_PREVENTED status on the atomic test" src="https://github.com/user-attachments/assets/59082c82-f253-483d-becd-cddfe8728c3b" />

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
