### PR TITLE
[frontend/backend] can add and remove manual/challenge/article expect…

### DIFF
--- a/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
+++ b/openbas-api/src/main/java/io/openbas/service/InjectExpectationService.java
@@ -205,7 +205,9 @@ public class InjectExpectationService {
           injectExpectation.getResults().stream()
               .filter(r -> !sourceId.equals(r.getSourceId()))
               .toList());
-      if (MANUAL.equals(injectExpectation.getType())) {
+      if (MANUAL.equals(injectExpectation.getType())
+          || ARTICLE.equals(injectExpectation.getType())
+          || CHALLENGE.equals(injectExpectation.getType())) {
         injectExpectation.setScore(null);
       } else {
         List<Double> scores =
@@ -231,7 +233,10 @@ public class InjectExpectationService {
     }
 
     // If The expectation is type manual, We should update expectations for teams and players
-    if (MANUAL.equals(updated.getType()) && updated.getTeam() != null) {
+    if ((MANUAL.equals(updated.getType())
+            || CHALLENGE.equals(updated.getType())
+            || ARTICLE.equals(updated.getType()))
+        && updated.getTeam() != null) {
       computeExpectationsForTeamsAndPlayer(updated, null);
     }
 

--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsDetail.tsx
@@ -1,4 +1,4 @@
-import { AddModeratorOutlined, MoreVertOutlined, PersonAddOutlined } from '@mui/icons-material';
+import { AddModeratorOutlined, InventoryOutlined, MoreVertOutlined, PersonAddOutlined } from '@mui/icons-material';
 import { Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogContentText, GridLegacy, IconButton, Menu, MenuItem, Paper, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { type Edge, MarkerType, ReactFlow, ReactFlowProvider, useEdgesState, useNodesState, useReactFlow } from '@xyflow/react';
@@ -24,7 +24,11 @@ import { useAppDispatch } from '../../../../utils/hooks';
 import { emptyFilled, truncate } from '../../../../utils/String';
 import { isNotEmptyField } from '../../../../utils/utils';
 import { type InjectExpectationsStore } from '../../common/injects/expectations/Expectation';
-import { HUMAN_EXPECTATION, isTechnicalExpectation } from '../../common/injects/expectations/ExpectationUtils';
+import {
+  HUMAN_EXPECTATION,
+  isManualExpectation,
+  isTechnicalExpectation,
+} from '../../common/injects/expectations/ExpectationUtils';
 import InjectIcon from '../../common/injects/InjectIcon';
 import ExecutionStatusDetail from '../../common/injects/status/ExecutionStatusDetail';
 import DetectionPreventionExpectationsValidationForm from '../../simulations/simulation/validation/expectations/DetectionPreventionExpectationsValidationForm';
@@ -660,47 +664,45 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
                             </GridLegacy>
                           )}
                       {
-                        injectExpectation.inject_expectation_type === 'MANUAL' && injectExpectation.inject_expectation_results && injectExpectation.inject_expectation_results.map((expectationResult) => {
+                        isManualExpectation(injectExpectation.inject_expectation_type) && injectExpectation.inject_expectation_results && injectExpectation.inject_expectation_results.map((expectationResult) => {
                           return (
-                            <>
-                              <GridLegacy item={true} xs={1} style={{ textAlign: 'end' }}>
-                                <IconButton
-                                  color="primary"
-                                  onClick={(ev) => {
-                                    ev.stopPropagation();
-                                    setAnchorEls({
-                                      ...anchorEls,
-                                      [`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]: ev.currentTarget,
-                                    });
-                                  }}
-                                  aria-haspopup="true"
-                                  size="large"
-                                  disabled={['collector', 'media-pressure', 'challenge'].includes(expectationResult.sourceType ?? 'unknown')}
-                                >
-                                  <MoreVertOutlined />
-                                </IconButton>
-                                <Menu
-                                  anchorEl={anchorEls[`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]}
-                                  open={Boolean(anchorEls[`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`])}
-                                  onClose={() => setAnchorEls({
+                            <GridLegacy item={true} xs={1} style={{ textAlign: 'end' }}>
+                              <IconButton
+                                color="primary"
+                                onClick={(ev) => {
+                                  ev.stopPropagation();
+                                  setAnchorEls({
                                     ...anchorEls,
-                                    [`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]: null,
-                                  })}
-                                >
-                                  <MenuItem onClick={() => handleOpenResultEdition(injectExpectation, expectationResult)}>
-                                    {t('Update')}
-                                  </MenuItem>
-                                  <MenuItem onClick={() => handleOpenResultDeletion(injectExpectation, expectationResult)}>
-                                    {t('Delete')}
-                                  </MenuItem>
-                                </Menu>
-                              </GridLegacy>
-                            </>
+                                    [`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]: ev.currentTarget,
+                                  });
+                                }}
+                                aria-haspopup="true"
+                                size="large"
+                                disabled={['collector', 'media-pressure', 'challenge'].includes(expectationResult.sourceType ?? 'unknown')}
+                              >
+                                <MoreVertOutlined />
+                              </IconButton>
+                              <Menu
+                                anchorEl={anchorEls[`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]}
+                                open={Boolean(anchorEls[`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`])}
+                                onClose={() => setAnchorEls({
+                                  ...anchorEls,
+                                  [`${injectExpectation.inject_expectation_id}-${expectationResult.sourceId}`]: null,
+                                })}
+                              >
+                                <MenuItem onClick={() => handleOpenResultEdition(injectExpectation, expectationResult)}>
+                                  {t('Update')}
+                                </MenuItem>
+                                <MenuItem onClick={() => handleOpenResultDeletion(injectExpectation, expectationResult)}>
+                                  {t('Delete')}
+                                </MenuItem>
+                              </Menu>
+                            </GridLegacy>
                           );
                         })
                       }
                       {(['DETECTION', 'PREVENTION'].includes(injectExpectation.inject_expectation_type)
-                        || (injectExpectation.inject_expectation_type === 'MANUAL'
+                        || (isManualExpectation(injectExpectation.inject_expectation_type)
                           && injectExpectation.inject_expectation_results
                           && injectExpectation.inject_expectation_results.length === 0))
                         && (
@@ -719,8 +721,8 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
                                   )
                                 }
                                 {
-                                  injectExpectation.inject_expectation_type === 'MANUAL' && (
-                                    <PersonAddOutlined fontSize="medium" />
+                                  isManualExpectation(injectExpectation.inject_expectation_type) && (
+                                    <InventoryOutlined fontSize="medium" />
                                   )
                                 }
 
@@ -886,7 +888,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
             <DialogContent>
               {selectedExpectationForCreation && (
                 <>
-                  {selectedExpectationForCreation.injectExpectation.inject_expectation_type === 'MANUAL'
+                  {isManualExpectation(selectedExpectationForCreation.injectExpectation.inject_expectation_type)
                     && <ManualExpectationsValidationForm expectation={selectedExpectationForCreation.injectExpectation} onUpdate={onUpdateValidation} />}
                   {['DETECTION', 'PREVENTION'].includes(selectedExpectationForCreation.injectExpectation.inject_expectation_type)
                     && (
@@ -911,7 +913,7 @@ const TargetResultsDetailFlow: FunctionComponent<Props> = ({
             <DialogContent>
               {selectedResultEdition && selectedResultEdition.injectExpectation && (
                 <>
-                  {selectedResultEdition.injectExpectation.inject_expectation_type === 'MANUAL'
+                  {isManualExpectation(selectedResultEdition.injectExpectation.inject_expectation_type)
                     && (
                       <ManualExpectationsValidationForm
                         expectation={selectedResultEdition.injectExpectation}

--- a/openbas-front/src/admin/components/common/injects/expectations/ExpectationUtils.tsx
+++ b/openbas-front/src/admin/components/common/injects/expectations/ExpectationUtils.tsx
@@ -30,3 +30,6 @@ export const typeIcon = (type: string) => {
 export const isTechnicalExpectation = (type: string) => {
   return [ExpectationType.PREVENTION.toString(), ExpectationType.DETECTION.toString(), ExpectationType.VULNERABILITY.toString()].includes(type);
 };
+export const isManualExpectation = (type: string) => {
+  return [ExpectationType.MANUAL.toString(), ExpectationType.ARTICLE.toString(), ExpectationType.CHALLENGE.toString()].includes(type);
+};


### PR DESCRIPTION
### Proposed changes

* Be able to add/update/remove expectations of type challenge and article


### Related issues

* Closes #3454 

