### PR TITLE
[backend] add attack pattern and killchaine phase to scenario export

### DIFF
--- a/openbas-api/src/main/java/io/openbas/export/FileExportBase.java
+++ b/openbas-api/src/main/java/io/openbas/export/FileExportBase.java
@@ -46,6 +46,7 @@ public class FileExportBase {
     this.objectMapper.addMixIn(InjectorContract.class, Mixins.InjectorContract.class);
     this.objectMapper.addMixIn(AttackPattern.class, Mixins.AttackPattern.class);
     this.objectMapper.addMixIn(Payload.class, Mixins.Payload.class);
+    this.objectMapper.addMixIn(KillChainPhase.class, Mixins.KillChainPhase.class);
 
     // default options
     // variables with no value

--- a/openbas-api/src/main/java/io/openbas/export/Mixins.java
+++ b/openbas-api/src/main/java/io/openbas/export/Mixins.java
@@ -71,7 +71,7 @@ public class Mixins {
 
   public abstract static class Payload {
     @JsonSerialize(using = JsonSerializer.None.class)
-    public abstract List<AttackPattern> getAttackPatterns();
+    public abstract List<io.openbas.database.model.AttackPattern> getAttackPatterns();
   }
 
   @JsonIncludeProperties(

--- a/openbas-api/src/main/java/io/openbas/export/Mixins.java
+++ b/openbas-api/src/main/java/io/openbas/export/Mixins.java
@@ -44,8 +44,25 @@ public class Mixins {
         "attack_pattern_name",
         "attack_pattern_description",
         "attack_pattern_external_id",
+        "attack_pattern_kill_chain_phases",
       })
-  public static class AttackPattern {}
+  public abstract static class AttackPattern {
+    @JsonSerialize(using = JsonSerializer.None.class)
+    public abstract List<io.openbas.database.model.KillChainPhase> getKillChainPhases();
+  }
+
+  @JsonIncludeProperties(
+      value = {
+        "phase_id",
+        "phase_external_id",
+        "phase_stix_id",
+        "phase_name",
+        "phase_shortname",
+        "phase_kill_chain_name",
+        "phase_description",
+        "phase_order",
+      })
+  public static class KillChainPhase {}
 
   public abstract static class InjectorContract {
     @JsonSerialize(using = JsonSerializer.None.class)
@@ -54,7 +71,7 @@ public class Mixins {
 
   public abstract static class Payload {
     @JsonSerialize(using = JsonSerializer.None.class)
-    public abstract List<io.openbas.database.model.AttackPattern> getAttackPatterns();
+    public abstract List<AttackPattern> getAttackPatterns();
   }
 
   @JsonIncludeProperties(

--- a/openbas-api/src/test/resources/importer-v1/import-scenario-with-attack-pattern.json
+++ b/openbas-api/src/test/resources/importer-v1/import-scenario-with-attack-pattern.json
@@ -1,0 +1,309 @@
+{
+  "export_version" : 1,
+  "scenario_information" : {
+    "scenario_id" : "8c745b27-b865-498b-ad3b-cb84f9941693",
+    "scenario_name" : "test export",
+    "scenario_description" : "",
+    "scenario_subtitle" : "",
+    "scenario_category" : "attack-scenario",
+    "scenario_main_focus" : "incident-response",
+    "scenario_severity" : "high",
+    "scenario_message_header" : "SIMULATION HEADER",
+    "scenario_message_footer" : "SIMULATION FOOTER",
+    "scenario_mail_from" : "openex-dev@filigran.cloud",
+    "scenario_tags" : [ ],
+    "scenario_documents" : [ ]
+  },
+  "scenario_teams" : [ ],
+  "scenario_objectives" : null,
+  "scenario_users" : [ ],
+  "scenario_organizations" : [ ],
+  "scenario_injects" : [ {
+    "inject_id" : "73fb1354-7b85-482d-a9e7-0319c0efefbe",
+    "inject_title" : "whoami",
+    "inject_description" : "",
+    "inject_country" : null,
+    "inject_city" : null,
+    "inject_enabled" : true,
+    "inject_content" : {
+      "obfuscator" : "plain-text"
+    },
+    "inject_all_teams" : false,
+    "inject_depends_on" : [ ],
+    "inject_depends_duration" : 0,
+    "inject_injector_contract" : {
+      "convertedContent" : {
+        "config" : {
+          "type" : "openbas_implant",
+          "expose" : true,
+          "label" : {
+            "en" : "OpenBAS Implant",
+            "fr" : "OpenBAS Implant"
+          },
+          "color_dark" : "#000000",
+          "color_light" : "#000000"
+        },
+        "label" : {
+          "en" : "whoami",
+          "fr" : "whoami"
+        },
+        "manual" : false,
+        "fields" : [ {
+          "key" : "assets",
+          "label" : "Assets",
+          "mandatory" : false,
+          "readOnly" : false,
+          "mandatoryGroups" : [ "assets", "assetgroups" ],
+          "mandatoryConditionField" : null,
+          "mandatoryConditionValue" : null,
+          "linkedFields" : [ ],
+          "linkedValues" : [ ],
+          "cardinality" : "n",
+          "defaultValue" : [ ],
+          "type" : "asset"
+        }, {
+          "key" : "assetgroups",
+          "label" : "Asset groups",
+          "mandatory" : false,
+          "readOnly" : false,
+          "mandatoryGroups" : [ "assets", "assetgroups" ],
+          "mandatoryConditionField" : null,
+          "mandatoryConditionValue" : null,
+          "linkedFields" : [ ],
+          "linkedValues" : [ ],
+          "cardinality" : "n",
+          "defaultValue" : [ ],
+          "type" : "asset-group"
+        }, {
+          "key" : "obfuscator",
+          "label" : "Obfuscators",
+          "mandatory" : false,
+          "readOnly" : false,
+          "mandatoryGroups" : null,
+          "mandatoryConditionField" : null,
+          "mandatoryConditionValue" : null,
+          "linkedFields" : [ ],
+          "linkedValues" : [ ],
+          "cardinality" : "1",
+          "defaultValue" : [ "plain-text" ],
+          "choices" : [ {
+            "label" : "plain-text",
+            "value" : "plain-text",
+            "information" : ""
+          }, {
+            "label" : "base64",
+            "value" : "base64",
+            "information" : "CMD does not support base64 obfuscation"
+          } ],
+          "type" : "choice"
+        }, {
+          "key" : "expectations",
+          "label" : "Expectations",
+          "mandatory" : false,
+          "readOnly" : false,
+          "mandatoryGroups" : null,
+          "mandatoryConditionField" : null,
+          "mandatoryConditionValue" : null,
+          "linkedFields" : [ ],
+          "linkedValues" : [ ],
+          "cardinality" : "n",
+          "defaultValue" : [ ],
+          "predefinedExpectations" : [ {
+            "expectation_type" : "PREVENTION",
+            "expectation_name" : "Expect inject to be prevented",
+            "expectation_description" : null,
+            "expectation_score" : 100.0,
+            "expectation_expectation_group" : false,
+            "expectation_expiration_time" : 21600
+          }, {
+            "expectation_type" : "DETECTION",
+            "expectation_name" : "Expect inject to be detected",
+            "expectation_description" : null,
+            "expectation_score" : 100.0,
+            "expectation_expectation_group" : false,
+            "expectation_expiration_time" : 21600
+          } ],
+          "type" : "expectation"
+        } ],
+        "variables" : [ {
+          "key" : "user",
+          "label" : "User that will receive the injection",
+          "type" : "String",
+          "cardinality" : "1",
+          "children" : [ {
+            "key" : "user.id",
+            "label" : "Id of the user in the platform",
+            "type" : "String",
+            "cardinality" : "1",
+            "children" : [ ]
+          }, {
+            "key" : "user.email",
+            "label" : "Email of the user",
+            "type" : "String",
+            "cardinality" : "1",
+            "children" : [ ]
+          }, {
+            "key" : "user.firstname",
+            "label" : "First name of the user",
+            "type" : "String",
+            "cardinality" : "1",
+            "children" : [ ]
+          }, {
+            "key" : "user.lastname",
+            "label" : "Last name of the user",
+            "type" : "String",
+            "cardinality" : "1",
+            "children" : [ ]
+          }, {
+            "key" : "user.lang",
+            "label" : "Language of the user",
+            "type" : "String",
+            "cardinality" : "1",
+            "children" : [ ]
+          } ]
+        }, {
+          "key" : "exercise",
+          "label" : "Exercise of the current injection",
+          "type" : "Object",
+          "cardinality" : "1",
+          "children" : [ {
+            "key" : "exercise.id",
+            "label" : "Id of the user in the platform",
+            "type" : "String",
+            "cardinality" : "1",
+            "children" : [ ]
+          }, {
+            "key" : "exercise.name",
+            "label" : "Name of the exercise",
+            "type" : "String",
+            "cardinality" : "1",
+            "children" : [ ]
+          }, {
+            "key" : "exercise.description",
+            "label" : "Description of the exercise",
+            "type" : "String",
+            "cardinality" : "1",
+            "children" : [ ]
+          } ]
+        }, {
+          "key" : "teams",
+          "label" : "List of team name for the injection",
+          "type" : "String",
+          "cardinality" : "n",
+          "children" : [ ]
+        }, {
+          "key" : "player_uri",
+          "label" : "Player interface platform link",
+          "type" : "String",
+          "cardinality" : "1",
+          "children" : [ ]
+        }, {
+          "key" : "challenges_uri",
+          "label" : "Challenges interface platform link",
+          "type" : "String",
+          "cardinality" : "1",
+          "children" : [ ]
+        }, {
+          "key" : "scoreboard_uri",
+          "label" : "Scoreboard interface platform link",
+          "type" : "String",
+          "cardinality" : "1",
+          "children" : [ ]
+        }, {
+          "key" : "lessons_uri",
+          "label" : "Lessons learned interface platform link",
+          "type" : "String",
+          "cardinality" : "1",
+          "children" : [ ]
+        } ],
+        "context" : { },
+        "contract_id" : "bb128f18-c5ad-4f1a-b08b-93582ff0ae1c",
+        "contract_attack_patterns_external_ids" : [ ],
+        "is_atomic_testing" : true,
+        "needs_executor" : true,
+        "platforms" : [ "Windows", "Linux" ]
+      },
+      "listened" : true,
+      "injector_contract_id" : "bb128f18-c5ad-4f1a-b08b-93582ff0ae1c",
+      "injector_contract_labels" : {
+        "en" : "whoami",
+        "fr" : "whoami"
+      },
+      "injector_contract_manual" : false,
+      "injector_contract_content" : "{\"config\":{\"type\":\"openbas_implant\",\"expose\":true,\"label\":{\"en\":\"OpenBAS Implant\",\"fr\":\"OpenBAS Implant\"},\"color_dark\":\"#000000\",\"color_light\":\"#000000\"},\"label\":{\"en\":\"whoami\",\"fr\":\"whoami\"},\"manual\":false,\"fields\":[{\"key\":\"assets\",\"label\":\"Assets\",\"mandatory\":false,\"readOnly\":false,\"mandatoryGroups\":[\"assets\",\"assetgroups\"],\"mandatoryConditionField\":null,\"mandatoryConditionValue\":null,\"linkedFields\":[],\"linkedValues\":[],\"cardinality\":\"n\",\"defaultValue\":[],\"type\":\"asset\"},{\"key\":\"assetgroups\",\"label\":\"Asset groups\",\"mandatory\":false,\"readOnly\":false,\"mandatoryGroups\":[\"assets\",\"assetgroups\"],\"mandatoryConditionField\":null,\"mandatoryConditionValue\":null,\"linkedFields\":[],\"linkedValues\":[],\"cardinality\":\"n\",\"defaultValue\":[],\"type\":\"asset-group\"},{\"key\":\"obfuscator\",\"label\":\"Obfuscators\",\"mandatory\":false,\"readOnly\":false,\"mandatoryGroups\":null,\"mandatoryConditionField\":null,\"mandatoryConditionValue\":null,\"linkedFields\":[],\"linkedValues\":[],\"cardinality\":\"1\",\"defaultValue\":[\"plain-text\"],\"choices\":[{\"label\":\"plain-text\",\"value\":\"plain-text\",\"information\":\"\"},{\"label\":\"base64\",\"value\":\"base64\",\"information\":\"CMD does not support base64 obfuscation\"}],\"type\":\"choice\"},{\"key\":\"expectations\",\"label\":\"Expectations\",\"mandatory\":false,\"readOnly\":false,\"mandatoryGroups\":null,\"mandatoryConditionField\":null,\"mandatoryConditionValue\":null,\"linkedFields\":[],\"linkedValues\":[],\"cardinality\":\"n\",\"defaultValue\":[],\"predefinedExpectations\":[{\"expectation_type\":\"PREVENTION\",\"expectation_name\":\"Expect inject to be prevented\",\"expectation_description\":null,\"expectation_score\":100.0,\"expectation_expectation_group\":false,\"expectation_expiration_time\":21600},{\"expectation_type\":\"DETECTION\",\"expectation_name\":\"Expect inject to be detected\",\"expectation_description\":null,\"expectation_score\":100.0,\"expectation_expectation_group\":false,\"expectation_expiration_time\":21600}],\"type\":\"expectation\"}],\"variables\":[{\"key\":\"user\",\"label\":\"User that will receive the injection\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[{\"key\":\"user.id\",\"label\":\"Id of the user in the platform\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]},{\"key\":\"user.email\",\"label\":\"Email of the user\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]},{\"key\":\"user.firstname\",\"label\":\"First name of the user\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]},{\"key\":\"user.lastname\",\"label\":\"Last name of the user\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]},{\"key\":\"user.lang\",\"label\":\"Language of the user\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]}]},{\"key\":\"exercise\",\"label\":\"Exercise of the current injection\",\"type\":\"Object\",\"cardinality\":\"1\",\"children\":[{\"key\":\"exercise.id\",\"label\":\"Id of the user in the platform\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]},{\"key\":\"exercise.name\",\"label\":\"Name of the exercise\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]},{\"key\":\"exercise.description\",\"label\":\"Description of the exercise\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]}]},{\"key\":\"teams\",\"label\":\"List of team name for the injection\",\"type\":\"String\",\"cardinality\":\"n\",\"children\":[]},{\"key\":\"player_uri\",\"label\":\"Player interface platform link\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]},{\"key\":\"challenges_uri\",\"label\":\"Challenges interface platform link\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]},{\"key\":\"scoreboard_uri\",\"label\":\"Scoreboard interface platform link\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]},{\"key\":\"lessons_uri\",\"label\":\"Lessons learned interface platform link\",\"type\":\"String\",\"cardinality\":\"1\",\"children\":[]}],\"context\":{},\"contract_id\":\"bb128f18-c5ad-4f1a-b08b-93582ff0ae1c\",\"contract_attack_patterns_external_ids\":[],\"is_atomic_testing\":true,\"needs_executor\":true,\"platforms\":[\"Windows\",\"Linux\"]}",
+      "injector_contract_custom" : false,
+      "injector_contract_needs_executor" : true,
+      "injector_contract_platforms" : [ "Windows", "Linux" ],
+      "injector_contract_payload" : {
+        "listened" : true,
+        "payload_id" : "18f89410-ab02-4050-afa1-e5e0d4e60e6e",
+        "payload_type" : "Command",
+        "payload_name" : "whoami",
+        "payload_description" : "",
+        "payload_platforms" : [ "Windows", "Linux" ],
+        "payload_cleanup_executor" : null,
+        "payload_cleanup_command" : null,
+        "payload_elevation_required" : false,
+        "payload_arguments" : [ ],
+        "payload_prerequisites" : [ ],
+        "payload_external_id" : "PAYLOAD_EXTERNAL_ID",
+        "payload_source" : "MANUAL",
+        "payload_status" : "VERIFIED",
+        "payload_execution_arch" : "ALL_ARCHITECTURES",
+        "payload_collector" : null,
+        "payload_tags" : [ ],
+        "payload_created_at" : "2025-03-25T15:23:54.670789Z",
+        "payload_updated_at" : "2025-03-25T15:23:54.670789Z",
+        "command_executor" : "psh",
+        "command_content" : "whoami",
+        "payload_collector_type" : null,
+        "payload_attack_patterns" : [ {
+          "listened" : true,
+          "attack_pattern_id" : "5024dfcd-c940-4108-96d7-05547ab7f693",
+          "attack_pattern_stix_id" : "attack-pattern--5945a706-0737-4a09-ad48-380b4f06ddbb",
+          "attack_pattern_name" : "test",
+          "attack_pattern_description" : null,
+          "attack_pattern_external_id" : "ATTACK_PATTERN_EXTERNAL_ID",
+          "attack_pattern_platforms" : [ ],
+          "attack_pattern_permissions_required" : [ ],
+          "attack_pattern_created_at" : "2025-03-25T15:22:16.653941Z",
+          "attack_pattern_updated_at" : "2025-03-25T15:22:53.972779Z",
+          "attack_pattern_parent" : null,
+          "attack_pattern_kill_chain_phases" : [ {
+            "listened" : true,
+            "phase_id" : "468add69-fdef-4d6f-a1da-466038f30e98",
+            "phase_external_id" : "KILLCHAIN_EXTERNAL_ID",
+            "phase_stix_id" : null,
+            "phase_name" : "kp1",
+            "phase_shortname" : "kp1",
+            "phase_kill_chain_name" : "kp1",
+            "phase_description" : null,
+            "phase_order" : 0,
+            "phase_created_at" : "2025-03-25T15:22:43.858905Z",
+            "phase_updated_at" : "2025-03-25T15:22:43.858905Z"
+          } ]
+        } ]
+      },
+      "injector_contract_created_at" : "2025-03-25T15:23:54.744592Z",
+      "injector_contract_updated_at" : "2025-03-25T15:23:54.744592Z",
+      "injector_contract_injector" : "49229430-b5b5-431f-ba5b-f36f599b0144",
+      "injector_contract_attack_patterns" : [ "5024dfcd-c940-4108-96d7-05547ab7f693" ],
+      "injector_contract_atomic_testing" : true,
+      "injector_contract_import_available" : false,
+      "injector_contract_arch" : "ALL_ARCHITECTURES",
+      "injector_contract_injector_type_name" : "OpenBAS Implant",
+      "injector_contract_injector_type" : "openbas_implant"
+    },
+    "inject_tags" : [ ],
+    "inject_teams" : [ ],
+    "inject_documents" : [ ]
+  } ],
+  "scenario_tags" : [ ],
+  "scenario_documents" : [ ],
+  "scenario_channels" : [ ],
+  "scenario_articles" : [ ],
+  "scenario_challenges" : [ ],
+  "scenario_lessons_categories" : [ ],
+  "scenario_lessons_questions" : [ ],
+  "scenario_variables" : [ ]
+}

--- a/openbas-model/src/main/java/io/openbas/database/repository/KillChainPhaseRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/KillChainPhaseRepository.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Repository;
 public interface KillChainPhaseRepository
     extends CrudRepository<KillChainPhase, String>, JpaSpecificationExecutor<KillChainPhase> {
 
+  List<KillChainPhase> findAllByExternalIdInIgnoreCase(List<String> externalIds);
+
   @NotNull
   Optional<KillChainPhase> findById(@NotNull String id);
 


### PR DESCRIPTION

### Proposed changes

* Added the KillChain phase and AttackPattern details to the export by adding another attribute containing the list of the whole objects to avoid to modify the existing attribute that only serialize the ids and is used by the front end
*In the import we now verify if the KillChainPhase / Attack Pattern exist and and we create it if it doesn't

For testing:
-> export a scenario containing payload with killchain phases
-> delete the payload and the killchain phases
-> import the scenario and verify that the payload and the killchainphase /attack pattern are created

### Related issues

* Closes #2016


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
- [X] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
