### PR TITLE
[backend] Fix on the mapper when trigger time not correctly set

### DIFF
--- a/openbas-api/src/main/java/io/openbas/service/InjectImportService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectImportService.java
@@ -593,19 +593,34 @@ public class InjectImportService {
       if (relativeDays
           && relativeDayMatcher.groupCount() > 0
           && !relativeDayMatcher.group(1).isBlank()) {
-        injectTime.setRelativeDayNumber(Integer.parseInt(relativeDayMatcher.group(1)));
+        try {
+          injectTime.setRelativeDayNumber(Integer.parseInt(relativeDayMatcher.group(1)));
+        } catch (NumberFormatException ex) {
+          log.warning(
+              String.format("Can't format %s into an integer", relativeDayMatcher.group(1)));
+        }
       }
       injectTime.setRelativeHour(relativeHour);
       if (relativeHour
           && relativeHourMatcher.groupCount() > 0
           && !relativeHourMatcher.group(1).isBlank()) {
-        injectTime.setRelativeHourNumber(Integer.parseInt(relativeHourMatcher.group(1)));
+        try {
+          injectTime.setRelativeHourNumber(Integer.parseInt(relativeHourMatcher.group(1)));
+        } catch (NumberFormatException ex) {
+          log.warning(
+              String.format("Can't format %s into an integer", relativeHourMatcher.group(1)));
+        }
       }
       injectTime.setRelativeMinute(relativeMinute);
       if (relativeMinute
           && relativeMinuteMatcher.groupCount() > 0
           && !relativeMinuteMatcher.group(1).isBlank()) {
-        injectTime.setRelativeMinuteNumber(Integer.parseInt(relativeMinuteMatcher.group(1)));
+        try {
+          injectTime.setRelativeMinuteNumber(Integer.parseInt(relativeMinuteMatcher.group(1)));
+        } catch (NumberFormatException ex) {
+          log.warning(
+              String.format("Can't format %s into an integer", relativeMinuteMatcher.group(1)));
+        }
       }
 
       // Special case : a mix of relative day and absolute hour
@@ -981,6 +996,7 @@ public class InjectImportService {
     // First of all, are there any absolute date
     boolean allDatesAreAbsolute =
         mapInstantByRowIndex.values().stream()
+            .filter(injectTime -> !injectTime.getUnformattedDate().isBlank())
             .noneMatch(
                 injectTime ->
                     injectTime.getDate() == null
@@ -989,6 +1005,7 @@ public class InjectImportService {
                         || injectTime.isRelativeMinute());
     boolean allDatesAreRelative =
         mapInstantByRowIndex.values().stream()
+            .filter(injectTime -> !injectTime.getUnformattedDate().isBlank())
             .allMatch(
                 injectTime ->
                     injectTime.getDate() == null


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* If we can't parse what is after the + or - of a relative date, we just log a warning 
* If a trigger time is empty, we ignore it when finding out if we are all relative or all absolute

### Related issues

* Closes #2906 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
