### PR TITLE
[backend] Asset group dynamic filter not null

### DIFF
--- a/openbas-api/src/main/java/io/openbas/migration/V3_88__Enforce_constraint_asset_group_dynamic_filter.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_88__Enforce_constraint_asset_group_dynamic_filter.java
@@ -13,8 +13,8 @@ public class V3_88__Enforce_constraint_asset_group_dynamic_filter extends BaseJa
     try (Statement statement = context.getConnection().createStatement()) {
       statement.execute(
           """
-          ALTER TABLE asset_groups ALTER COLUMN asset_group_dynamic_filter SET DEFAULT '{"mode":"or","filters":[]}';
-          UPDATE asset_groups SET asset_group_dynamic_filter = '{"mode":"or","filters":[]}' where asset_group_dynamic_filter IS NULL;
+          ALTER TABLE asset_groups ALTER COLUMN asset_group_dynamic_filter SET DEFAULT '{"mode":"and","filters":[]}';
+          UPDATE asset_groups SET asset_group_dynamic_filter = '{"mode":"and","filters":[]}' where asset_group_dynamic_filter IS NULL;
           ALTER TABLE asset_groups ALTER COLUMN asset_group_dynamic_filter SET NOT NULL;
           """);
     }

--- a/openbas-api/src/main/java/io/openbas/migration/V3_88__Enforce_constraint_asset_group_dynamic_filter.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_88__Enforce_constraint_asset_group_dynamic_filter.java
@@ -1,0 +1,22 @@
+package io.openbas.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V3_88__Enforce_constraint_asset_group_dynamic_filter extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          """
+          ALTER TABLE asset_groups ALTER COLUMN asset_group_dynamic_filter SET DEFAULT '{"mode":"or","filters":[]}';
+          UPDATE asset_groups SET asset_group_dynamic_filter = '{"mode":"or","filters":[]}' where asset_group_dynamic_filter IS NULL;
+          ALTER TABLE asset_groups ALTER COLUMN asset_group_dynamic_filter SET NOT NULL;
+          """);
+    }
+  }
+}

--- a/openbas-api/src/main/java/io/openbas/rest/asset_group/form/AssetGroupInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/asset_group/form/AssetGroupInput.java
@@ -25,5 +25,5 @@ public class AssetGroupInput {
   private List<String> tagIds = new ArrayList<>();
 
   @JsonProperty("asset_group_dynamic_filter")
-  private FilterGroup dynamicFilter;
+  private FilterGroup dynamicFilter = FilterGroup.defaultFilterGroup();
 }

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/AssetGroupFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/AssetGroupFixture.java
@@ -25,18 +25,11 @@ public class AssetGroupFixture {
     return assetGroupInput;
   }
 
-  public static AssetGroupInput createAssetGroupWithDynamicFilters(@NotNull final String name) {
+  public static AssetGroupInput createAssetGroupWithDynamicFilters(
+      @NotNull final String name, @NotNull final Filters.FilterGroup dynamicFilter) {
     AssetGroupInput assetGroupInput = new AssetGroupInput();
     assetGroupInput.setName(name);
     assetGroupInput.setDescription("An asset group");
-    Filters.FilterGroup dynamicFilter = new Filters.FilterGroup();
-    dynamicFilter.setMode(Filters.FilterMode.or);
-    Filters.Filter filter = new Filters.Filter();
-    filter.setKey("endpoint_platform");
-    filter.setMode(Filters.FilterMode.or);
-    filter.setOperator(Filters.FilterOperator.eq);
-    filter.setValues(List.of("Windows"));
-    dynamicFilter.setFilters(List.of(filter));
     assetGroupInput.setDynamicFilter(dynamicFilter);
     return assetGroupInput;
   }

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/AssetGroupFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/AssetGroupFixture.java
@@ -2,6 +2,7 @@ package io.openbas.utils.fixtures;
 
 import io.openbas.database.model.Asset;
 import io.openbas.database.model.AssetGroup;
+import io.openbas.database.model.Filters;
 import io.openbas.rest.asset_group.form.AssetGroupInput;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -21,6 +22,22 @@ public class AssetGroupFixture {
     assetGroupInput.setName(name);
     assetGroupInput.setDescription("An asset group");
     assetGroupInput.setTagIds(tagIds);
+    return assetGroupInput;
+  }
+
+  public static AssetGroupInput createAssetGroupWithDynamicFilters(@NotNull final String name) {
+    AssetGroupInput assetGroupInput = new AssetGroupInput();
+    assetGroupInput.setName(name);
+    assetGroupInput.setDescription("An asset group");
+    Filters.FilterGroup dynamicFilter = new Filters.FilterGroup();
+    dynamicFilter.setMode(Filters.FilterMode.or);
+    Filters.Filter filter = new Filters.Filter();
+    filter.setKey("endpoint_platform");
+    filter.setMode(Filters.FilterMode.or);
+    filter.setOperator(Filters.FilterOperator.eq);
+    filter.setValues(List.of("Windows"));
+    dynamicFilter.setFilters(List.of(filter));
+    assetGroupInput.setDynamicFilter(dynamicFilter);
     return assetGroupInput;
   }
 

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -194,7 +194,7 @@ export interface AssetGroup {
   asset_group_description?: string;
   asset_group_dynamic_assets?: string[];
   /** Filter object to search within filterable attributes */
-  asset_group_dynamic_filter?: FilterGroup;
+  asset_group_dynamic_filter: FilterGroup;
   asset_group_external_reference?: string;
   asset_group_id: string;
   asset_group_injects?: string[];

--- a/openbas-model/src/main/java/io/openbas/database/model/AssetGroup.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/AssetGroup.java
@@ -62,7 +62,8 @@ public class AssetGroup implements Base {
   @Type(JsonType.class)
   @Column(name = "asset_group_dynamic_filter")
   @JsonProperty("asset_group_dynamic_filter")
-  private FilterGroup dynamicFilter;
+  @NotNull
+  private FilterGroup dynamicFilter = FilterGroup.defaultFilterGroup();
 
   @ArraySchema(schema = @Schema(type = "string"))
   @ManyToMany(fetch = FetchType.LAZY)

--- a/openbas-model/src/main/java/io/openbas/database/model/Filters.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Filters.java
@@ -36,6 +36,13 @@ public class Filters {
     @NotNull private FilterMode mode; // Between filters
     private List<Filter> filters = new ArrayList<>();
 
+    public static FilterGroup defaultFilterGroup() {
+      FilterGroup filterGroup = new FilterGroup();
+      filterGroup.setMode(FilterMode.or);
+      filterGroup.setFilters(List.of());
+      return filterGroup;
+    }
+
     // -- UTILS --
 
     public Optional<Filter> findByKey(@NotBlank final String filterKey) {

--- a/openbas-model/src/main/java/io/openbas/database/model/Filters.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Filters.java
@@ -36,10 +36,16 @@ public class Filters {
     @NotNull private FilterMode mode; // Between filters
     private List<Filter> filters = new ArrayList<>();
 
+    /**
+     * asset_group_dynamic_filter in AssetGroup is now not null so we added a default not null value
+     * for the java object AssetGroup and the SQL table asset_groups Tests to protect this are
+     * implemented in AssetGroupApiTest Don't forget to update the default value for each case
+     * described above if needed !
+     */
     public static FilterGroup defaultFilterGroup() {
       FilterGroup filterGroup = new FilterGroup();
-      filterGroup.setMode(FilterMode.or);
-      filterGroup.setFilters(List.of());
+      filterGroup.setMode(FilterMode.and);
+      filterGroup.setFilters(new ArrayList<>());
       return filterGroup;
     }
 


### PR DESCRIPTION
### Proposed changes

* Add default value to dynamic filter for asset group as it's already done when you create an asset group manually

### Testing Instructions

1. Add a Crowdstrike config
2. Create manual asset groups
3. Create injects with the manual asset groups and the Crowdstrike asset group
4. Check it works

### Related issues

* Closes #3147 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug
