### PR TITLE
[frontend] Impossible to create a payload of type executable file

### DIFF
--- a/openbas-api/src/test/java/io/openbas/rest/DocumentApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/DocumentApiTest.java
@@ -41,12 +41,10 @@ import org.springframework.transaction.annotation.Transactional;
 class DocumentApiTest extends IntegrationTest {
 
   @Resource protected ObjectMapper mapper;
-
-  @Autowired private MockMvc mvc;
-
   @Autowired DocumentComposer documentComposer;
   @Autowired ChallengeComposer challengeComposer;
   @Autowired PayloadComposer payloadComposer;
+  @Autowired private MockMvc mvc;
   @Autowired private DocumentRepository documentRepository;
   @Autowired private ChallengeRepository challengeRepository;
 
@@ -60,6 +58,34 @@ class DocumentApiTest extends IntegrationTest {
   void afterAll() {
     challengeComposer.reset();
     documentComposer.reset();
+  }
+
+  private Document getDocumentWithChallenge() {
+
+    ChallengeComposer.Composer challenge =
+        challengeComposer.forChallenge(ChallengeFixture.createDefaultChallenge());
+
+    BinaryFile badCoffeeFileContent = FileFixture.getBadCoffeeFileContent();
+    return documentComposer
+        .forDocument(DocumentFixture.getDocument(badCoffeeFileContent))
+        .withInMemoryFile(badCoffeeFileContent)
+        .withChallenge(challenge)
+        .persist()
+        .get();
+  }
+
+  private Document getDocumentWithPayload() {
+
+    PayloadComposer.Composer payload =
+        payloadComposer.forPayload(PayloadFixture.createDefaultExecutable());
+
+    BinaryFile badCoffeeFileContent = FileFixture.getBadCoffeeFileContent();
+    return documentComposer
+        .forDocument(DocumentFixture.getDocument(badCoffeeFileContent))
+        .withInMemoryFile(badCoffeeFileContent)
+        .withPayloadExecutable(payload)
+        .persist()
+        .get();
   }
 
   @Nested
@@ -114,33 +140,5 @@ class DocumentApiTest extends IntegrationTest {
 
       assertThatJson(response).when(IGNORING_ARRAY_ORDER).isEqualTo(relationJson);
     }
-  }
-
-  private Document getDocumentWithChallenge() {
-
-    ChallengeComposer.Composer challenge =
-        challengeComposer.forChallenge(ChallengeFixture.createDefaultChallenge());
-
-    BinaryFile badCoffeeFileContent = FileFixture.getBadCoffeeFileContent();
-    return documentComposer
-        .forDocument(DocumentFixture.getDocument(badCoffeeFileContent))
-        .withInMemoryFile(badCoffeeFileContent)
-        .withChallenge(challenge)
-        .persist()
-        .get();
-  }
-
-  private Document getDocumentWithPayload() {
-
-    PayloadComposer.Composer payload =
-        payloadComposer.forPayload(PayloadFixture.createDefaultExecutable());
-
-    BinaryFile badCoffeeFileContent = FileFixture.getBadCoffeeFileContent();
-    return documentComposer
-        .forDocument(DocumentFixture.getDocument(badCoffeeFileContent))
-        .withInMemoryFile(badCoffeeFileContent)
-        .withPayloadExecutable(payload)
-        .persist()
-        .get();
   }
 }

--- a/openbas-api/src/test/java/io/openbas/rest/PayloadApiSearchTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/PayloadApiSearchTest.java
@@ -14,8 +14,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.openbas.IntegrationTest;
+import io.openbas.database.model.Document;
 import io.openbas.database.model.Payload;
+import io.openbas.database.repository.DocumentRepository;
 import io.openbas.database.repository.PayloadRepository;
+import io.openbas.utils.fixtures.DocumentFixture;
 import io.openbas.utils.fixtures.PaginationFixture;
 import io.openbas.utils.mockUser.WithMockAdminUser;
 import io.openbas.utils.pagination.SearchPaginationInput;
@@ -30,11 +33,10 @@ import org.springframework.test.web.servlet.MockMvc;
 @TestInstance(PER_CLASS)
 public class PayloadApiSearchTest extends IntegrationTest {
 
-  @Autowired private MockMvc mvc;
-
-  @Autowired private PayloadRepository payloadRepository;
-
   private static final List<String> PAYLOAD_COMMAND_IDS = new ArrayList<>();
+  @Autowired private MockMvc mvc;
+  @Autowired private PayloadRepository payloadRepository;
+  @Autowired private DocumentRepository documentRepository;
 
   @BeforeAll
   void beforeAll() {
@@ -46,7 +48,10 @@ public class PayloadApiSearchTest extends IntegrationTest {
     Payload dnsResolutionSaved = this.payloadRepository.save(dnsResolution);
     PAYLOAD_COMMAND_IDS.add(dnsResolutionSaved.getId());
 
-    Payload executable = createDefaultExecutable();
+    Document document = DocumentFixture.getDocumentJpeg();
+    Document documentSaved = this.documentRepository.save(document);
+
+    Payload executable = createDefaultExecutable(documentSaved);
     Payload executableSaved = this.payloadRepository.save(executable);
     PAYLOAD_COMMAND_IDS.add(executableSaved.getId());
   }

--- a/openbas-api/src/test/java/io/openbas/rest/inject/InjectImportTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/InjectImportTest.java
@@ -52,6 +52,9 @@ import org.springframework.transaction.annotation.Transactional;
 @DisplayName("Importing injects tests")
 public class InjectImportTest extends IntegrationTest {
 
+  public final String INJECT_IMPORT_URI = INJECT_URI + "/import";
+  private final Map<String, ArticleComposer.Composer> staticArticleWrappers = new HashMap<>();
+  private final String KNOWN_ARTICLE_WRAPPER_KEY = "known article key";
   @Autowired ObjectMapper objectMapper;
   @Autowired MockMvc mvc;
   @Autowired InjectExportService exportService;
@@ -78,7 +81,6 @@ public class InjectImportTest extends IntegrationTest {
   @Autowired private InjectRepository injectRepository;
   @Autowired private ArticleService articleService;
   @Autowired private InjectorFixture injectorFixture;
-
   @MockBean private Ee eeService;
 
   @BeforeEach
@@ -107,10 +109,6 @@ public class InjectImportTest extends IntegrationTest {
 
     clearEntityManager();
   }
-
-  public final String INJECT_IMPORT_URI = INJECT_URI + "/import";
-  private final Map<String, ArticleComposer.Composer> staticArticleWrappers = new HashMap<>();
-  private final String KNOWN_ARTICLE_WRAPPER_KEY = "known article key";
 
   private Map<String, ArticleComposer.Composer> getStaticArticleWrappers() {
     if (!staticArticleWrappers.containsKey(KNOWN_ARTICLE_WRAPPER_KEY)) {

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/PayloadFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/PayloadFixture.java
@@ -83,12 +83,11 @@ public class PayloadFixture {
 
   public static Payload createDefaultExecutable() {
     final Executable executable =
-            new Executable("executable-id", Executable.EXECUTABLE_TYPE, "executable payload");
+        new Executable("executable-id", Executable.EXECUTABLE_TYPE, "executable payload");
     executable.setExecutionArch(Payload.PAYLOAD_EXECUTION_ARCH.arm64);
     initializeDefaultPayload(executable, MACOS_PLATFORM);
     return executable;
   }
-
 
   public static Payload createDefaultFileDrop() {
     final FileDrop filedrop =

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/PayloadFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/PayloadFixture.java
@@ -72,13 +72,23 @@ public class PayloadFixture {
     return dnsResolution;
   }
 
-  public static Payload createDefaultExecutable() {
+  public static Payload createDefaultExecutable(Document document) {
     final Executable executable =
         new Executable("executable-id", Executable.EXECUTABLE_TYPE, "executable payload");
+    executable.setExecutionArch(Payload.PAYLOAD_EXECUTION_ARCH.arm64);
+    executable.setExecutableFile(document);
+    initializeDefaultPayload(executable, MACOS_PLATFORM);
+    return executable;
+  }
+
+  public static Payload createDefaultExecutable() {
+    final Executable executable =
+            new Executable("executable-id", Executable.EXECUTABLE_TYPE, "executable payload");
     executable.setExecutionArch(Payload.PAYLOAD_EXECUTION_ARCH.arm64);
     initializeDefaultPayload(executable, MACOS_PLATFORM);
     return executable;
   }
+
 
   public static Payload createDefaultFileDrop() {
     final FileDrop filedrop =

--- a/openbas-front/src/admin/components/payloads/CreatePayload.js
+++ b/openbas-front/src/admin/components/payloads/CreatePayload.js
@@ -54,7 +54,7 @@ class CreatePayload extends Component {
       R.assoc('payload_platforms', data.payload_platforms),
       R.assoc('payload_tags', data.payload_tags),
       R.assoc('payload_attack_patterns', data.payload_attack_patterns),
-      R.assoc('executable_file', data.executable_file?.id),
+      R.assoc('executable_file', data.executable_file),
       R.assoc('payload_cleanup_executor', handleCleanupExecutorValue(data.payload_cleanup_executor, data.payload_cleanup_command)),
       R.assoc('payload_cleanup_command', handleCleanupCommandValue(data.payload_cleanup_command)),
       R.assoc('payload_detection_remediations', Object.entries(data.remediations).filter(value => value[1]).map(value => ({

--- a/openbas-front/src/admin/components/payloads/PayloadForm.tsx
+++ b/openbas-front/src/admin/components/payloads/PayloadForm.tsx
@@ -36,7 +36,7 @@ const PayloadForm = ({
     payload_attack_patterns: [],
     payload_cleanup_command: '',
     payload_cleanup_executor: '',
-    executable_file: undefined,
+    executable_file: '',
     file_drop_file: '',
     dns_resolution_hostname: '',
     payload_tags: [],
@@ -161,7 +161,7 @@ const PayloadForm = ({
   const executableSchema = z.object({
     ...baseSchema,
     payload_type: z.literal('Executable').describe('Commands-tab'),
-    executable_file: z.string().optional().describe('Commands-tab'),
+    executable_file: z.string().min(1, { message: t('Should not be empty') }).describe('Commands-tab'),
   });
   const fileDropSchema = z.object({
     ...baseSchema,

--- a/openbas-front/src/admin/components/payloads/PayloadPopover.js
+++ b/openbas-front/src/admin/components/payloads/PayloadPopover.js
@@ -48,7 +48,7 @@ const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate
       R.assoc('payload_platforms', data.payload_platforms),
       R.assoc('payload_tags', data.payload_tags),
       R.assoc('payload_attack_patterns', data.payload_attack_patterns),
-      R.assoc('executable_file', data.executable_file?.id),
+      R.assoc('executable_file', data.executable_file),
       R.assoc('payload_cleanup_executor', handleCleanupExecutorValue(data.payload_cleanup_executor, data.payload_cleanup_command)),
       R.assoc('payload_cleanup_command', handleCleanupCommandValue(data.payload_cleanup_command)),
       R.assoc('payload_detection_remediations', Object.entries(data.remediations).filter(value => value[1]).map(value => ({
@@ -108,7 +108,6 @@ const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate
     });
   };
 
-  const payloadExecutableFiles = documentOptions(payload.executable_file ? [payload.executable_file] : [], documentsMap);
   const initialValues = {
     payload_name: payload.payload_name,
     payload_description: payload.payload_description,
@@ -124,7 +123,7 @@ const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate
     payload_execution_arch: payload.payload_execution_arch,
     payload_output_parsers: payload.payload_output_parsers,
     payload_platforms: payload.payload_platforms,
-    executable_file: R.head(payloadExecutableFiles),
+    executable_file: payload.executable_file,
     payload_cleanup_executor: payload.payload_cleanup_executor === null ? '' : payload.payload_cleanup_executor,
     payload_cleanup_command: payload.payload_cleanup_command === null ? '' : payload.payload_cleanup_command,
     remediations: {},

--- a/openbas-front/src/admin/components/payloads/PayloadPopover.js
+++ b/openbas-front/src/admin/components/payloads/PayloadPopover.js
@@ -14,11 +14,10 @@ import DialogDelete from '../../../components/common/DialogDelete';
 import Drawer from '../../../components/common/Drawer';
 import Transition from '../../../components/common/Transition';
 import { useFormatter } from '../../../components/i18n';
-import { documentOptions } from '../../../utils/Option';
 import { download } from '../../../utils/utils.js';
 import PayloadForm from './PayloadForm';
 
-const PayloadPopover = ({ payload, documentsMap, onUpdate, onDelete, onDuplicate, disableUpdate, disableDelete }) => {
+const PayloadPopover = ({ payload, onUpdate, onDelete, onDuplicate, disableUpdate, disableDelete }) => {
   const [openDuplicate, setOpenDuplicate] = useState(false);
   const [openEdit, setOpenEdit] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);

--- a/openbas-front/src/admin/components/payloads/Payloads.tsx
+++ b/openbas-front/src/admin/components/payloads/Payloads.tsx
@@ -107,7 +107,7 @@ const Payloads = () => {
   const dispatch = useAppDispatch();
 
   const [selectedPayload, setSelectedPayload] = useState<Payload | null>(null);
-  const { documentsMap, collectorsMap } = useHelper((helper: DocumentHelper & CollectorHelper) => ({
+  const { collectorsMap } = useHelper((helper: DocumentHelper & CollectorHelper) => ({
     documentsMap: helper.getDocumentsMap(),
     collectorsMap: helper.getCollectorsMap(),
   }));
@@ -297,7 +297,6 @@ const Payloads = () => {
                     divider
                     secondaryAction={(
                       <PayloadPopover
-                        documentsMap={documentsMap}
                         payload={payload}
                         onUpdate={(result: Payload) => setPayloads(payloads.map(a => (a.payload_id !== result.payload_id ? a : result)))}
                         onDuplicate={(result: Payload) => setPayloads([result, ...payloads])}

--- a/openbas-front/src/admin/components/payloads/form/CommandsFormTab.tsx
+++ b/openbas-front/src/admin/components/payloads/form/CommandsFormTab.tsx
@@ -132,9 +132,9 @@ const CommandsFormTab = ({ disabledPayloadType = false }: Props) => {
               name="executable_file"
               label={t('Executable file')}
               setFieldValue={(_name, document) => {
-                onChange(document);
+                onChange(document?.id);
               }}
-              initialValue={{ id: value?.id }}
+              initialValue={{ id: value }}
               InputLabelProps={{ required: true }}
               error={!!error}
             />

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/AuthorizedPerspectives.ts
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/AuthorizedPerspectives.ts
@@ -1,5 +1,5 @@
 const getAuthorizedPerspectives = (): Map<string, string[]> => new Map([
-  ['expectation-inject', ['base_created_at', 'inject_expectation_status', 'inject_expectation_type', 'base_updated_at', 'base_simulation_side']],
+  ['expectation-inject', ['base_created_at', 'inject_expectation_status', 'inject_expectation_type', 'base_updated_at', 'base_simulation_side', 'base_agent_side', 'base_asset_side', 'base_asset_group_side']],
   ['finding', ['base_created_at', 'finding_type', 'base_updated_at', 'base_endpoint_side', 'base_simulation_side']],
   ['endpoint', ['endpoint_arch', 'endpoint_platform', 'endpoint_ips', 'endpoint_hostname']],
   ['vulnerable-endpoint', ['vulnerable_endpoint_architecture', 'vulnerable_endpoint_agents_active_status', 'vulnerable_endpoint_agents_privileges', 'vulnerable_endpoint_platform', 'base_simulation_side']],

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -1813,7 +1813,7 @@ export interface EvaluationInput {
 }
 
 export interface Executable {
-  executable_file: string;
+  executable_file?: string;
   listened?: boolean;
   payload_arguments?: PayloadArgument[];
   payload_attack_patterns?: string[];

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -1813,7 +1813,7 @@ export interface EvaluationInput {
 }
 
 export interface Executable {
-  executable_file?: string;
+  executable_file: string;
   listened?: boolean;
   payload_arguments?: PayloadArgument[];
   payload_attack_patterns?: string[];

--- a/openbas-model/src/main/java/io/openbas/database/model/Executable.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Executable.java
@@ -7,9 +7,8 @@ import io.openbas.database.audit.ModelBaseListener;
 import io.openbas.helper.MonoIdDeserializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import java.util.Optional;
-
 import jakarta.validation.constraints.NotNull;
+import java.util.Optional;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/openbas-model/src/main/java/io/openbas/database/model/Executable.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Executable.java
@@ -8,6 +8,8 @@ import io.openbas.helper.MonoIdDeserializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import java.util.Optional;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -28,17 +30,18 @@ public class Executable extends Payload {
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("executable_file")
   @Schema(type = "string")
+  @NotNull
   private Document executableFile;
-
-  @Override
-  @JsonIgnore
-  public Optional<Document> getAttachedDocument() {
-    return Optional.of(this.getExecutableFile());
-  }
 
   public Executable() {}
 
   public Executable(String id, String type, String name) {
     super(id, type, name);
+  }
+
+  @Override
+  @JsonIgnore
+  public Optional<Document> getAttachedDocument() {
+    return Optional.of(this.getExecutableFile());
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Updated the Zod schema to expect a string for executable_file instead of an object with id and label, with only the id being passed now and the label handled separately.

### Testing Instructions

1. Go on payload page
2. Try to create a payload of type executable file
3. Add an executable file and all the mandatory fields
4. Click on create : it supposed to work without "shloud not be empty" when you've filled in the field.
5. You can try to update it

### Related issues

* Closes #3425
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
