### PR TITLE
[backend] Add default value from the injector contract whent inject's content is empty Issue/3181

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -166,7 +166,7 @@ public class InjectService {
 
     // if inject content is null we add the defaults from the injector contract
     // this is the case when creating an inject from OpenCti
-    if (inject.getContent() == null) {
+    if (inject.getContent() == null || inject.getContent().isEmpty()) {
       inject.setContent(
           injectorContractService.getDynamicInjectorContractFieldsForInject(injectorContract));
     }

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -163,6 +163,14 @@ public class InjectService {
               tags.stream().map(Tag::getId).toList(),
               assetGroupService.assetGroups(input.getAssetGroups())));
     }
+
+
+    //if inject content is null we add the defaults from the injector contract
+    //this is the case when creating an inject from OpenCti
+    if(inject.getInject() == null){
+      inject.setContent(injectorContractService.getDynamicInjectorContractFieldsForInject(injectorContract));
+    }
+
     return injectRepository.save(inject);
   }
 

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -164,11 +164,11 @@ public class InjectService {
               assetGroupService.assetGroups(input.getAssetGroups())));
     }
 
-
-    //if inject content is null we add the defaults from the injector contract
-    //this is the case when creating an inject from OpenCti
-    if(inject.getInject() == null){
-      inject.setContent(injectorContractService.getDynamicInjectorContractFieldsForInject(injectorContract));
+    // if inject content is null we add the defaults from the injector contract
+    // this is the case when creating an inject from OpenCti
+    if (inject.getContent() == null) {
+      inject.setContent(
+          injectorContractService.getDynamicInjectorContractFieldsForInject(injectorContract));
     }
 
     return injectRepository.save(inject);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Load the default value from the injector contract when the inject is created with an empty content
*

### Testing Instructions

1. Create a scenario in the UI
2. Create an inject in this scenario  using the API -> choose or create a payload that has default values in the injector contract content
3. Get the inject using the api and check that the content contains the default value

### Related issues

* Closes #3181 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [X] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
