### PR TITLE
[frontend/backend] "players" target paginated tab

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -821,7 +821,7 @@ public class InjectService {
       case TEAMS:
         return injectStatusMapper.toExecutionTracesOutput(
             this.executionTraceRepository.findByInjectIdAndTeamId(injectId, targetId));
-      case PLAYER:
+      case PLAYERS:
         return injectStatusMapper.toExecutionTracesOutput(
             this.executionTraceRepository.findByInjectIdAndPlayerId(injectId, targetId));
       default:

--- a/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
@@ -858,10 +858,16 @@ public class InjectExpectationService {
                           electedExpectations.get(expectation.getType()).getResults().stream(),
                           Stream.of(expectationResult))
                       .toList());
+          electedExpectations
+              .get(expectation.getType())
+              .setScore(
+                  Collections.max(
+                      electedExpectations.get(expectation.getType()).getResults().stream()
+                          .map(InjectExpectationResult::getScore)
+                          .toList()));
         }
       }
     }
-
     return electedExpectations.values().stream().toList();
   }
 

--- a/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
@@ -801,7 +801,8 @@ public class InjectExpectationService {
             case TEAMS, ASSETS_GROUPS ->
                 this.findMergedExpectationsByInjectAndTargetAndTargetType(
                     injectId, targetId, "not applicable", targetType);
-            case PLAYER -> injectExpectationRepository.findAllByInjectAndPlayer(injectId, targetId);
+            case PLAYERS ->
+                injectExpectationRepository.findAllByInjectAndPlayer(injectId, targetId);
             case AGENT -> injectExpectationRepository.findAllByInjectAndAgent(injectId, targetId);
             case ASSETS -> injectExpectationRepository.findAllByInjectAndAsset(injectId, targetId);
           });
@@ -819,7 +820,7 @@ public class InjectExpectationService {
       TargetType targetTypeEnum = TargetType.valueOf(targetType);
       return switch (targetTypeEnum) {
         case TEAMS -> injectExpectationRepository.findAllByInjectAndTeam(injectId, targetId);
-        case PLAYER ->
+        case PLAYERS ->
             injectExpectationRepository.findAllByInjectAndTeamAndPlayer(
                 injectId, parentTargetId, targetId);
         case AGENT ->

--- a/openbas-api/src/main/java/io/openbas/service/targets/TargetService.java
+++ b/openbas-api/src/main/java/io/openbas/service/targets/TargetService.java
@@ -3,6 +3,7 @@ package io.openbas.service.targets;
 import io.openbas.database.model.*;
 import io.openbas.service.targets.search.AssetGroupTargetSearchAdaptor;
 import io.openbas.service.targets.search.EndpointTargetSearchAdaptor;
+import io.openbas.service.targets.search.PlayerTargetSearchAdaptor;
 import io.openbas.service.targets.search.TeamTargetSearchAdaptor;
 import io.openbas.utils.FilterUtilsJpa;
 import io.openbas.utils.TargetType;
@@ -18,6 +19,7 @@ public class TargetService {
   private final AssetGroupTargetSearchAdaptor assetGroupTargetSearchAdaptor;
   private final EndpointTargetSearchAdaptor endpointTargetSearchAdaptor;
   private final TeamTargetSearchAdaptor teamTargetSearchAdaptor;
+  private final PlayerTargetSearchAdaptor playerTargetSearchAdaptor;
 
   public Page<InjectTarget> searchTargets(
       TargetType injectTargetType, Inject inject, SearchPaginationInput input) {
@@ -33,6 +35,7 @@ public class TargetService {
       case ASSETS_GROUPS -> assetGroupTargetSearchAdaptor.search(input, inject);
       case ASSETS -> endpointTargetSearchAdaptor.search(input, inject);
       case TEAMS -> teamTargetSearchAdaptor.search(input, inject);
+      case PLAYERS -> playerTargetSearchAdaptor.search(input, inject);
       default -> throw new IllegalArgumentException("Unsupported target type: " + injectTargetType);
     };
   }
@@ -43,6 +46,7 @@ public class TargetService {
       case ASSETS_GROUPS -> assetGroupTargetSearchAdaptor.getOptionsForInject(inject, textSearch);
       case ASSETS -> endpointTargetSearchAdaptor.getOptionsForInject(inject, textSearch);
       case TEAMS -> teamTargetSearchAdaptor.getOptionsForInject(inject, textSearch);
+      case PLAYERS -> playerTargetSearchAdaptor.getOptionsForInject(inject, textSearch);
       default -> throw new IllegalArgumentException("Unsupported target type: " + targetType);
     };
   }
@@ -53,6 +57,7 @@ public class TargetService {
       case ASSETS_GROUPS -> assetGroupTargetSearchAdaptor.getOptionsByIds(ids);
       case ASSETS -> endpointTargetSearchAdaptor.getOptionsByIds(ids);
       case TEAMS -> teamTargetSearchAdaptor.getOptionsByIds(ids);
+      case PLAYERS -> playerTargetSearchAdaptor.getOptionsByIds(ids);
       default -> throw new IllegalArgumentException("Unsupported target type: " + targetType);
     };
   }

--- a/openbas-api/src/main/java/io/openbas/service/targets/search/PlayerTargetSearchAdaptor.java
+++ b/openbas-api/src/main/java/io/openbas/service/targets/search/PlayerTargetSearchAdaptor.java
@@ -92,7 +92,7 @@ public class PlayerTargetSearchAdaptor extends SearchAdaptorBase {
     PlayerTarget target =
         new PlayerTarget(
             player.getId(),
-            player.getName(),
+            player.getNameOrEmail(),
             player.getTags().stream().map(Tag::getId).collect(Collectors.toSet()),
             player.getTeams().stream().map(Team::getId).collect(Collectors.toSet()));
 

--- a/openbas-api/src/main/java/io/openbas/service/targets/search/PlayerTargetSearchAdaptor.java
+++ b/openbas-api/src/main/java/io/openbas/service/targets/search/PlayerTargetSearchAdaptor.java
@@ -8,6 +8,7 @@ import io.openbas.service.InjectExpectationService;
 import io.openbas.utils.AtomicTestingUtils;
 import io.openbas.utils.FilterUtilsJpa;
 import io.openbas.utils.pagination.SearchPaginationInput;
+import io.openbas.utils.pagination.SortField;
 import jakarta.persistence.criteria.Path;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -61,6 +62,10 @@ public class PlayerTargetSearchAdaptor extends SearchAdaptorBase {
   @Override
   public Page<InjectTarget> search(SearchPaginationInput input, Inject scopedInject) {
     SearchPaginationInput translatedInput = this.translate(input, scopedInject);
+
+    // mind the specific sorts "email" because no name for players
+    SortField defaultSort = new SortField("user_email", "ASC");
+    translatedInput.setSorts(List.of(defaultSort));
 
     Page<User> filteredPlayers =
         buildPaginationJPA(

--- a/openbas-api/src/main/java/io/openbas/service/targets/search/PlayerTargetSearchAdaptor.java
+++ b/openbas-api/src/main/java/io/openbas/service/targets/search/PlayerTargetSearchAdaptor.java
@@ -1,0 +1,114 @@
+package io.openbas.service.targets.search;
+
+import static io.openbas.utils.pagination.PaginationUtils.buildPaginationJPA;
+
+import io.openbas.database.model.*;
+import io.openbas.database.repository.UserRepository;
+import io.openbas.service.InjectExpectationService;
+import io.openbas.utils.AtomicTestingUtils;
+import io.openbas.utils.FilterUtilsJpa;
+import io.openbas.utils.pagination.SearchPaginationInput;
+import jakarta.persistence.criteria.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.NotImplementedException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlayerTargetSearchAdaptor extends SearchAdaptorBase {
+  private final UserRepository userRepository;
+  private final InjectExpectationService injectExpectationService;
+
+  public PlayerTargetSearchAdaptor(
+      UserRepository userRepository, InjectExpectationService injectExpectationService) {
+    this.userRepository = userRepository;
+    this.injectExpectationService = injectExpectationService;
+
+    // field name translations
+    this.fieldTranslations.put("target_tags", "user_tags");
+    this.fieldTranslations.put("target_teams", "user_teams");
+  }
+
+  private static Specification<User> playersSpecificationFromInject(Inject scopedInject) {
+    return (root, query, builder) -> {
+      if (scopedInject.isAtomicTesting()) {
+        Path<Object> injectPath = root.join("teams").join("injects").get("id");
+        return builder.equal(injectPath, scopedInject.getId());
+      } else {
+        if (scopedInject.isAllTeams()) {
+          Path<Object> exerciseTeamUsersPath =
+              root.get("exerciseTeamUsers").get("exercise").get("id");
+          Path<Object> injectPath = root.join("teams").join("exercises").get("injects").get("id");
+          return builder.and(
+              builder.equal(injectPath, scopedInject.getId()),
+              builder.equal(exerciseTeamUsersPath, scopedInject.getExercise().getId()));
+        } else {
+          Path<Object> exerciseTeamUsersPath =
+              root.get("exerciseTeamUsers").get("exercise").get("id");
+          Path<Object> injectPath = root.join("teams").join("injects").get("id");
+          return builder.and(
+              builder.equal(injectPath, scopedInject.getId()),
+              builder.equal(exerciseTeamUsersPath, scopedInject.getExercise().getId()));
+        }
+      }
+    };
+  }
+
+  @Override
+  public Page<InjectTarget> search(SearchPaginationInput input, Inject scopedInject) {
+    SearchPaginationInput translatedInput = this.translate(input, scopedInject);
+
+    Page<User> filteredPlayers =
+        buildPaginationJPA(
+            (Specification<User> specification, Pageable pageable) ->
+                this.userRepository.findAll(
+                    playersSpecificationFromInject(scopedInject).and(specification), pageable),
+            translatedInput,
+            User.class);
+
+    return new PageImpl<>(
+        filteredPlayers.getContent().stream()
+            .map(player -> convertFromPlayerOutput(player, scopedInject))
+            .toList(),
+        filteredPlayers.getPageable(),
+        filteredPlayers.getTotalElements());
+  }
+
+  @Override
+  public List<FilterUtilsJpa.Option> getOptionsForInject(Inject scopedInject, String textSearch) {
+    throw new NotImplementedException("Implement when needed");
+  }
+
+  @Override
+  public List<FilterUtilsJpa.Option> getOptionsByIds(List<String> ids) {
+    throw new NotImplementedException("Implement when needed");
+  }
+
+  private InjectTarget convertFromPlayerOutput(User player, Inject inject) {
+    PlayerTarget target =
+        new PlayerTarget(
+            player.getId(),
+            player.getName(),
+            player.getTags().stream().map(Tag::getId).collect(Collectors.toSet()),
+            player.getTeams().stream().map(Team::getId).collect(Collectors.toSet()));
+
+    List<AtomicTestingUtils.ExpectationResultsByType> results =
+        AtomicTestingUtils.getExpectationResultByTypes(
+            injectExpectationService.findMergedExpectationsByInjectAndTargetAndTargetType(
+                inject.getId(), target.getId(), target.getTargetType()));
+
+    for (AtomicTestingUtils.ExpectationResultsByType result : results) {
+      switch (result.type()) {
+        case DETECTION -> target.setTargetDetectionStatus(result.avgResult());
+        case PREVENTION -> target.setTargetPreventionStatus(result.avgResult());
+        case HUMAN_RESPONSE -> target.setTargetHumanResponseStatus(result.avgResult());
+      }
+    }
+
+    return target;
+  }
+}

--- a/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
+++ b/openbas-api/src/main/java/io/openbas/utils/AtomicTestingUtils.java
@@ -289,7 +289,7 @@ public class AtomicTestingUtils {
                               : calculateResultsFromChildren(
                                   groupedByTeamAndUser.get(entry.getKey()),
                                   rawUserMap,
-                                  TargetType.PLAYER,
+                                  TargetType.PLAYERS,
                                   RawInjectExpectation::getUser_id,
                                   RawUser::computeName,
                                   null),

--- a/openbas-api/src/main/java/io/openbas/utils/TargetType.java
+++ b/openbas-api/src/main/java/io/openbas/utils/TargetType.java
@@ -4,6 +4,6 @@ public enum TargetType {
   AGENT,
   ASSETS,
   ASSETS_GROUPS,
-  PLAYER,
+  PLAYERS,
   TEAMS
 }

--- a/openbas-api/src/test/java/io/openbas/rest/inject/InjectApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/InjectApiTest.java
@@ -1118,7 +1118,7 @@ class InjectApiTest extends IntegrationTest {
               INJECT_URI + "/execution-traces",
               inject.getId(),
               savedPlayer.getId(),
-              TargetType.PLAYER);
+              TargetType.PLAYERS);
 
       assertExecutionTracesMatch(response);
     }

--- a/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
@@ -2,6 +2,7 @@ package io.openbas.rest.inject;
 
 import static io.openbas.rest.inject.InjectApi.INJECT_URI;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -1525,8 +1526,9 @@ public class InjectTargetSearchTest extends IntegrationTest {
                         Set.of(team.getId()));
                   })
               .toList();
-
-      assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
+      expected.forEach(
+          player ->
+              assertTrue(response.contains(player.getId()) && response.contains(player.getName())));
     }
 
     @Test

--- a/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
@@ -2,7 +2,6 @@ package io.openbas.rest.inject;
 
 import static io.openbas.rest.inject.InjectApi.INJECT_URI;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -1482,7 +1481,7 @@ public class InjectTargetSearchTest extends IntegrationTest {
     public void withSomePlayersTargets_returnMatchingItemsInPage1() throws Exception {
       String searchTerm = "player target";
       InjectComposer.Composer injectWrapper = getInjectWrapper();
-      for (int i = 10; i < 20; i++) {
+      for (int i = 10; i < 30; i++) {
         injectWrapper.withTeam(
             getTeamComposerWithName(searchTerm + " " + i)
                 .withUser(
@@ -1526,9 +1525,63 @@ public class InjectTargetSearchTest extends IntegrationTest {
                         Set.of(team.getId()));
                   })
               .toList();
-      expected.forEach(
-          player ->
-              assertTrue(response.contains(player.getId()) && response.contains(player.getName())));
+
+      assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
+    }
+
+    @Test
+    @DisplayName("With some players targets, return matching items in page 2")
+    public void withSomePlayersTargets_returnMatchingItemsInPage2() throws Exception {
+      String searchTerm = "team target";
+      InjectComposer.Composer injectWrapper = getInjectWrapper();
+      for (int i = 10; i < 30; i++) {
+        injectWrapper.withTeam(
+            getTeamComposerWithName(searchTerm + " " + i)
+                .withUser(
+                    getPlayerComposerWithName(
+                        searchTerm + " " + i,
+                        searchTerm + " " + i,
+                        searchTerm + " " + i + "@toto.fr")));
+      }
+      Inject inject = injectWrapper.persist().get();
+      entityManager.flush();
+      entityManager.clear();
+
+      SearchPaginationInput search =
+          PaginationFixture.simpleFilter("", searchTerm, Filters.FilterOperator.contains);
+      search.setPage(1); // 0-based
+      String response =
+          mvc.perform(
+                  post(INJECT_URI
+                          + "/"
+                          + inject.getId()
+                          + "/targets/"
+                          + targetType.name()
+                          + "/search")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(mapper.writeValueAsString(search)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      List<PlayerTarget> expected =
+          inject.getTeams().stream()
+              .skip((long) search.getPage() * search.getSize())
+              .sorted(Comparator.comparing(Team::getName))
+              .limit(search.getSize())
+              .map(
+                  team -> {
+                    User user = team.getUsers().getFirst();
+                    return new PlayerTarget(
+                        user.getId(),
+                        user.getNameOrEmail(),
+                        user.getTags().stream().map(Tag::getId).collect(Collectors.toSet()),
+                        Set.of(team.getId()));
+                  })
+              .toList();
+
+      assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
     }
 
     @Test

--- a/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
@@ -1513,6 +1513,7 @@ public class InjectTargetSearchTest extends IntegrationTest {
 
       List<PlayerTarget> expected =
           inject.getTeams().stream()
+              .sorted(Comparator.comparing(Team::getName))
               .limit(search.getSize())
               .map(
                   team -> {
@@ -1567,6 +1568,7 @@ public class InjectTargetSearchTest extends IntegrationTest {
       List<PlayerTarget> expected =
           inject.getTeams().stream()
               .skip((long) search.getPage() * search.getSize())
+              .sorted(Comparator.comparing(Team::getName))
               .limit(search.getSize())
               .map(
                   team -> {

--- a/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
@@ -1481,7 +1481,7 @@ public class InjectTargetSearchTest extends IntegrationTest {
     public void withSomePlayersTargets_returnMatchingItemsInPage1() throws Exception {
       String searchTerm = "player target";
       InjectComposer.Composer injectWrapper = getInjectWrapper();
-      for (int i = 10; i < 30; i++) {
+      for (int i = 10; i < 20; i++) {
         injectWrapper.withTeam(
             getTeamComposerWithName(searchTerm + " " + i)
                 .withUser(
@@ -1513,61 +1513,6 @@ public class InjectTargetSearchTest extends IntegrationTest {
 
       List<PlayerTarget> expected =
           inject.getTeams().stream()
-              .sorted(Comparator.comparing(Team::getName))
-              .limit(search.getSize())
-              .map(
-                  team -> {
-                    User user = team.getUsers().getFirst();
-                    return new PlayerTarget(
-                        user.getId(),
-                        user.getNameOrEmail(),
-                        user.getTags().stream().map(Tag::getId).collect(Collectors.toSet()),
-                        Set.of(team.getId()));
-                  })
-              .toList();
-
-      assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
-    }
-
-    @Test
-    @DisplayName("With some players targets, return matching items in page 2")
-    public void withSomePlayersTargets_returnMatchingItemsInPage2() throws Exception {
-      String searchTerm = "team target";
-      InjectComposer.Composer injectWrapper = getInjectWrapper();
-      for (int i = 10; i < 30; i++) {
-        injectWrapper.withTeam(
-            getTeamComposerWithName(searchTerm + " " + i)
-                .withUser(
-                    getPlayerComposerWithName(
-                        searchTerm + " " + i,
-                        searchTerm + " " + i,
-                        searchTerm + " " + i + "@toto.fr")));
-      }
-      Inject inject = injectWrapper.persist().get();
-      entityManager.flush();
-      entityManager.clear();
-
-      SearchPaginationInput search =
-          PaginationFixture.simpleFilter("", searchTerm, Filters.FilterOperator.contains);
-      search.setPage(1); // 0-based
-      String response =
-          mvc.perform(
-                  post(INJECT_URI
-                          + "/"
-                          + inject.getId()
-                          + "/targets/"
-                          + targetType.name()
-                          + "/search")
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .content(mapper.writeValueAsString(search)))
-              .andExpect(status().isOk())
-              .andReturn()
-              .getResponse()
-              .getContentAsString();
-
-      List<PlayerTarget> expected =
-          inject.getTeams().stream()
-              .skip((long) search.getPage() * search.getSize())
               .sorted(Comparator.comparing(Team::getName))
               .limit(search.getSize())
               .map(

--- a/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
@@ -1481,7 +1481,7 @@ public class InjectTargetSearchTest extends IntegrationTest {
     public void withSomePlayersTargets_returnMatchingItemsInPage1() throws Exception {
       String searchTerm = "player target";
       InjectComposer.Composer injectWrapper = getInjectWrapper();
-      for (int i = 0; i < 20; i++) {
+      for (int i = 10; i < 30; i++) {
         injectWrapper.withTeam(
             getTeamComposerWithName(searchTerm + " " + i)
                 .withUser(
@@ -1533,7 +1533,7 @@ public class InjectTargetSearchTest extends IntegrationTest {
     public void withSomePlayersTargets_returnMatchingItemsInPage2() throws Exception {
       String searchTerm = "team target";
       InjectComposer.Composer injectWrapper = getInjectWrapper();
-      for (int i = 0; i < 20; i++) {
+      for (int i = 10; i < 30; i++) {
         injectWrapper.withTeam(
             getTeamComposerWithName(searchTerm + " " + i)
                 .withUser(

--- a/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/InjectTargetSearchTest.java
@@ -19,10 +19,7 @@ import io.openbas.utils.mockUser.WithMockAdminUser;
 import io.openbas.utils.mockUser.WithMockUnprivilegedUser;
 import io.openbas.utils.pagination.SearchPaginationInput;
 import jakarta.persistence.EntityManager;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.*;
@@ -42,6 +39,8 @@ public class InjectTargetSearchTest extends IntegrationTest {
   @Autowired private ExpectationComposer expectationComposer;
   @Autowired private EndpointComposer endpointComposer;
   @Autowired private TeamComposer teamComposer;
+  @Autowired private UserComposer userComposer;
+  @Autowired private ExerciseComposer exerciseComposer;
   @Autowired private MockMvc mvc;
   @Autowired private ObjectMapper mapper;
   @Autowired private EntityManager entityManager;
@@ -1415,6 +1414,344 @@ public class InjectTargetSearchTest extends IntegrationTest {
                 teamWrapper.get().getTags().stream().map(Tag::getId).collect(Collectors.toSet()));
         expectedTeam.setTargetHumanResponseStatus(InjectExpectation.EXPECTATION_STATUS.PENDING);
         List<TeamTarget> expected = List.of(expectedTeam);
+
+        assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
+      }
+    }
+  }
+
+  @Nested
+  @WithMockAdminUser
+  @DisplayName("With players search")
+  public class WithPlayersSearch {
+
+    private final TargetType targetType = TargetType.PLAYERS;
+
+    private UserComposer.Composer getPlayerComposerWithName(
+        String firstname, String lastname, String email) {
+      return userComposer.forUser(UserFixture.getUser(firstname, lastname, email));
+    }
+
+    private TeamComposer.Composer getTeamComposerWithName(String teamName) {
+      return teamComposer.forTeam(TeamFixture.createTeamWithName(teamName));
+    }
+
+    private ExerciseComposer.Composer getExerciseComposerWithName() {
+      return exerciseComposer.forExercise(ExerciseFixture.createDefaultExercise());
+    }
+
+    private InjectComposer.Composer getInjectWithAllTeams() {
+      return injectComposer
+          .forInject(InjectFixture.getInjectWithAllTeams())
+          .withInjectorContract(
+              injectContractComposer
+                  .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+                  .withPayload(payloadComposer.forPayload(PayloadFixture.createDefaultCommand())));
+    }
+
+    @Test
+    @DisplayName("With no player targets, return no items in page")
+    public void withNoPlayerTargets_returnNoItemsInPage() throws Exception {
+      Inject inject = getInjectWrapper().persist().get();
+      entityManager.flush();
+      entityManager.clear();
+
+      SearchPaginationInput search =
+          PaginationFixture.simpleFilter("", "target player", Filters.FilterOperator.eq);
+      String response =
+          mvc.perform(
+                  post(INJECT_URI
+                          + "/"
+                          + inject.getId()
+                          + "/targets/"
+                          + targetType.name()
+                          + "/search")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(mapper.writeValueAsString(search)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      assertThatJson(response).node("content").isEqualTo("[]");
+    }
+
+    @Test
+    @DisplayName("With some players targets, return matching items in page 1")
+    public void withSomePlayersTargets_returnMatchingItemsInPage1() throws Exception {
+      String searchTerm = "player target";
+      InjectComposer.Composer injectWrapper = getInjectWrapper();
+      for (int i = 0; i < 20; i++) {
+        injectWrapper.withTeam(
+            getTeamComposerWithName(searchTerm + " " + i)
+                .withUser(
+                    getPlayerComposerWithName(
+                        searchTerm + " " + i,
+                        searchTerm + " " + i,
+                        searchTerm + " " + i + "@toto.fr")));
+      }
+      Inject inject = injectWrapper.persist().get();
+      entityManager.flush();
+      entityManager.clear();
+
+      SearchPaginationInput search =
+          PaginationFixture.simpleFilter("", searchTerm, Filters.FilterOperator.contains);
+      String response =
+          mvc.perform(
+                  post(INJECT_URI
+                          + "/"
+                          + inject.getId()
+                          + "/targets/"
+                          + targetType.name()
+                          + "/search")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(mapper.writeValueAsString(search)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      List<PlayerTarget> expected =
+          inject.getTeams().stream()
+              .limit(search.getSize())
+              .map(
+                  team -> {
+                    User user = team.getUsers().getFirst();
+                    return new PlayerTarget(
+                        user.getId(),
+                        user.getNameOrEmail(),
+                        user.getTags().stream().map(Tag::getId).collect(Collectors.toSet()),
+                        Set.of(team.getId()));
+                  })
+              .toList();
+
+      assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
+    }
+
+    @Test
+    @DisplayName("With some players targets, return matching items in page 2")
+    public void withSomePlayersTargets_returnMatchingItemsInPage2() throws Exception {
+      String searchTerm = "team target";
+      InjectComposer.Composer injectWrapper = getInjectWrapper();
+      for (int i = 0; i < 20; i++) {
+        injectWrapper.withTeam(
+            getTeamComposerWithName(searchTerm + " " + i)
+                .withUser(
+                    getPlayerComposerWithName(
+                        searchTerm + " " + i,
+                        searchTerm + " " + i,
+                        searchTerm + " " + i + "@toto.fr")));
+      }
+      Inject inject = injectWrapper.persist().get();
+      entityManager.flush();
+      entityManager.clear();
+
+      SearchPaginationInput search =
+          PaginationFixture.simpleFilter("", searchTerm, Filters.FilterOperator.contains);
+      search.setPage(1); // 0-based
+      String response =
+          mvc.perform(
+                  post(INJECT_URI
+                          + "/"
+                          + inject.getId()
+                          + "/targets/"
+                          + targetType.name()
+                          + "/search")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(mapper.writeValueAsString(search)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      List<PlayerTarget> expected =
+          inject.getTeams().stream()
+              .skip((long) search.getPage() * search.getSize())
+              .limit(search.getSize())
+              .map(
+                  team -> {
+                    User user = team.getUsers().getFirst();
+                    return new PlayerTarget(
+                        user.getId(),
+                        user.getNameOrEmail(),
+                        user.getTags().stream().map(Tag::getId).collect(Collectors.toSet()),
+                        Set.of(team.getId()));
+                  })
+              .toList();
+
+      assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
+    }
+
+    @Test
+    @DisplayName(
+        "With some players targets, return matching items for exercises with inject all teams")
+    public void withSomePlayersTargets_returnMatchingItemsForExercisesWithInjectAllTeams()
+        throws Exception {
+      String searchTerm1 = "player target 1";
+      String searchTerm2 = "player target 2";
+      TeamComposer.Composer teamWrapper1 = getTeamComposerWithName(searchTerm1);
+      UserComposer.Composer userWrapper1 =
+          getPlayerComposerWithName(searchTerm1, searchTerm1, searchTerm1 + "@toto.fr");
+      TeamComposer.Composer teamWrapper2 = getTeamComposerWithName(searchTerm2);
+      UserComposer.Composer userWrapper2 =
+          getPlayerComposerWithName(searchTerm2, searchTerm2, searchTerm2 + "@toto.fr");
+      InjectComposer.Composer injectWrapper = getInjectWithAllTeams();
+      ExerciseComposer.Composer exerciseWrapper =
+          getExerciseComposerWithName()
+              .withTeam(teamWrapper1.withUser(userWrapper1))
+              .withTeam(teamWrapper2.withUser(userWrapper2))
+              .withTeamUsers()
+              .withInject(injectWrapper);
+      Exercise exercise = exerciseWrapper.persist().get();
+      entityManager.flush();
+      entityManager.clear();
+
+      SearchPaginationInput search =
+          PaginationFixture.simpleFilter("", "player target", Filters.FilterOperator.contains);
+      String response =
+          mvc.perform(
+                  post(INJECT_URI
+                          + "/"
+                          + exercise.getInjects().getFirst().getId()
+                          + "/targets/"
+                          + targetType.name()
+                          + "/search")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(mapper.writeValueAsString(search)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      List<PlayerTarget> expected =
+          exercise.getTeams().stream()
+              .limit(search.getSize())
+              .map(
+                  team -> {
+                    User user = team.getUsers().getFirst();
+                    return new PlayerTarget(
+                        user.getId(),
+                        user.getNameOrEmail(),
+                        user.getTags().stream().map(Tag::getId).collect(Collectors.toSet()),
+                        Set.of(team.getId()));
+                  })
+              .toList();
+
+      assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
+    }
+
+    @Test
+    @DisplayName(
+        "With some players targets, return matching items for exercises with inject with 1 team")
+    public void withSomePlayersTargets_returnMatchingItemsForExercisesWithInjectWith1Team()
+        throws Exception {
+      String searchTerm1 = "player target 1";
+      String searchTerm2 = "player target 2";
+      TeamComposer.Composer teamWrapper1 = getTeamComposerWithName(searchTerm1);
+      UserComposer.Composer userWrapper1 =
+          getPlayerComposerWithName(searchTerm1, searchTerm1, searchTerm1 + "@toto.fr");
+      TeamComposer.Composer teamWrapper2 = getTeamComposerWithName(searchTerm2);
+      UserComposer.Composer userWrapper2 =
+          getPlayerComposerWithName(searchTerm2, searchTerm2, searchTerm2 + "@toto.fr");
+      InjectComposer.Composer injectWrapper = getInjectWrapper();
+      ExerciseComposer.Composer exerciseWrapper =
+          getExerciseComposerWithName()
+              .withTeam(teamWrapper1.withUser(userWrapper1))
+              .withTeam(teamWrapper2.withUser(userWrapper2))
+              .withTeamUsers()
+              .withInject(injectWrapper.withTeam(teamWrapper1));
+      Exercise exercise = exerciseWrapper.persist().get();
+      entityManager.flush();
+      entityManager.clear();
+
+      SearchPaginationInput search =
+          PaginationFixture.simpleFilter("", "player target", Filters.FilterOperator.contains);
+      String response =
+          mvc.perform(
+                  post(INJECT_URI
+                          + "/"
+                          + exercise.getInjects().getFirst().getId()
+                          + "/targets/"
+                          + targetType.name()
+                          + "/search")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(mapper.writeValueAsString(search)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      List<PlayerTarget> expected =
+          exercise.getInjects().getFirst().getTeams().stream()
+              .limit(search.getSize())
+              .map(
+                  team -> {
+                    User user = team.getUsers().getFirst();
+                    return new PlayerTarget(
+                        user.getId(),
+                        user.getNameOrEmail(),
+                        user.getTags().stream().map(Tag::getId).collect(Collectors.toSet()),
+                        Set.of(team.getId()));
+                  })
+              .toList();
+
+      assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
+    }
+
+    @Nested
+    @DisplayName("With actual results")
+    public class WithActualResults {
+      private ExpectationComposer.Composer getExpectationWrapperWithResult(
+          InjectExpectation.EXPECTATION_TYPE type, InjectExpectation.EXPECTATION_STATUS status) {
+        return expectationComposer.forExpectation(
+            InjectExpectationFixture.createExpectationWithTypeAndStatus(type, status));
+      }
+
+      @Test
+      @DisplayName("Given specific scores, expectation type results are of correct status")
+      public void givenSpecificScores_expectationTypeResultsAreOfCorrectStatus() throws Exception {
+        String searchTerm = "player target";
+        InjectComposer.Composer injectWrapper = getInjectWrapper();
+        TeamComposer.Composer teamWrapper = getTeamComposerWithName(searchTerm);
+        UserComposer.Composer userWrapper =
+            getPlayerComposerWithName(searchTerm, searchTerm, searchTerm + "@toto.fr");
+        ExpectationComposer.Composer expectationHumanResponseWrapper =
+            getExpectationWrapperWithResult(
+                    InjectExpectation.EXPECTATION_TYPE.CHALLENGE,
+                    InjectExpectation.EXPECTATION_STATUS.PENDING)
+                .withTeam(teamWrapper)
+                .withUser(userWrapper);
+        injectWrapper.withTeam(teamWrapper.withUser(userWrapper));
+        injectWrapper.withExpectation(expectationHumanResponseWrapper);
+        Inject inject = injectWrapper.persist().get();
+        entityManager.flush();
+        entityManager.clear();
+
+        SearchPaginationInput search =
+            PaginationFixture.simpleFilter("", searchTerm, Filters.FilterOperator.contains);
+        String response =
+            mvc.perform(
+                    post(INJECT_URI
+                            + "/"
+                            + inject.getId()
+                            + "/targets/"
+                            + targetType.name()
+                            + "/search")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(search)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        PlayerTarget expectedPlayer =
+            new PlayerTarget(
+                userWrapper.get().getId(),
+                userWrapper.get().getName(),
+                userWrapper.get().getTags().stream().map(Tag::getId).collect(Collectors.toSet()),
+                Set.of(teamWrapper.get().getId()));
+        expectedPlayer.setTargetHumanResponseStatus(InjectExpectation.EXPECTATION_STATUS.PENDING);
+        List<PlayerTarget> expected = List.of(expectedPlayer);
 
         assertThatJson(response).node("content").isEqualTo(mapper.writeValueAsString(expected));
       }

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectFixture.java
@@ -51,6 +51,14 @@ public class InjectFixture {
     return inject;
   }
 
+  public static Inject getInjectWithAllTeams() {
+    Inject inject = createInjectWithTitle(INJECT_EMAIL_NAME);
+    inject.setEnabled(true);
+    inject.setDependsDuration(0L);
+    inject.setAllTeams(true);
+    return inject;
+  }
+
   public static Inject getDefaultInject() {
     Inject inject = createInjectWithDefaultTitle();
     inject.setEnabled(true);

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/ExpectationComposer.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/ExpectationComposer.java
@@ -14,6 +14,7 @@ public class ExpectationComposer extends ComposerBase<InjectExpectation> {
     private final InjectExpectation injectExpectation;
     private Optional<AssetGroupComposer.Composer> assetGroupComposer = Optional.empty();
     private Optional<TeamComposer.Composer> teamComposer = Optional.empty();
+    private Optional<UserComposer.Composer> userComposer = Optional.empty();
     private Optional<EndpointComposer.Composer> endpointComposer = Optional.empty();
 
     public Composer(InjectExpectation injectExpectation) {
@@ -23,6 +24,12 @@ public class ExpectationComposer extends ComposerBase<InjectExpectation> {
     public Composer withTeam(TeamComposer.Composer teamComposer) {
       this.teamComposer = Optional.of(teamComposer);
       this.injectExpectation.setTeam(teamComposer.get());
+      return this;
+    }
+
+    public Composer withUser(UserComposer.Composer userComposer) {
+      this.userComposer = Optional.of(userComposer);
+      this.injectExpectation.setUser(userComposer.get());
       return this;
     }
 
@@ -43,6 +50,7 @@ public class ExpectationComposer extends ComposerBase<InjectExpectation> {
       assetGroupComposer.ifPresent(AssetGroupComposer.Composer::persist);
       endpointComposer.ifPresent(EndpointComposer.Composer::persist);
       teamComposer.ifPresent(TeamComposer.Composer::persist);
+      userComposer.ifPresent(UserComposer.Composer::persist);
       injectExpectationRepository.save(injectExpectation);
       return this;
     }
@@ -52,6 +60,7 @@ public class ExpectationComposer extends ComposerBase<InjectExpectation> {
       assetGroupComposer.ifPresent(AssetGroupComposer.Composer::delete);
       endpointComposer.ifPresent(EndpointComposer.Composer::delete);
       teamComposer.ifPresent(TeamComposer.Composer::delete);
+      userComposer.ifPresent(UserComposer.Composer::delete);
       injectExpectationRepository.delete(injectExpectation);
       return this;
     }

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
@@ -63,6 +63,8 @@ const AtomicTesting = () => {
   const [reloadContentCount, setReloadContentCount] = useState(0);
   const [hasTeams, setHasTeams] = useState(false);
   const [hasTeamsChecked, setHasTeamsChecked] = useState(false);
+  const [hasPlayers, setHasPlayers] = useState(false);
+  const [hasPlayersChecked, setHasPlayersChecked] = useState(false);
 
   const tabConfig: {
     key: number;
@@ -97,6 +99,14 @@ const AtomicTesting = () => {
         entityPrefix: 'endpoint_target',
       });
     }
+    if (hasPlayers) {
+      tabs.push({
+        key: index++,
+        label: t('Players'),
+        type: 'PLAYERS',
+        entityPrefix: 'player_target',
+      });
+    }
 
     tabs.push({
       key: index++,
@@ -106,7 +116,7 @@ const AtomicTesting = () => {
     });
 
     return tabs;
-  }, [hasAssetsGroup, hasTeams, hasEndpoints]);
+  }, [hasAssetsGroup, hasTeams, hasEndpoints, hasPlayers]);
 
   const injectId = injectResultOverviewOutput?.inject_id || '';
 
@@ -150,6 +160,16 @@ const AtomicTesting = () => {
       })
       .finally(() => {
         setHasTeamsChecked(true);
+      });
+
+    searchTargets(injectId, 'PLAYERS', searchPaginationInput1Result)
+      .then((response) => {
+        if (response.data.content.length > 0) {
+          setHasPlayers(true);
+        } else { setHasPlayers(false); }
+      })
+      .finally(() => {
+        setHasPlayersChecked(true);
       });
 
     setReloadContentCount(reloadContentCount + 1);

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
@@ -281,7 +281,7 @@ const AtomicTesting = () => {
         </Typography>
         <div className="clearfix" />
         <Paper classes={{ root: classes.paper }} variant="outlined">
-          {hasAssetsGroupChecked && hasTeamsChecked && hasEndpointsChecked && (
+          {hasAssetsGroupChecked && hasTeamsChecked && hasEndpointsChecked && hasPlayersChecked && (
             <>
               <Tabs
                 value={activeTab}

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/NewTargetListItem.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/NewTargetListItem.tsx
@@ -36,7 +36,7 @@ const NewTargetListItem: React.FC<Props> = ({ onClick, target, selected }) => {
       ASSETS_GROUPS: <SelectGroup />,
       ASSETS: <PlatformIcon platform={target?.target_subtype ?? 'Unknown'} width={20} marginRight={theme.spacing(2)} />,
       TEAMS: <Groups3Outlined />,
-      PLAYER: <PersonOutlined fontSize="small" />,
+      PLAYERS: <PersonOutlined fontSize="small" />,
     };
 
     return iconMap[target.target_type];

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetListItem.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetListItem.tsx
@@ -46,7 +46,7 @@ const TargetListItem: React.FC<Props> = ({ onClick, target, selected }) => {
         />
       ),
       TEAMS: <Groups3Outlined />,
-      PLAYER: <PersonOutlined fontSize="small" />,
+      PLAYERS: <PersonOutlined fontSize="small" />,
     };
 
     return iconMap[target.targetType];

--- a/openbas-front/src/components/common/queryable/filter/useRetrieveOptions.tsx
+++ b/openbas-front/src/components/common/queryable/filter/useRetrieveOptions.tsx
@@ -51,6 +51,11 @@ const useRetrieveOptions = () => {
           setOptions(response.data);
         });
         break;
+      case 'target_teams':
+        searchTargetOptionsById('TEAMS', ids).then((response) => {
+          setOptions(response.data);
+        });
+        break;
       case 'asset_tags':
       case 'asset_group_tags':
       case 'exercise_tags':

--- a/openbas-front/src/components/common/queryable/filter/useSearchOptions.tsx
+++ b/openbas-front/src/components/common/queryable/filter/useSearchOptions.tsx
@@ -52,6 +52,11 @@ const useSearchOptions = () => {
           setOptions(response.data);
         });
         break;
+      case 'target_teams':
+        searchTargetOptions(contextId, 'TEAMS').then((response) => {
+          setOptions(response.data);
+        });
+        break;
       case 'asset_tags':
       case 'asset_group_tags':
       case 'exercise_tags':

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -346,7 +346,6 @@ interface BaseInjectTarget {
     | "UNKNOWN"
     | "SUCCESS";
   target_id: string;
-  target_name?: string;
   target_prevention_status?:
     | "FAILED"
     | "PENDING"
@@ -2283,6 +2282,7 @@ export type InjectTarget = BaseInjectTarget &
     | BaseInjectTargetTargetTypeMapping<"ASSETS_GROUPS", AssetGroupTarget>
     | BaseInjectTargetTargetTypeMapping<"ASSETS", EndpointTarget>
     | BaseInjectTargetTargetTypeMapping<"TEAMS", TeamTarget>
+    | BaseInjectTargetTargetTypeMapping<"PLAYERS", PlayerTarget>
   );
 
 /** Results of expectations for each target */
@@ -2301,7 +2301,7 @@ export interface InjectTargetWithResult {
     | "Generic"
     | "Internal"
     | "Unknown";
-  targetType: "AGENT" | "ASSETS" | "ASSETS_GROUPS" | "PLAYER" | "TEAMS";
+  targetType: "AGENT" | "ASSETS" | "ASSETS_GROUPS" | "PLAYERS" | "TEAMS";
 }
 
 export interface InjectTeamsInput {
@@ -3765,11 +3765,49 @@ export interface PlayerOutput {
   user_firstname?: string;
   user_id: string;
   user_lastname?: string;
+  user_name?: string;
   user_organization?: string;
   user_pgp_key?: string;
   user_phone?: string;
   /** @uniqueItems true */
   user_tags?: string[];
+  /** @uniqueItems true */
+  user_teams?: string[];
+}
+
+export interface PlayerTarget {
+  target_detection_status?:
+    | "FAILED"
+    | "PENDING"
+    | "PARTIAL"
+    | "UNKNOWN"
+    | "SUCCESS";
+  target_execution_status?:
+    | "FAILED"
+    | "PENDING"
+    | "PARTIAL"
+    | "UNKNOWN"
+    | "SUCCESS";
+  target_human_response_status?:
+    | "FAILED"
+    | "PENDING"
+    | "PARTIAL"
+    | "UNKNOWN"
+    | "SUCCESS";
+  target_id: string;
+  target_name?: string;
+  target_prevention_status?:
+    | "FAILED"
+    | "PENDING"
+    | "PARTIAL"
+    | "UNKNOWN"
+    | "SUCCESS";
+  target_subtype?: string;
+  /** @uniqueItems true */
+  target_tags?: string[];
+  /** @uniqueItems true */
+  target_teams?: string[];
+  target_type?: string;
 }
 
 /** Policies of the platform */
@@ -4407,7 +4445,7 @@ export interface TagUpdateInput {
 export interface TargetSimple {
   target_id: string;
   target_name?: string;
-  target_type?: "AGENT" | "ASSETS" | "ASSETS_GROUPS" | "PLAYER" | "TEAMS";
+  target_type?: "AGENT" | "ASSETS" | "ASSETS_GROUPS" | "PLAYERS" | "TEAMS";
 }
 
 export interface Team {

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -3765,14 +3765,11 @@ export interface PlayerOutput {
   user_firstname?: string;
   user_id: string;
   user_lastname?: string;
-  user_name?: string;
   user_organization?: string;
   user_pgp_key?: string;
   user_phone?: string;
   /** @uniqueItems true */
   user_tags?: string[];
-  /** @uniqueItems true */
-  user_teams?: string[];
 }
 
 export interface PlayerTarget {
@@ -4752,6 +4749,7 @@ export interface User {
   /** Secondary phone number of the user */
   user_phone2?: string;
   listened?: boolean;
+  team_exercises_users?: string[];
   /** True if the user is admin */
   user_admin?: boolean;
   /** City of the user */

--- a/openbas-front/src/utils/lang/en.json
+++ b/openbas-front/src/utils/lang/en.json
@@ -1279,6 +1279,7 @@
   "target_asset_groups": "Asset Groups",
   "target_name": "Name",
   "target_tags": "Tags",
+  "target_teams": "Teams",
   "Targeted asset groups": "Targeted asset groups",
   "Targeted assets": "Targeted assets",
   "Targeted players": "Targeted players",

--- a/openbas-front/src/utils/lang/fr.json
+++ b/openbas-front/src/utils/lang/fr.json
@@ -1279,7 +1279,7 @@
   "target_asset_groups": "Groupes d'actifs",
   "target_name": "Nom",
   "target_tags": "Tags",
-  "target_teams": "Equipes",
+  "target_teams": "Équipes",
   "Targeted asset groups": "Groupes d'assets ciblés",
   "Targeted assets": "Assets ciblés",
   "Targeted players": "Joueurs ciblés",

--- a/openbas-front/src/utils/lang/fr.json
+++ b/openbas-front/src/utils/lang/fr.json
@@ -1279,6 +1279,7 @@
   "target_asset_groups": "Groupes d'actifs",
   "target_name": "Nom",
   "target_tags": "Tags",
+  "target_teams": "Equipes",
   "Targeted asset groups": "Groupes d'assets ciblés",
   "Targeted assets": "Assets ciblés",
   "Targeted players": "Joueurs ciblés",

--- a/openbas-front/src/utils/lang/zh.json
+++ b/openbas-front/src/utils/lang/zh.json
@@ -1279,6 +1279,7 @@
   "target_asset_groups": "资产组",
   "target_name": "名称",
   "target_tags": "标签",
+  "target_teams": "团队",
   "Targeted asset groups": "目标资产组",
   "Targeted assets": "目标资产",
   "Targeted players": "目标选手",

--- a/openbas-model/src/main/java/io/openbas/database/model/AssetGroupTarget.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/AssetGroupTarget.java
@@ -1,7 +1,11 @@
 package io.openbas.database.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openbas.annotation.Queryable;
 import java.util.Set;
+import lombok.Data;
 
+@Data
 public class AssetGroupTarget extends InjectTarget {
   public AssetGroupTarget(String id, String name, Set<String> tags) {
     this.setId(id);
@@ -9,6 +13,10 @@ public class AssetGroupTarget extends InjectTarget {
     this.setTags(tags);
     this.setTargetType("ASSETS_GROUPS");
   }
+
+  @JsonProperty("target_name")
+  @Queryable(filterable = true, searchable = true, sortable = true)
+  private String name;
 
   @Override
   protected String getTargetSubtype() {

--- a/openbas-model/src/main/java/io/openbas/database/model/EndpointTarget.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/EndpointTarget.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openbas.annotation.Queryable;
 import java.util.Optional;
 import java.util.Set;
+import lombok.Data;
 import org.apache.commons.lang3.NotImplementedException;
 
+@Data
 public class EndpointTarget extends InjectTarget {
   public EndpointTarget(String id, String name, Set<String> tags, String subType) {
     this.setId(id);
@@ -15,6 +17,10 @@ public class EndpointTarget extends InjectTarget {
     this.setTargetType("ASSETS");
     this.subType = subType;
   }
+
+  @JsonProperty("target_name")
+  @Queryable(filterable = true, searchable = true, sortable = true)
+  private String name;
 
   @JsonIgnore private final String subType;
 

--- a/openbas-model/src/main/java/io/openbas/database/model/InjectTarget.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/InjectTarget.java
@@ -12,21 +12,18 @@ import lombok.Data;
 @Data
 @Schema(
     discriminatorProperty = "target_type",
-    oneOf = {AssetGroupTarget.class, TeamTarget.class},
+    oneOf = {AssetGroupTarget.class, TeamTarget.class, PlayerTarget.class},
     discriminatorMapping = {
       @DiscriminatorMapping(value = "ASSETS_GROUPS", schema = AssetGroupTarget.class),
       @DiscriminatorMapping(value = "ASSETS", schema = EndpointTarget.class),
-      @DiscriminatorMapping(value = "TEAMS", schema = TeamTarget.class)
+      @DiscriminatorMapping(value = "TEAMS", schema = TeamTarget.class),
+      @DiscriminatorMapping(value = "PLAYERS", schema = PlayerTarget.class)
     })
 public abstract class InjectTarget {
   @Id
   @NotBlank
   @JsonProperty("target_id")
   private String id;
-
-  @JsonProperty("target_name")
-  @Queryable(filterable = true, searchable = true, sortable = true)
-  private String name;
 
   @JsonProperty("target_tags")
   @Queryable(filterable = true, searchable = true, sortable = true, dynamicValues = true)

--- a/openbas-model/src/main/java/io/openbas/database/model/PlayerTarget.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/PlayerTarget.java
@@ -6,20 +6,24 @@ import java.util.Set;
 import lombok.Data;
 
 @Data
-public class TeamTarget extends InjectTarget {
-  public TeamTarget(String id, String name, Set<String> tags) {
+public class PlayerTarget extends InjectTarget {
+  public PlayerTarget(String id, String name, Set<String> tags, Set<String> teams) {
     this.setId(id);
     this.setName(name);
     this.setTags(tags);
-    this.setTargetType("TEAMS");
+    this.setTeams(teams);
+    this.setTargetType("PLAYERS");
   }
 
   @JsonProperty("target_name")
-  @Queryable(filterable = true, searchable = true, sortable = true)
   private String name;
 
   @Override
   protected String getTargetSubtype() {
     return this.getTargetType();
   }
+
+  @JsonProperty("target_teams")
+  @Queryable(filterable = true, searchable = true, sortable = true, dynamicValues = true)
+  private Set<String> teams;
 }

--- a/openbas-model/src/main/java/io/openbas/database/model/User.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/User.java
@@ -302,6 +302,15 @@ public class User implements Base {
     return getFirstname() + " " + getLastname();
   }
 
+  @JsonIgnore
+  public String getNameOrEmail() {
+    if (getFirstname() != null && getLastname() != null) {
+      return getName();
+    } else {
+      return getEmail();
+    }
+  }
+
   @JsonProperty("user_is_only_player")
   @Schema(description = "True if the user is only a player")
   public boolean isOnlyPlayer() {

--- a/openbas-model/src/main/java/io/openbas/database/model/User.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/User.java
@@ -9,10 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openbas.annotation.Queryable;
 import io.openbas.database.audit.ModelBaseListener;
-import io.openbas.helper.MonoIdDeserializer;
-import io.openbas.helper.MultiIdListDeserializer;
-import io.openbas.helper.MultiIdSetDeserializer;
-import io.openbas.helper.UserHelper;
+import io.openbas.helper.*;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
@@ -183,6 +180,7 @@ public class User implements Base {
       inverseJoinColumns = @JoinColumn(name = "team_id"))
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @JsonProperty("user_teams")
+  @Queryable(dynamicValues = true, filterable = true, sortable = true, path = "teams.id")
   private List<Team> teams = new ArrayList<>();
 
   @ArraySchema(schema = @Schema(description = "Tag IDs of the user", type = "string"))
@@ -207,6 +205,20 @@ public class User implements Base {
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @JsonProperty("user_communications")
   private List<Communication> communications = new ArrayList<>();
+
+  @ArraySchema(
+      schema =
+          @Schema(
+              description = "List of 3-tuple linking simulation IDs and team IDs to this user ID",
+              type = "string"))
+  @OneToMany(
+      mappedBy = "user",
+      fetch = FetchType.LAZY,
+      cascade = CascadeType.ALL,
+      orphanRemoval = true)
+  @JsonProperty("team_exercises_users")
+  @JsonSerialize(using = MultiModelDeserializer.class)
+  private List<ExerciseTeamUser> exerciseTeamUsers = new ArrayList<>();
 
   @Setter
   @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)


### PR DESCRIPTION
### Proposed changes

* Add a paginated tab for Players-type inject targets

### Testing Instructions

1. Create an email or sms inject and add Teams
2. Navigate to the Players tab; use filters

PS: Three options to test to create an inject with teams -> atomic testing OR exercise with inject option "all teams" OR exercise with inject without option "all teams"

### Related issues

* Closes #3150 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
