### PR TITLE
[frontend] Pagination is not updated when a datatable is filtered 

### DIFF
--- a/openbas-front/src/components/common/queryable/pagination/PaginationComponentV2.tsx
+++ b/openbas-front/src/components/common/queryable/pagination/PaginationComponentV2.tsx
@@ -109,6 +109,9 @@ const PaginationComponentV2 = <T extends object>({
       const { data } = result;
       setContent(data.content);
       queryableHelpers.paginationHelpers.handleChangeTotalElements(data.totalElements);
+      if (data.totalPages < data.pageable.pageNumber) {
+        queryableHelpers.paginationHelpers.handleChangePage(0);
+      }
     });
   }, [searchPaginationInput, reloadContentCount]);
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Check if the new total pages number is still superior to the actual page number

### Testing Instructions

1. Go to the payload list
2. Go to the second page of the data table : "41-60"
3. filter by status=verified
4. It's supposed to come back to the first page "1-11" 
5. You can check on the other page with filter and with lot of elements

### Related issues

* Closes #1677

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
