### PR TITLE
[backend/frontend] add filters for agent/asset/group on expectation dimension with custom operators (#3340)

### DIFF
--- a/openbas-api/src/main/java/io/openbas/schema/model/PropertySchemaDTO.java
+++ b/openbas-api/src/main/java/io/openbas/schema/model/PropertySchemaDTO.java
@@ -1,6 +1,7 @@
 package io.openbas.schema.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openbas.database.model.Filters;
 import io.openbas.schema.PropertySchema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -38,6 +39,9 @@ public class PropertySchemaDTO {
   @JsonProperty("schema_property_has_dynamic_value")
   private boolean dynamicValues;
 
+  @JsonProperty("schema_property_override_operators")
+  private List<Filters.FilterOperator> overrideOperators;
+
   public PropertySchemaDTO(@NotNull final PropertySchema propertySchema) {
     this.setJsonName(propertySchema.getJsonName());
     this.setEntity(propertySchema.getEntity());
@@ -51,5 +55,6 @@ public class PropertySchemaDTO {
     this.setValues(propertySchema.getAvailableValues());
     this.setDynamicValues(propertySchema.isDynamicValues());
     this.setType(propertySchema.getType().getSimpleName().toLowerCase());
+    this.setOverrideOperators(propertySchema.getOverrideOperators());
   }
 }

--- a/openbas-api/src/test/java/io/openbas/utilstest/SchemaUtilsTest.java
+++ b/openbas-api/src/test/java/io/openbas/utilstest/SchemaUtilsTest.java
@@ -1,0 +1,55 @@
+package io.openbas.utilstest;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.openbas.IntegrationTest;
+import io.openbas.annotation.Queryable;
+import io.openbas.database.model.Filters;
+import io.openbas.schema.PropertySchema;
+import io.openbas.schema.SchemaUtils;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.Getter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Schema Utils tests")
+public class SchemaUtilsTest extends IntegrationTest {
+  @Test
+  @DisplayName(
+      "When override operators are set on Queryable, PropertySchema has these operators set")
+  public void WhenOverrideOperatorsAreSetOnQueryable_PropertySchemaHasTheseOperatorsSet() {
+    List<Filters.FilterOperator> expectedOperators =
+        List.of(Filters.FilterOperator.eq, Filters.FilterOperator.contains);
+
+    @Getter
+    class TestClass {
+      @Queryable(
+          filterable = true,
+          overrideOperators = {Filters.FilterOperator.eq, Filters.FilterOperator.contains})
+      private String stringAttribute;
+
+      @Queryable(filterable = true)
+      private boolean booleanAttribute;
+    }
+
+    List<PropertySchema> propertySchemas = SchemaUtils.schema(TestClass.class);
+
+    PropertySchema stringAttribute =
+        propertySchemas.stream()
+            .filter(ps -> ps.getName().equals("stringAttribute"))
+            .findFirst()
+            .get();
+    assertThat(stringAttribute.getOverrideOperators()).isEqualTo(expectedOperators);
+
+    PropertySchema booleanAttribute =
+        propertySchemas.stream()
+            .filter(ps -> ps.getName().equals("booleanAttribute"))
+            .findFirst()
+            .get();
+    assertThat(booleanAttribute.getOverrideOperators()).isEqualTo(List.of());
+  }
+}

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/WidgetCreationSeries.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/WidgetCreationSeries.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles()(theme => ({
 }));
 
 const availableFilters = new Map([
-  ['expectation-inject', ['base_created_at', 'inject_expectation_status', 'inject_expectation_type', 'base_updated_at', 'base_simulation_side']],
+  ['expectation-inject', ['base_created_at', 'inject_expectation_status', 'inject_expectation_type', 'base_updated_at', 'base_simulation_side', 'base_agent_side', 'base_asset_side', 'base_asset_group_side']],
   ['finding', ['base_created_at', 'finding_type', 'base_updated_at', 'base_endpoint_side', 'base_simulation_side']],
   ['endpoint', ['endpoint_arch', 'endpoint_platform', 'endpoint_ips', 'endpoint_hostname']],
   ['vulnerable-endpoint', ['vulnerable_endpoint_architecture', 'vulnerable_endpoint_agents_active_status', 'vulnerable_endpoint_agents_privileges', 'vulnerable_endpoint_platform', 'base_simulation_side']],

--- a/openbas-front/src/components/common/queryable/filter/FilterUtils.tsx
+++ b/openbas-front/src/components/common/queryable/filter/FilterUtils.tsx
@@ -115,6 +115,9 @@ export const OperatorKeyValues: { [key: string]: string } = {
 };
 
 export const availableOperators = (propertySchema: PropertySchemaDTO) => {
+  if (propertySchema.schema_property_override_operators && propertySchema.schema_property_override_operators.length > 0) {
+    return propertySchema.schema_property_override_operators;
+  }
   // Date
   if (propertySchema.schema_property_type.includes('instant')) {
     return ['gt', 'gte', 'lt', 'lte', 'empty', 'not_empty'];

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -4481,6 +4481,20 @@ export interface PropertySchemaDTO {
   schema_property_has_dynamic_value?: boolean;
   schema_property_label: string;
   schema_property_name: string;
+  schema_property_override_operators?: (
+    | "eq"
+    | "not_eq"
+    | "contains"
+    | "not_contains"
+    | "starts_with"
+    | "not_starts_with"
+    | "gt"
+    | "gte"
+    | "lt"
+    | "lte"
+    | "empty"
+    | "not_empty"
+  )[];
   schema_property_type: string;
   schema_property_type_array?: boolean;
   schema_property_values?: string[];

--- a/openbas-front/src/utils/lang/en.json
+++ b/openbas-front/src/utils/lang/en.json
@@ -168,6 +168,7 @@
   "base_agent_side": "Agents",
   "base_agents_side": "Agents",
   "base_asset_group_side": "Asset groups",
+  "base_asset_side": "Asset",
   "base_attack_patterns_side": "Attack patterns",
   "base_created_at": "Created at",
   "base_endpoint_side": "Endpoint",
@@ -912,6 +913,7 @@
   "Messages header": "Messages header",
   "Metrics": "Metrics",
   "microblogging": "Microblogging",
+  "Minimum value is 1": "Minimum value is 1",
   "Minutes": "Minutes",
   "Missing content": "Missing content",
   "Missing token": "Missing token",
@@ -1694,6 +1696,5 @@
   "Your file should be a XLS": "Your file should be a XLS",
   "Your overall evaluation about this question.": "Your overall evaluation about this question.",
   "your trial license online": "your trial license online",
-  "YYYY": "YYYY",
-  "Minimum value is 1": "Minimum value is 1"
+  "YYYY": "YYYY"
 }

--- a/openbas-front/src/utils/lang/fr.json
+++ b/openbas-front/src/utils/lang/fr.json
@@ -168,6 +168,7 @@
   "base_agent_side": "Agents",
   "base_agents_side": "Agents",
   "base_asset_group_side": "Groupes d'actifs",
+  "base_asset_side": "Actif",
   "base_attack_patterns_side": "Modèles d'attaque",
   "base_created_at": "Crée à",
   "base_endpoint_side": "Endpoint",
@@ -912,6 +913,7 @@
   "Messages header": "En-tête des messages",
   "Metrics": "Métriques",
   "microblogging": "Microblogging",
+  "Minimum value is 1": "La valeur minimale est 1",
   "Minutes": "Minutes",
   "Missing content": "Contenu manquant",
   "Missing token": "Jeton manquant",
@@ -1694,6 +1696,5 @@
   "Your file should be a XLS": "Votre fichier doit être un XLS",
   "Your overall evaluation about this question.": "Votre évaluation globale de cette question.",
   "your trial license online": "votre licence d'essai en ligne",
-  "YYYY": "AAAA",
-  "Minimum value is 1": "La valeur minimale est 1"
+  "YYYY": "AAAA"
 }

--- a/openbas-front/src/utils/lang/zh.json
+++ b/openbas-front/src/utils/lang/zh.json
@@ -168,6 +168,7 @@
   "base_agent_side": "代理商",
   "base_agents_side": "代理商",
   "base_asset_group_side": "资产组",
+  "base_asset_side": "资产",
   "base_attack_patterns_side": "攻击模式",
   "base_created_at": "创建于",
   "base_endpoint_side": "终点",
@@ -912,6 +913,7 @@
   "Messages header": "消息头",
   "Metrics": "指标",
   "microblogging": "微博",
+  "Minimum value is 1": "最小值为 1",
   "Minutes": "分钟",
   "Missing content": "缺少内容",
   "Missing token": "缺少令牌",
@@ -1694,6 +1696,5 @@
   "Your file should be a XLS": "你的文件应该为XLS",
   "Your overall evaluation about this question.": "您对此问题的总体评价。",
   "your trial license online": "在线试用许可证",
-  "YYYY": "YYYY",
-  "Minimum value is 1": "最小值为 1"
+  "YYYY": "YYYY"
 }

--- a/openbas-model/src/main/java/io/openbas/annotation/Queryable.java
+++ b/openbas-model/src/main/java/io/openbas/annotation/Queryable.java
@@ -1,5 +1,6 @@
 package io.openbas.annotation;
 
+import io.openbas.database.model.Filters;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -25,4 +26,6 @@ public @interface Queryable {
   Class clazz() default Void.class;
 
   Class refEnumClazz() default Void.class;
+
+  Filters.FilterOperator[] overrideOperators() default {};
 }

--- a/openbas-model/src/main/java/io/openbas/engine/model/injectexpectation/EsInjectExpectation.java
+++ b/openbas-model/src/main/java/io/openbas/engine/model/injectexpectation/EsInjectExpectation.java
@@ -3,6 +3,7 @@ package io.openbas.engine.model.injectexpectation;
 import io.openbas.annotation.EsQueryable;
 import io.openbas.annotation.Indexable;
 import io.openbas.annotation.Queryable;
+import io.openbas.database.model.Filters;
 import io.openbas.database.model.InjectExpectation.EXPECTATION_STATUS;
 import io.openbas.database.model.InjectExpectation.EXPECTATION_TYPE;
 import io.openbas.engine.model.EsBase;
@@ -70,15 +71,24 @@ public class EsInjectExpectation extends EsBase {
   @EsQueryable(keyword = true)
   private String base_team_side; // Must finish by _side
 
-  @Queryable(label = "agent")
+  @Queryable(
+      label = "agent",
+      filterable = true,
+      overrideOperators = {Filters.FilterOperator.empty, Filters.FilterOperator.not_empty})
   @EsQueryable(keyword = true)
   private String base_agent_side; // Must finish by _side
 
-  @Queryable(label = "asset")
+  @Queryable(
+      label = "asset",
+      filterable = true,
+      overrideOperators = {Filters.FilterOperator.empty, Filters.FilterOperator.not_empty})
   @EsQueryable(keyword = true)
   private String base_asset_side; // Must finish by _side
 
-  @Queryable(label = "asset group")
+  @Queryable(
+      label = "asset group",
+      filterable = true,
+      overrideOperators = {Filters.FilterOperator.empty, Filters.FilterOperator.not_empty})
   @EsQueryable(keyword = true)
   private String base_asset_group_side; // Must finish by _side
 

--- a/openbas-model/src/main/java/io/openbas/schema/PropertySchema.java
+++ b/openbas-model/src/main/java/io/openbas/schema/PropertySchema.java
@@ -3,6 +3,7 @@ package io.openbas.schema;
 import static lombok.AccessLevel.NONE;
 import static org.springframework.util.StringUtils.hasText;
 
+import io.openbas.database.model.Filters;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -32,6 +33,7 @@ public class PropertySchema {
   private final List<String> availableValues;
   private final boolean dynamicValues;
   private final boolean sortable;
+  private final List<Filters.FilterOperator> overrideOperators;
 
   private final JoinTable joinTable;
   private final String path;

--- a/openbas-model/src/main/java/io/openbas/schema/SchemaUtils.java
+++ b/openbas-model/src/main/java/io/openbas/schema/SchemaUtils.java
@@ -196,6 +196,9 @@ public class SchemaUtils {
         if (!queryable.refEnumClazz().equals(Void.class)) {
           builder.availableValues(getEnumNames(queryable.refEnumClazz()));
         }
+        if (queryable.overrideOperators() != null) {
+          builder.overrideOperators(Arrays.stream(queryable.overrideOperators()).toList());
+        }
       }
     } else if (annotation.annotationType().equals(EsQueryable.class)) {
       EsQueryable esQueryable =


### PR DESCRIPTION
operators

<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add filters on Expectation dimension to filter out unwanted expectations for the wrong level (e.g. asset group expectations, agent expectations)

### Testing Instructions

1. Use the Horizontal bar
2. Choose Expectations
3. Use Agent, Asset, Asset group filters to include/exclude specific expectations for the unwanted/wanted types

### Related issues

* Contributes to #3340 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
