### PR TITLE
[backend] fix: macos is sometimes called mac in tanium

### DIFF
--- a/openbas-api/src/main/java/io/openbas/executors/tanium/service/TaniumExecutorService.java
+++ b/openbas-api/src/main/java/io/openbas/executors/tanium/service/TaniumExecutorService.java
@@ -41,7 +41,7 @@ public class TaniumExecutorService implements Runnable {
     return switch (platform) {
       case "Linux" -> Endpoint.PLATFORM_TYPE.Linux;
       case "Windows" -> Endpoint.PLATFORM_TYPE.Windows;
-      case "MacOS" -> Endpoint.PLATFORM_TYPE.MacOS;
+      case "MacOS", "Mac" -> Endpoint.PLATFORM_TYPE.MacOS;
       default -> Endpoint.PLATFORM_TYPE.Unknown;
     };
   }


### PR DESCRIPTION
### Proposed changes

* When registering a tanium agent, the platform is sometimes called Mac instead of MacOS

### Related issues

* None

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug