### PR TITLE
[backend] called hook-related code at the top level

### DIFF
--- a/openbas-front/src/admin/components/common/injects/Injects.tsx
+++ b/openbas-front/src/admin/components/common/injects/Injects.tsx
@@ -239,10 +239,16 @@ const Injects: FunctionComponent<Props> = ({
     size: 20,
   }));
 
+  const [loading, setLoading] = useState<boolean>(true);
+  const searchInjectsToLoad = (input: SearchPaginationInput) => {
+    setLoading(true);
+    return injectContext.searchInjects(input).finally(() => setLoading(false));
+  };
+
   // Injects
   // scoped to page
   const [injects, setInjects] = useState<InjectOutputType[]>([]);
-  // Bulk loading indcator for tests and delete
+  // Bulk loading indicator for tests and delete
   const [isBulkLoading, setIsBulkLoading] = useState<boolean>(false);
   const [selectedInjectId, setSelectedInjectId] = useState<string | null>(null);
   const [reloadInjectCount, setReloadInjectCount] = useState(0);
@@ -500,13 +506,6 @@ const Injects: FunctionComponent<Props> = ({
   if (isBulkLoading) {
     return <Loader />;
   }
-
-  const [loading, setLoading] = useState<boolean>(true);
-  const searchInjectsToLoad = (input: SearchPaginationInput) => {
-    setLoading(true);
-    return injectContext.searchInjects(input).finally(() => setLoading(false));
-  };
-
   return (
     <>
       <PaginationComponentV2


### PR DESCRIPTION
### Proposed changes

* Hook-related logic must always be called at the top level of your component, before any conditional return statements

### Related issues

* Closes #2960 