### PR TITLE
[backend] Fix simulation to scenario grants

### DIFF
--- a/openbas-api/src/main/java/io/openbas/migration/V3_86__Enforce_constraint_grant_scenario.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_86__Enforce_constraint_grant_scenario.java
@@ -1,0 +1,37 @@
+package io.openbas.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V3_86__Enforce_constraint_grant_scenario extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // Remove duplicate values
+      statement.execute(
+          """
+          DELETE FROM grants g
+          USING grants g2
+          WHERE g.ctid < g2.ctid
+             AND g.grant_group = g2.grant_group
+             AND g.grant_scenario = g2.grant_scenario
+             AND g.grant_name = g2.grant_name;
+          """);
+      // Rename existing index
+      statement.execute(
+          """
+                ALTER INDEX "grant" RENAME TO grant_exercise;
+              """);
+      // Create index for grant X scenario
+      statement.execute(
+          """
+              CREATE UNIQUE INDEX IF NOT EXISTS grant_scenario
+              ON grants (grant_group, grant_scenario, grant_name);
+          """);
+    }
+  }
+}


### PR DESCRIPTION
error → "could not execute statement [ERROR: duplicate key value violates unique constraint \"grant\"\n Detail: Key (grant_group, grant_exercise, grant_name)=(d5d8c183-e6d9-4d47-b041-25e5f3bdbc62, 375280f3-7207-4f6b-95f8-2b1aaa480697, PLANNER) already exists.] [insert into grants (grant_exercise,grant_group,grant_name,grant_scenario,grant_id) values (?,?,?,?,?)]"