### PR TITLE
[frontend]Correct height of agent installation tiles(#3470)

### DIFF
--- a/openbas-front/src/admin/components/agents/PlatformSelector.tsx
+++ b/openbas-front/src/admin/components/agents/PlatformSelector.tsx
@@ -38,7 +38,7 @@ const PlatformSelector: React.FC<PlatformSelectorProps> = ({ selectedExecutor, s
             key={platform}
             variant="outlined"
             style={{
-              height: '300px',
+              height: '200px',
               margin: theme.spacing(2),
             }}
           >


### PR DESCRIPTION
<img width="885" height="396" alt="image" src="https://github.com/user-attachments/assets/573b91eb-7363-49e4-951e-828cd0490fc7" />
