### PR TITLE
[frontend] Select a default target on tab change, load

### DIFF
--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
@@ -191,6 +191,10 @@ const AtomicTesting = () => {
   const handleTabChange = (_event: SyntheticEvent, newValue: number) => {
     setActiveTab(newValue);
     setReloadContentCount(reloadContentCount + 1);
+
+    if (tabConfig[newValue].type == 'ALL_TARGETS') {
+      handleTargetClick(sortedTargets[0]);
+    }
   };
 
   const renderTargetItem = (target: InjectTargetWithResult, parent: InjectTargetWithResult | undefined, upperParent: InjectTargetWithResult | undefined) => {

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/PaginatedTargetTab.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/PaginatedTargetTab.tsx
@@ -44,6 +44,12 @@ const PaginatedTargetTab: React.FC<Props> = (props) => {
     props.handleSelectTarget(target);
   };
 
+  useEffect(() => {
+    if (targets && targets.length > 0) {
+      handleSelectTarget(targets[0]);
+    }
+  }, [targets]);
+
   return (
     <>
       <PaginationComponentV2


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Select a default target on tab change, load

### Testing Instructions

1. Add several target types to an inject (e.g. asset groups with endpoints)
2. Navigate to the inject
3. First target of first displayed tab is selected with loaded results (if applicable)
4. switch tabs
5. First target of newly navigated tab is selected, its results loaded

### Related issues

* Supersedes #3074

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
