### PR TITLE
[backend] Only show findings of latest simulation for global, scenario, endpoint findings view (#3076)

### DIFF
--- a/openbas-api/src/main/java/io/openbas/migration/V3_90__add_automatic_finding_hash_column.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_90__add_automatic_finding_hash_column.java
@@ -1,0 +1,92 @@
+package io.openbas.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+import java.sql.Statement;
+
+@Component
+public class V3_90__add_automatic_finding_hash_column extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+
+      String updateInjectExpectationResult =
+          """
+          -- necessary for hashing functions
+          CREATE EXTENSION IF NOT EXISTS pgcrypto;
+          
+          CREATE OR REPLACE FUNCTION compute_finding_identity(id TEXT)
+          RETURNS TEXT
+          AS
+          $$
+            BEGIN
+              RETURN (
+                SELECT digest(
+                  concat(
+                      finding_field,
+                      finding_type,
+                      finding_type,
+                      finding_value,
+                      array_to_string(finding_labels, ''),
+                      finding_name,
+                      i.inject_content,
+                      i.inject_injector_contract,
+                      -- to force differentiating between identical atomic tests
+                      -- use an ad hoc random uuid instead of a scenario id.
+                      -- also assume a single scenario per simulation
+                      COALESCE(se.scenario_id, gen_random_uuid()::text)
+                  ),
+                  'sha256') as identity_hash_value
+                FROM findings f
+                  JOIN injects i
+                    ON f.finding_inject_id = i.inject_id
+                  LEFT JOIN exercises e
+                    ON e.exercise_id = i.inject_exercise
+                  LEFT JOIN scenarios_exercises se
+                    ON e.exercise_id = se.exercise_id
+                where finding_id = id
+              );
+            END;
+            $$ LANGUAGE plpgsql;
+          
+          ALTER TABLE findings
+          ADD COLUMN finding_identity_hash TEXT NULL;
+          
+          CREATE OR REPLACE FUNCTION update_finding_identity_hash_trigger()
+          RETURNS TRIGGER AS $$
+          BEGIN
+              UPDATE findings
+              SET finding_identity_hash = compute_finding_identity(NEW.finding_id)
+              WHERE finding_id = NEW.finding_id;
+              RETURN NEW;
+          END;
+          $$ LANGUAGE plpgsql;
+          
+          CREATE OR REPLACE TRIGGER after_insert_finding
+          AFTER INSERT ON findings
+          FOR EACH ROW
+          EXECUTE PROCEDURE update_finding_identity_hash_trigger();
+          
+          CREATE OR REPLACE TRIGGER after_update_finding
+          AFTER UPDATE OF finding_field,
+                      finding_type,
+                      finding_value,
+                      finding_labels,
+                      finding_name,
+                      finding_inject_id ON findings
+          FOR EACH ROW
+          EXECUTE PROCEDURE update_finding_identity_hash_trigger();
+          
+          -- migration of existing records
+          UPDATE findings
+          SET finding_identity_hash = compute_finding_identity(finding_id)
+          WHERE finding_identity_hash IS NULL;
+          """;
+
+      statement.executeUpdate(updateInjectExpectationResult);
+    }
+  }
+}

--- a/openbas-api/src/main/java/io/openbas/migration/V3_90__add_automatic_finding_hash_column.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_90__add_automatic_finding_hash_column.java
@@ -1,10 +1,9 @@
 package io.openbas.migration;
 
+import java.sql.Statement;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 import org.springframework.stereotype.Component;
-
-import java.sql.Statement;
 
 @Component
 public class V3_90__add_automatic_finding_hash_column extends BaseJavaMigration {
@@ -17,7 +16,7 @@ public class V3_90__add_automatic_finding_hash_column extends BaseJavaMigration 
           """
           -- necessary for hashing functions
           CREATE EXTENSION IF NOT EXISTS pgcrypto;
-          
+
           CREATE OR REPLACE FUNCTION compute_finding_identity(id TEXT)
           RETURNS TEXT
           AS
@@ -51,10 +50,10 @@ public class V3_90__add_automatic_finding_hash_column extends BaseJavaMigration 
               );
             END;
             $$ LANGUAGE plpgsql;
-          
+
           ALTER TABLE findings
           ADD COLUMN finding_identity_hash TEXT NULL;
-          
+
           CREATE OR REPLACE FUNCTION update_finding_identity_hash_trigger()
           RETURNS TRIGGER AS $$
           BEGIN
@@ -64,12 +63,12 @@ public class V3_90__add_automatic_finding_hash_column extends BaseJavaMigration 
               RETURN NEW;
           END;
           $$ LANGUAGE plpgsql;
-          
+
           CREATE OR REPLACE TRIGGER after_insert_finding
           AFTER INSERT ON findings
           FOR EACH ROW
           EXECUTE PROCEDURE update_finding_identity_hash_trigger();
-          
+
           CREATE OR REPLACE TRIGGER after_update_finding
           AFTER UPDATE OF finding_field,
                       finding_type,
@@ -79,7 +78,7 @@ public class V3_90__add_automatic_finding_hash_column extends BaseJavaMigration 
                       finding_inject_id ON findings
           FOR EACH ROW
           EXECUTE PROCEDURE update_finding_identity_hash_trigger();
-          
+
           -- migration of existing records
           UPDATE findings
           SET finding_identity_hash = compute_finding_identity(finding_id)

--- a/openbas-api/src/main/java/io/openbas/migration/V3_90__add_automatic_finding_hash_column.java
+++ b/openbas-api/src/main/java/io/openbas/migration/V3_90__add_automatic_finding_hash_column.java
@@ -15,74 +15,46 @@ public class V3_90__add_automatic_finding_hash_column extends BaseJavaMigration 
       String updateInjectExpectationResult =
           """
           -- necessary for hashing functions
-          CREATE EXTENSION IF NOT EXISTS pgcrypto;
+          CREATE SEQUENCE IF NOT EXISTS exercise_launch_order_seq
+          AS BIGINT
+          INCREMENT BY 1
+          START WITH 1;
 
-          CREATE OR REPLACE FUNCTION compute_finding_identity(id TEXT)
-          RETURNS TEXT
-          AS
-          $$
-            BEGIN
-              RETURN (
-                SELECT digest(
-                  concat(
-                      finding_field,
-                      finding_type,
-                      finding_type,
-                      finding_value,
-                      array_to_string(finding_labels, ''),
-                      finding_name,
-                      i.inject_content,
-                      i.inject_injector_contract,
-                      -- to force differentiating between identical atomic tests
-                      -- use an ad hoc random uuid instead of a scenario id.
-                      -- also assume a single scenario per simulation
-                      COALESCE(se.scenario_id, gen_random_uuid()::text)
-                  ),
-                  'sha256') as identity_hash_value
-                FROM findings f
-                  JOIN injects i
-                    ON f.finding_inject_id = i.inject_id
-                  LEFT JOIN exercises e
-                    ON e.exercise_id = i.inject_exercise
-                  LEFT JOIN scenarios_exercises se
-                    ON e.exercise_id = se.exercise_id
-                where finding_id = id
-              );
-            END;
-            $$ LANGUAGE plpgsql;
+          ALTER TABLE exercises
+          ADD COLUMN exercise_launch_order BIGINT;
 
-          ALTER TABLE findings
-          ADD COLUMN finding_identity_hash TEXT NULL;
-
-          CREATE OR REPLACE FUNCTION update_finding_identity_hash_trigger()
+          CREATE OR REPLACE FUNCTION update_launch_order_trigger()
           RETURNS TRIGGER AS $$
           BEGIN
-              UPDATE findings
-              SET finding_identity_hash = compute_finding_identity(NEW.finding_id)
-              WHERE finding_id = NEW.finding_id;
+              UPDATE exercises
+              SET exercise_launch_order = CASE
+                  WHEN NEW.exercise_start_date IS NULL
+                      THEN NULL
+                  ELSE nextval('exercise_launch_order_seq')
+                  END
+              WHERE exercise_id = NEW.exercise_id;
               RETURN NEW;
           END;
           $$ LANGUAGE plpgsql;
 
-          CREATE OR REPLACE TRIGGER after_insert_finding
-          AFTER INSERT ON findings
+          CREATE OR REPLACE TRIGGER after_insert_exercise
+          AFTER INSERT ON exercises
           FOR EACH ROW
-          EXECUTE PROCEDURE update_finding_identity_hash_trigger();
+          EXECUTE PROCEDURE update_launch_order_trigger();
 
-          CREATE OR REPLACE TRIGGER after_update_finding
-          AFTER UPDATE OF finding_field,
-                      finding_type,
-                      finding_value,
-                      finding_labels,
-                      finding_name,
-                      finding_inject_id ON findings
+          CREATE OR REPLACE TRIGGER after_update_exercise_start_date
+          AFTER UPDATE OF exercise_start_date ON exercises
           FOR EACH ROW
-          EXECUTE PROCEDURE update_finding_identity_hash_trigger();
+          EXECUTE PROCEDURE update_launch_order_trigger();
 
           -- migration of existing records
-          UPDATE findings
-          SET finding_identity_hash = compute_finding_identity(finding_id)
-          WHERE finding_identity_hash IS NULL;
+          UPDATE exercises e
+          SET exercise_launch_order = migrated_start_order
+          FROM (SELECT exercise_id, nextval('exercise_launch_order_seq') as migrated_start_order
+                FROM exercises
+                WHERE exercise_start_date IS NOT NULL
+                ORDER BY exercise_start_date DESC NULLS LAST) o
+          WHERE e.exercise_id = o.exercise_id;
           """;
 
       statement.executeUpdate(updateInjectExpectationResult);

--- a/openbas-api/src/main/java/io/openbas/service/targets/search/specifications/ExcludeMembersOfAssetGroupsSpecification.java
+++ b/openbas-api/src/main/java/io/openbas/service/targets/search/specifications/ExcludeMembersOfAssetGroupsSpecification.java
@@ -52,8 +52,7 @@ public class ExcludeMembersOfAssetGroupsSpecification<T> {
           .select(criteriaBuilder.literal(1))
           .where(
               positiveSpec.toPredicate(assetTable, query, criteriaBuilder),
-              criteriaBuilder.equal(
-                  finalFrom.get("id"), query.getRoots().stream().findFirst().get().get("id")));
+              criteriaBuilder.equal(finalFrom.get("id"), root.get("id")));
       return criteriaBuilder.exists(subQuery).not();
     });
   }
@@ -68,8 +67,7 @@ public class ExcludeMembersOfAssetGroupsSpecification<T> {
       subQuery
           .select(criteriaBuilder.literal(1))
           .where(
-              criteriaBuilder.equal(
-                  finalFrom.get("id"), query.getRoots().stream().findFirst().get().get("id")),
+              criteriaBuilder.equal(finalFrom.get("id"), root.get("id")),
               assetGroupTable.get("id").in(assetGroupIds.stream().toList()));
       return criteriaBuilder.exists(subQuery).not();
     };

--- a/openbas-api/src/main/java/io/openbas/service/targets/search/specifications/IncludeDirectEndpointTargetsSpecification.java
+++ b/openbas-api/src/main/java/io/openbas/service/targets/search/specifications/IncludeDirectEndpointTargetsSpecification.java
@@ -30,8 +30,7 @@ public class IncludeDirectEndpointTargetsSpecification<T> {
           .select(criteriaBuilder.literal(1))
           .where(
               criteriaBuilder.equal(injectTable.get("id"), scopedInject.getId()),
-              criteriaBuilder.equal(
-                  finalFrom.get("id"), query.getRoots().stream().findFirst().get().get("id")));
+              criteriaBuilder.equal(finalFrom.get("id"), root.get("id")));
       return criteriaBuilder.exists(subQuery);
     };
   }

--- a/openbas-api/src/main/java/io/openbas/service/targets/search/specifications/IncludeMembersOfAssetGroupsSpecification.java
+++ b/openbas-api/src/main/java/io/openbas/service/targets/search/specifications/IncludeMembersOfAssetGroupsSpecification.java
@@ -52,8 +52,7 @@ public class IncludeMembersOfAssetGroupsSpecification<T> {
           .select(criteriaBuilder.literal(1))
           .where(
               positiveSpec.toPredicate(assetTable, query, criteriaBuilder),
-              criteriaBuilder.equal(
-                  finalJoin.get("id"), query.getRoots().stream().findFirst().get().get("id")));
+              criteriaBuilder.equal(finalJoin.get("id"), root.get("id")));
       return criteriaBuilder.exists(subQuery);
     });
   }
@@ -68,8 +67,7 @@ public class IncludeMembersOfAssetGroupsSpecification<T> {
       subQuery
           .select(criteriaBuilder.literal(1))
           .where(
-              criteriaBuilder.equal(
-                  finalJoin.get("id"), query.getRoots().stream().findFirst().get().get("id")),
+              criteriaBuilder.equal(finalJoin.get("id"), root.get("id")),
               assetGroupTable.get("id").in(assetGroupIds));
       return criteriaBuilder.exists(subQuery);
     };

--- a/openbas-api/src/test/java/io/openbas/rest/finding/EsFindingServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/finding/EsFindingServiceTest.java
@@ -1,6 +1,6 @@
 package io.openbas.rest.finding;
 
-import static io.openbas.rest.finding.FindingFixture.*;
+import static io.openbas.utils.fixtures.FindingFixture.*;
 import static io.openbas.utils.fixtures.InjectFixture.getDefaultInject;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/openbas-api/src/test/java/io/openbas/rest/finding/FindingApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/finding/FindingApiTest.java
@@ -381,8 +381,19 @@ class FindingApiTest extends IntegrationTest {
           latestFindingWrappers.add(findingWrapper);
           entry.getValue().withFinding(findingWrapper).withEndpoint(endpointWrapper);
         }
-
         scenarioWrapper.persist();
+
+        // add injects (atomic testing) with findings too
+        for (int i = 0; i < 2; i++) {
+          FindingComposer.Composer findingWrapper =
+                  findingComposer.forFinding(FindingFixture.createDefaultTextFindingWithRandomValue());
+          latestFindingWrappers.add(findingWrapper);
+          injectComposer
+                  .forInject(InjectFixture.getDefaultInject())
+                  .withFinding(findingWrapper)
+                  .withEndpoint(endpointWrapper)
+                  .persist();
+        }
 
         SearchPaginationInput input = PaginationFixture.getDefault().build();
 

--- a/openbas-api/src/test/java/io/openbas/rest/finding/FindingApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/finding/FindingApiTest.java
@@ -1,7 +1,8 @@
 package io.openbas.rest.finding;
 
-import static io.openbas.rest.finding.FindingFixture.TEXT_FIELD;
 import static io.openbas.utils.JsonUtils.asJsonString;
+import static io.openbas.utils.fixtures.FindingFixture.TEXT_FIELD;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -10,6 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openbas.IntegrationTest;
 import io.openbas.database.model.*;
+import io.openbas.database.repository.FindingRepository;
+import io.openbas.rest.finding.form.FindingOutput;
+import io.openbas.utils.FindingMapper;
 import io.openbas.utils.fixtures.*;
 import io.openbas.utils.fixtures.composers.*;
 import io.openbas.utils.mockUser.WithMockAdminUser;
@@ -20,11 +24,10 @@ import jakarta.transaction.Transactional;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Hashtable;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import java.util.Map;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,6 +36,7 @@ import org.springframework.test.web.servlet.ResultActions;
 @TestInstance(PER_CLASS)
 @Transactional
 @WithMockAdminUser
+@DisplayName("Findings search tests")
 class FindingApiTest extends IntegrationTest {
 
   private static final String FINDING_URI = "/api/findings";
@@ -44,176 +48,362 @@ class FindingApiTest extends IntegrationTest {
   @Autowired private AssetGroupComposer assetGroupComposer;
   @Autowired private EndpointComposer endpointComposer;
   @Autowired private InjectComposer injectComposer;
+  @Autowired private InjectorContractComposer injectorContractComposer;
   @Autowired private ScenarioComposer scenarioComposer;
   @Autowired private ExerciseComposer simulationComposer;
   @Autowired private AgentComposer agentComposer;
   @Autowired private TagComposer tagComposer;
+  @Autowired private InjectorFixture injectorFixture;
+  @Autowired private FindingRepository findingRepository;
+  @Autowired private FindingMapper findingMapper;
   @Autowired private EntityManager entityManager;
-  private Exercise savedSimulation;
-  private Scenario savedScenario;
-  private AssetGroup savedAssetGroup;
-  private Endpoint savedEndpoint;
-  private InjectComposer.Composer injectComposer1;
-  private ExerciseComposer.Composer simulationComposer1;
-  private EndpointComposer.Composer endpointComposer1;
 
   @BeforeEach
-  void setup() {
-    endpointComposer1 = endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
-
-    savedEndpoint =
-        endpointComposer1
-            .withAgent(agentComposer.forAgent(AgentFixture.createDefaultAgentService()))
-            .persist()
-            .get();
-
-    AssetGroupComposer.Composer assetGroupComposer =
-        this.assetGroupComposer
-            .forAssetGroup(AssetGroupFixture.createDefaultAssetGroup("asset-group"))
-            .withAsset(endpointComposer1);
-
-    savedAssetGroup = assetGroupComposer.persist().get();
-
-    injectComposer1 =
-        injectComposer
-            .forInject(InjectFixture.getDefaultInject())
-            .withAssetGroup(assetGroupComposer);
-
-    simulationComposer1 =
-        simulationComposer
-            .forExercise(ExerciseFixture.createRunningAttackExercise())
-            .withInject(injectComposer1);
-
-    savedScenario =
-        scenarioComposer
-            .forScenario(ScenarioFixture.createDefaultCrisisScenario())
-            .withSimulation(simulationComposer1)
-            .persist()
-            .get();
-
-    savedSimulation = savedScenario.getExercises().getFirst();
+  void setUp() {
+    scenarioComposer.reset();
+    simulationComposer.reset();
+    injectComposer.reset();
+    tagComposer.reset();
+    agentComposer.reset();
+    findingComposer.reset();
+    endpointComposer.reset();
+    assetGroupComposer.reset();
+    injectorContractComposer.reset();
   }
 
-  @DisplayName("Search global findings")
-  @Test
-  public void given_a_search_input_should_return_page_of_findings() throws Exception {
-    Finding savedFinding =
-        findingComposer
-            .forFinding(FindingFixture.createDefaultTextFinding())
-            .withEndpoint(endpointComposer.forEndpoint(savedEndpoint))
-            .withInject(injectComposer1)
-            .withTag(tagComposer.forTag(TagFixture.getTagWithText("Finding")))
-            .persist()
-            .get();
-    SearchPaginationInput input =
-        buildDefaultFilters(
-            ContractOutputType.Text,
-            "Text",
-            savedFinding,
-            savedSimulation,
-            savedScenario,
-            savedEndpoint,
-            savedAssetGroup);
+  @Nested
+  @DisplayName("With several simulations from same scenario in database")
+  class WithSeveralSimulationsFromSameScenario {
+    private final int numberOfPreviousSimulations = 5;
+    private final String firstInjectName = "firstInjectName";
+    private final String secondInjectName = "secondInjectName";
+    private final String thirdInjectName = "thirdInjectName";
+    private final String fourthInjectName = "fourthInjectName";
 
-    entityManager.flush();
-    entityManager.clear();
+    private ScenarioComposer.Composer getScenarioWrapper() throws Exception {
+      return scenarioComposer.forScenario(ScenarioFixture.getScenario());
+    }
 
-    performCallbackRequest(FINDING_URI + "/search", input)
-        .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
-        .andExpect(jsonPath("$.content.[0].finding_name").value("Text"))
-        .andExpect(jsonPath("$.content.[0].finding_field").value(TEXT_FIELD))
-        .andExpect(jsonPath("$.content.[0].finding_value").value("text_value"))
-        .andExpect(
-            jsonPath("$.content.[0].finding_assets.[0].asset_id").value(savedEndpoint.getId()))
-        .andExpect(
-            jsonPath("$.content.[0].finding_inject.inject_id")
-                .value(savedFinding.getInject().getId()))
-        .andExpect(
-            jsonPath("$.content.[0].finding_simulation.exercise_id").value(savedSimulation.getId()))
-        .andExpect(
-            jsonPath("$.content.[0].finding_scenario.scenario_id").value(savedScenario.getId()));
+    private Hashtable<String, InjectComposer.Composer> attachSimulationToScenario(
+        ScenarioComposer.Composer scenarioWrapper) throws Exception {
+      // create arbitrary injects
+      Hashtable<String, InjectComposer.Composer> injects = new Hashtable<>();
+      injects.put(
+          firstInjectName,
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withInjectorContract(
+                  injectorContractComposer
+                      .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+                      .withInjector(injectorFixture.getWellKnownObasImplantInjector())));
+      injects.put(
+          secondInjectName,
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withInjectorContract(
+                  injectorContractComposer
+                      .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+                      .withInjector(injectorFixture.getWellKnownObasImplantInjector())));
+      injects.put(
+          thirdInjectName,
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withInjectorContract(
+                  injectorContractComposer
+                      .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+                      .withInjector(injectorFixture.getWellKnownObasImplantInjector())));
+      injects.put(
+          fourthInjectName,
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withInjectorContract(
+                  injectorContractComposer
+                      .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+                      .withInjector(injectorFixture.getWellKnownObasImplantInjector())));
+
+      ExerciseComposer.Composer simulationWrapper =
+          simulationComposer.forExercise(ExerciseFixture.createDefaultExercise());
+      for (Map.Entry<String, InjectComposer.Composer> entry : injects.entrySet()) {
+        simulationWrapper.withInject(entry.getValue());
+      }
+
+      scenarioWrapper.withSimulation(simulationWrapper);
+
+      return injects;
+    }
+
+    private List<FindingComposer.Composer> getDefaultFindings() throws Exception {
+      return new ArrayList<>(
+          List.of(
+              findingComposer.forFinding(FindingFixture.createDefaultTextFindingWithRandomValue()),
+              findingComposer.forFinding(FindingFixture.createDefaultTextFindingWithRandomValue()),
+              findingComposer.forFinding(FindingFixture.createDefaultTextFindingWithRandomValue()),
+              findingComposer.forFinding(
+                  FindingFixture.createDefaultTextFindingWithRandomValue())));
+    }
+
+    @Nested
+    @DisplayName("When searching globally for findings")
+    class WhenSearchingGloballyForFindings {
+      @Test
+      @DisplayName("Returns only findings for latest simulation")
+      public void ReturnsOnlyFindingsForLatestSimulation() throws Exception {
+        ScenarioComposer.Composer scenarioWrapper = getScenarioWrapper();
+        for (int i = 0; i < numberOfPreviousSimulations; i++) {
+          Hashtable<String, InjectComposer.Composer> injects =
+              attachSimulationToScenario(scenarioWrapper);
+          for (Map.Entry<String, InjectComposer.Composer> entry : injects.entrySet()) {
+            for (FindingComposer.Composer findingWrapper : getDefaultFindings()) {
+              entry.getValue().withFinding(findingWrapper);
+            }
+          }
+        }
+
+        // latest findings
+        Hashtable<String, List<FindingComposer.Composer>> latestFindingWrappers = new Hashtable<>();
+        latestFindingWrappers.put(
+            firstInjectName,
+            List.of(
+                findingComposer.forFinding(
+                    FindingFixture.createDefaultTextFindingWithRandomValue())));
+        latestFindingWrappers.put(
+            secondInjectName,
+            List.of(
+                findingComposer.forFinding(
+                    FindingFixture.createDefaultTextFindingWithRandomValue())));
+        latestFindingWrappers.put(
+            thirdInjectName,
+            List.of(
+                findingComposer.forFinding(
+                    FindingFixture.createDefaultTextFindingWithRandomValue())));
+        latestFindingWrappers.put(
+            fourthInjectName,
+            List.of(
+                findingComposer.forFinding(
+                    FindingFixture.createDefaultTextFindingWithRandomValue())));
+
+        // add latest simulation
+        Hashtable<String, InjectComposer.Composer> latestSimulationInjectWrappers =
+            attachSimulationToScenario(scenarioWrapper);
+        for (Map.Entry<String, InjectComposer.Composer> entry :
+            latestSimulationInjectWrappers.entrySet()) {
+          for (FindingComposer.Composer findingWrapper :
+              latestFindingWrappers.get(entry.getKey())) {
+            entry.getValue().withFinding(findingWrapper);
+          }
+        }
+
+        scenarioWrapper.persist();
+
+        SearchPaginationInput input = PaginationFixture.getDefault().build();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        String response =
+            performCallbackRequest(FINDING_URI + "/search", input)
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        List<FindingOutput> expectedFindings =
+            latestFindingWrappers.entrySet().stream()
+                .flatMap(e -> e.getValue().stream())
+                .map(wrapper -> findingMapper.toFindingOutput(wrapper.get()))
+                .toList();
+
+        assertThatJson(response)
+            .node("content")
+            .isEqualTo(mapper.writeValueAsString(expectedFindings));
+      }
+    }
+
+    @Nested
+    @DisplayName("When searching for findings on scenario")
+    class WhenSearchingForFindingsOnScenario {}
+
+    @Nested
+    @DisplayName("When searching for findings on simulation")
+    class WhenSearchingForFindingsOnSimulation {}
+
+    @Nested
+    @DisplayName("When searching for findings on inject")
+    class WhenSearchingForFindingsOnInject {}
+
+    @Nested
+    @DisplayName("When searching for findings on Endpoint")
+    class WhenSearchingForFindingsOnEndpoint {}
   }
 
-  @Test
-  @DisplayName("Search findings by simulation")
-  void should_return_findings_by_simulation() throws Exception {
-    Finding savedFinding =
-        findingComposer
-            .forFinding(FindingFixture.createDefaultIPV6Finding())
-            .withEndpoint(endpointComposer.forEndpoint(savedEndpoint))
-            .withInject(injectComposer1)
-            .withTag(tagComposer.forTag(TagFixture.getTagWithText("Finding IPv6")))
-            .persist()
-            .get();
-    SearchPaginationInput input =
-        buildDefaultFilters(
-            ContractOutputType.IPv6,
-            "IPv6",
-            savedFinding,
-            savedSimulation,
-            null,
-            savedEndpoint,
-            null);
+  @Nested
+  @DisplayName("Basic tests")
+  class BasicTests {
+    private Exercise savedSimulation;
+    private Scenario savedScenario;
+    private AssetGroup savedAssetGroup;
+    private Endpoint savedEndpoint;
+    private InjectComposer.Composer injectWrapper;
 
-    performCallbackRequest(FINDING_URI + "/exercises/" + savedSimulation.getId() + "/search", input)
-        .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
-        .andExpect(
-            jsonPath("$.content.[0].finding_value")
-                .value("2001:0000:130F:0000:0000:09C0:876A:130B"));
-  }
+    @BeforeEach
+    void setup() {
+      EndpointComposer.Composer endpointWrapper =
+          endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
 
-  @Test
-  @DisplayName("Search findings by scenario")
-  void should_return_findings_by_scenario() throws Exception {
-    Finding savedFinding =
-        findingComposer
-            .forFinding(FindingFixture.createDefaultFindingCredentials())
-            .withEndpoint(endpointComposer.forEndpoint(savedEndpoint))
-            .withInject(injectComposer1)
-            .withTag(tagComposer.forTag(TagFixture.getTagWithText("Finding")))
-            .persist()
-            .get();
+      savedEndpoint =
+          endpointWrapper
+              .withAgent(agentComposer.forAgent(AgentFixture.createDefaultAgentService()))
+              .get();
 
-    SearchPaginationInput input =
-        buildDefaultFilters(
-            ContractOutputType.Credentials,
-            "Credentials",
-            savedFinding,
-            null,
-            savedScenario,
-            savedEndpoint,
-            savedAssetGroup);
+      AssetGroupComposer.Composer assetGroupWrapper =
+          assetGroupComposer
+              .forAssetGroup(AssetGroupFixture.createDefaultAssetGroup("asset-group"))
+              .withAsset(endpointWrapper);
 
-    entityManager.flush();
-    entityManager.clear();
+      savedAssetGroup = assetGroupWrapper.get();
 
-    performCallbackRequest(FINDING_URI + "/scenarios/" + savedScenario.getId() + "/search", input)
-        .andExpect(
-            jsonPath("$.content.[0].finding_scenario.scenario_id").value(savedScenario.getId()))
-        .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
-        .andExpect(jsonPath("$.content.[0].finding_value").value("admin:admin"));
-  }
+      injectWrapper =
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withAssetGroup(assetGroupWrapper);
 
-  @Test
-  @DisplayName("Search findings by endpoint")
-  void should_return_findings_by_endpoint() throws Exception {
-    Finding savedFinding =
-        findingComposer
-            .forFinding(FindingFixture.createDefaultTextFinding())
-            .withEndpoint(endpointComposer.forEndpoint(savedEndpoint))
-            .withInject(injectComposer1)
-            .withTag(tagComposer.forTag(TagFixture.getTagWithText("Finding Text")))
-            .persist()
-            .get();
-    SearchPaginationInput input =
-        buildDefaultFilters(
-            ContractOutputType.Text, "Text", savedFinding, null, null, savedEndpoint, null);
+      ExerciseComposer.Composer simulationWrapper =
+          simulationComposer
+              .forExercise(ExerciseFixture.createRunningAttackExercise())
+              .withInject(injectWrapper);
 
-    performCallbackRequest(FINDING_URI + "/endpoints/" + savedEndpoint.getId() + "/search", input)
-        .andExpect(
-            jsonPath("$.content.[0].finding_assets.[0].asset_id").value(savedEndpoint.getId()))
-        .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
-        .andExpect(jsonPath("$.content.[0].finding_value").value("text_value"));
+      savedScenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .withSimulation(simulationWrapper)
+              .persist()
+              .get();
+
+      savedSimulation = savedScenario.getExercises().getFirst();
+    }
+
+    @DisplayName("Search global findings")
+    @Test
+    public void given_a_search_input_should_return_page_of_findings() throws Exception {
+      Finding savedFinding =
+          findingComposer
+              .forFinding(FindingFixture.createDefaultTextFinding())
+              .withEndpoint(endpointComposer.forEndpoint(savedEndpoint))
+              .withInject(injectWrapper)
+              .withTag(tagComposer.forTag(TagFixture.getTagWithText("Finding")))
+              .persist()
+              .get();
+      SearchPaginationInput input =
+          buildDefaultFilters(
+              ContractOutputType.Text,
+              "Text",
+              savedFinding,
+              savedSimulation,
+              savedScenario,
+              savedEndpoint,
+              savedAssetGroup);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      performCallbackRequest(FINDING_URI + "/search", input)
+          .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
+          .andExpect(jsonPath("$.content.[0].finding_name").value("Text"))
+          .andExpect(jsonPath("$.content.[0].finding_field").value(TEXT_FIELD))
+          .andExpect(jsonPath("$.content.[0].finding_value").value("text_value"))
+          .andExpect(
+              jsonPath("$.content.[0].finding_assets.[0].asset_id").value(savedEndpoint.getId()))
+          .andExpect(
+              jsonPath("$.content.[0].finding_inject.inject_id")
+                  .value(savedFinding.getInject().getId()))
+          .andExpect(
+              jsonPath("$.content.[0].finding_simulation.exercise_id")
+                  .value(savedSimulation.getId()))
+          .andExpect(
+              jsonPath("$.content.[0].finding_scenario.scenario_id").value(savedScenario.getId()));
+    }
+
+    @Test
+    @DisplayName("Search findings by simulation")
+    void should_return_findings_by_simulation() throws Exception {
+      Finding savedFinding =
+          findingComposer
+              .forFinding(FindingFixture.createDefaultIPV6Finding())
+              .withEndpoint(endpointComposer.forEndpoint(savedEndpoint))
+              .withInject(injectWrapper)
+              .withTag(tagComposer.forTag(TagFixture.getTagWithText("Finding IPv6")))
+              .persist()
+              .get();
+      SearchPaginationInput input =
+          buildDefaultFilters(
+              ContractOutputType.IPv6,
+              "IPv6",
+              savedFinding,
+              savedSimulation,
+              null,
+              savedEndpoint,
+              null);
+
+      performCallbackRequest(
+              FINDING_URI + "/exercises/" + savedSimulation.getId() + "/search", input)
+          .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
+          .andExpect(
+              jsonPath("$.content.[0].finding_value")
+                  .value("2001:0000:130F:0000:0000:09C0:876A:130B"));
+    }
+
+    @Test
+    @DisplayName("Search findings by scenario")
+    void should_return_findings_by_scenario() throws Exception {
+      Finding savedFinding =
+          findingComposer
+              .forFinding(FindingFixture.createDefaultFindingCredentials())
+              .withEndpoint(endpointComposer.forEndpoint(savedEndpoint))
+              .withInject(injectWrapper)
+              .withTag(tagComposer.forTag(TagFixture.getTagWithText("Finding")))
+              .persist()
+              .get();
+
+      SearchPaginationInput input =
+          buildDefaultFilters(
+              ContractOutputType.Credentials,
+              "Credentials",
+              savedFinding,
+              null,
+              savedScenario,
+              savedEndpoint,
+              savedAssetGroup);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      performCallbackRequest(FINDING_URI + "/scenarios/" + savedScenario.getId() + "/search", input)
+          .andExpect(
+              jsonPath("$.content.[0].finding_scenario.scenario_id").value(savedScenario.getId()))
+          .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
+          .andExpect(jsonPath("$.content.[0].finding_value").value("admin:admin"));
+    }
+
+    @Test
+    @DisplayName("Search findings by endpoint")
+    void should_return_findings_by_endpoint() throws Exception {
+      Finding savedFinding =
+          findingComposer
+              .forFinding(FindingFixture.createDefaultTextFinding())
+              .withEndpoint(endpointComposer.forEndpoint(savedEndpoint))
+              .withInject(injectWrapper)
+              .withTag(tagComposer.forTag(TagFixture.getTagWithText("Finding Text")))
+              .persist()
+              .get();
+      SearchPaginationInput input =
+          buildDefaultFilters(
+              ContractOutputType.Text, "Text", savedFinding, null, null, savedEndpoint, null);
+
+      performCallbackRequest(FINDING_URI + "/endpoints/" + savedEndpoint.getId() + "/search", input)
+          .andExpect(
+              jsonPath("$.content.[0].finding_assets.[0].asset_id").value(savedEndpoint.getId()))
+          .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
+          .andExpect(jsonPath("$.content.[0].finding_value").value("text_value"));
+    }
   }
 
   private SearchPaginationInput buildDefaultFilters(

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/ExerciseFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/ExerciseFixture.java
@@ -99,6 +99,10 @@ public class ExerciseFixture {
     return exercise;
   }
 
+  public static Exercise createFinishedAttackExercise() {
+    return createFinishedAttackExercise(Instant.now());
+  }
+
   public static Exercise createFinishedAttackExercise(Instant startTime) {
     Exercise exercise = createDefaultExerciseWithName("Draft incident response exercise");
     exercise.setDescription("An incident response exercise for my enterprise");

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/FindingFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/FindingFixture.java
@@ -1,7 +1,8 @@
-package io.openbas.rest.finding;
+package io.openbas.utils.fixtures;
 
 import io.openbas.database.model.ContractOutputType;
 import io.openbas.database.model.Finding;
+import java.util.UUID;
 
 public class FindingFixture {
 
@@ -16,6 +17,12 @@ public class FindingFixture {
     finding.setField(TEXT_FIELD);
     finding.setValue("text_value");
     finding.setLabels(new String[] {"reconnaissance phase"});
+    return finding;
+  }
+
+  public static Finding createDefaultTextFindingWithRandomValue() {
+    Finding finding = createDefaultTextFinding();
+    finding.setValue(UUID.randomUUID().toString());
     return finding;
   }
 

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/InjectComposer.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/InjectComposer.java
@@ -25,6 +25,7 @@ public class InjectComposer extends ComposerBase<Inject> {
     private final List<TeamComposer.Composer> teamComposers = new ArrayList<>();
     private final List<AssetGroupComposer.Composer> assetGroupComposers = new ArrayList<>();
     private final List<InjectExpectationComposer.Composer> expectationComposers = new ArrayList<>();
+    private final List<FindingComposer.Composer> findingComposers = new ArrayList<>();
 
     public Composer(Inject inject) {
       this.inject = inject;
@@ -108,6 +109,15 @@ public class InjectComposer extends ComposerBase<Inject> {
       injectDependencyId.setInjectChildren(this.inject);
       injectDependency.setCompositeId(injectDependencyId);
       this.inject.setDependsOn(List.of(injectDependency));
+      return this;
+    }
+
+    public Composer withFinding(FindingComposer.Composer findingComposer) {
+      findingComposers.add(findingComposer);
+      List<Finding> tmpFindings = this.inject.getFindings();
+      tmpFindings.add(findingComposer.get());
+      findingComposer.get().setInject(this.inject);
+      this.inject.setFindings(tmpFindings);
       return this;
     }
 

--- a/openbas-api/src/test/resources/application.properties
+++ b/openbas-api/src/test/resources/application.properties
@@ -41,6 +41,8 @@ spring.flyway.postgresql.transactional-lock=false
 spring.profiles.active=test
 spring.jpa.properties.hibernate.jdbc.batch_size=250
 spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
 
 ### ENGINE Configuration
 engine.index-prefix=openbas

--- a/openbas-api/src/test/resources/application.properties
+++ b/openbas-api/src/test/resources/application.properties
@@ -41,8 +41,6 @@ spring.flyway.postgresql.transactional-lock=false
 spring.profiles.active=test
 spring.jpa.properties.hibernate.jdbc.batch_size=250
 spring.jpa.properties.hibernate.order_inserts=true
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
 
 ### ENGINE Configuration
 engine.index-prefix=openbas

--- a/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
@@ -23,6 +23,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
@@ -91,6 +92,11 @@ public class Exercise implements Base {
   @JsonProperty("exercise_start_date")
   @Queryable(filterable = true, sortable = true)
   private Instant start;
+
+  @Column(name = "exercise_launch_order", insertable = false, updatable = false)
+  @JsonProperty("exercise_launch_order")
+  @Setter(AccessLevel.NONE)
+  private Long launchOrder;
 
   @Column(name = "exercise_end_date")
   @JsonProperty("exercise_end_date")

--- a/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
@@ -94,7 +94,7 @@ public class Exercise implements Base {
   private Instant start;
 
   @Column(name = "exercise_launch_order", insertable = false, updatable = false)
-  @JsonProperty("exercise_launch_order")
+  @JsonIgnore
   @Setter(AccessLevel.NONE)
   private Long launchOrder;
 

--- a/openbas-model/src/main/java/io/openbas/database/model/Inject.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Inject.java
@@ -252,6 +252,7 @@ public class Inject implements Base, Injection {
   private List<InjectExpectation> expectations = new ArrayList<>();
 
   @JsonIgnore
+  @Getter
   @OneToMany(mappedBy = "inject", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Finding> findings = new ArrayList<>();
 

--- a/openbas-model/src/main/java/io/openbas/database/specification/FindingSpecification.java
+++ b/openbas-model/src/main/java/io/openbas/database/specification/FindingSpecification.java
@@ -1,5 +1,6 @@
 package io.openbas.database.specification;
 
+import io.openbas.database.model.ExerciseStatus;
 import io.openbas.database.model.Finding;
 import jakarta.persistence.criteria.*;
 import org.jetbrains.annotations.NotNull;
@@ -30,8 +31,8 @@ public class FindingSpecification {
 
   public static Specification<Finding> forLatestSimulations() {
     return (root, query, cb) -> {
-      Join<?, ?> injectJoin = root.join("inject", JoinType.INNER);
-      Join<?, ?> exerciseJoin1 = injectJoin.join("exercise", JoinType.LEFT);
+      Join<?, ?> exerciseJoin1 =
+          root.join("inject", JoinType.INNER).join("exercise", JoinType.LEFT);
       Join<?, ?> exerciseJoin2 =
           exerciseJoin1.join("scenario", JoinType.LEFT).join("exercises", JoinType.LEFT);
 
@@ -39,9 +40,20 @@ public class FindingSpecification {
           cb.and(
               cb.equal(
                   exerciseJoin1.get("scenario").get("id"), exerciseJoin2.get("scenario").get("id")),
-              cb.lessThan(exerciseJoin1.get("createdAt"), exerciseJoin2.get("createdAt"))));
+              // check this column is not null for joining
+              cb.isNotNull(exerciseJoin1.get("launchOrder")),
+              cb.isNotNull(exerciseJoin2.get("launchOrder")),
+              // only consider finished simulations
+              cb.equal(exerciseJoin1.get("status"), ExerciseStatus.FINISHED),
+              cb.equal(exerciseJoin2.get("status"), ExerciseStatus.FINISHED),
+              // trim to "latest" simulation
+              cb.lessThan(exerciseJoin1.get("launchOrder"), exerciseJoin2.get("launchOrder"))));
 
-      return cb.isNull(exerciseJoin2.get("id"));
+      return cb.and(
+          cb.isNull(exerciseJoin2.get("id")),
+          cb.or(
+              cb.equal(exerciseJoin1.get("status"), ExerciseStatus.FINISHED),
+              cb.isNull(exerciseJoin1.get("id"))));
     };
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Only show findings from the latest FINISHED simulation of any given scenario, in Global, Scenario and Endpoint fidings views
* [drive by change] optimise some queries for target search

### Testing Instructions

1. Create a scenario and equip it with an inject that will generate findings (nmap is a good candidate); preferrably an inject that will assign findings to an endpoint too
2. Run several simulations of the same scenario
3. In parallel, run a few atomic testings generating some findings, also preferrably assigning some to the same endpoint than the scenario inject.
4. Wait for simulations and atomics to end
5. Browse to global finding search: only latest finished simulation for each scenario are shown; additionally the findings from the atomic testings are also there
6. Browse to the Scenario findings: only the findings of the latest finished simulation of that scenario are shown
7. Browse to the Endpoint details page: only findings attached to that Endpoint from the latest finished simulation of each scenario (if relevant) are shown; also, the findings of any atomic testing attached to the Endpoint are shown

### Related issues

* Closes #3076

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Note as to why there is a "launchOrder": this is to strictly sequentially order simulations; since simulations start on the minute, launching several simulations in a short time risks having them start at the (almost) exact same time.

Note that the exercise_start_date column has a resolution of 0 (meaning precise to the entire second), which is an almost guaranteed collision in the scenario described above.

Changing this resolution to eg the microsecond (the most precise possible in pg), overlooking possible side effects on various locations of the codebase, does not in effect guarantee the absence of collision; in fact I could already create a collision with launching a few simulations in a row.

Using a strictly increasing sequence for marking the "launch order" gets rid of that issue.