### PR TITLE
[backend/frontend] Add scenario filter (#3531)

### DIFF
--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/CustomDashboardParameterFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/CustomDashboardParameterFixture.java
@@ -1,5 +1,8 @@
 package io.openbas.utils.fixtures;
 
+import static io.openbas.database.model.CustomDashboardParameters.CustomDashboardParameterType.scenario;
+import static io.openbas.database.model.CustomDashboardParameters.CustomDashboardParameterType.simulation;
+
 import io.openbas.database.model.CustomDashboardParameters;
 
 public class CustomDashboardParameterFixture {
@@ -7,8 +10,14 @@ public class CustomDashboardParameterFixture {
   public static CustomDashboardParameters createSimulationCustomDashboardParameter() {
     CustomDashboardParameters customDashboardParameters = new CustomDashboardParameters();
     customDashboardParameters.setName("simulation_param");
-    customDashboardParameters.setType(
-        CustomDashboardParameters.CustomDashboardParameterType.simulation);
+    customDashboardParameters.setType(simulation);
+    return customDashboardParameters;
+  }
+
+  public static CustomDashboardParameters createScenarioCustomDashboardParameter() {
+    CustomDashboardParameters customDashboardParameters = new CustomDashboardParameters();
+    customDashboardParameters.setName("scenario_param");
+    customDashboardParameters.setType(scenario);
     return customDashboardParameters;
   }
 }

--- a/openbas-front/src/admin/components/simulations/simulation/analysis/SimulationAnalysis.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/analysis/SimulationAnalysis.tsx
@@ -42,6 +42,13 @@ const SimulationAnalysis = () => {
             if ('simulation' === p.custom_dashboards_parameter_type) {
               params[p.custom_dashboards_parameter_id] = exerciseId;
             }
+            if ('scenario' === p.custom_dashboards_parameter_type) {
+              if (exercise.exercise_scenario) {
+                params[p.custom_dashboards_parameter_id] = exercise.exercise_scenario;
+              } else {
+                params[p.custom_dashboards_parameter_id] = '';
+              }
+            }
           });
           setCustomDashboardParameters(params);
 

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardForm.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardForm.tsx
@@ -6,6 +6,7 @@ import { type FunctionComponent, useMemo } from 'react';
 import { FormProvider, type SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
+import SelectFieldController, { createItems, type Item } from '../../../../components/fields/SelectFieldController';
 import TextFieldController from '../../../../components/fields/TextFieldController';
 import { useFormatter } from '../../../../components/i18n';
 import { type CustomDashboardInput, type CustomDashboardParametersInput } from '../../../../utils/api-types';
@@ -35,7 +36,7 @@ const CustomDashboardForm: FunctionComponent<Props> = ({
   const parametersSchema = z.object({
     custom_dashboards_parameter_id: z.string().optional(),
     custom_dashboards_parameter_name: z.string().min(1, { message: t('Should not be empty') }),
-    custom_dashboards_parameter_type: z.literal('simulation'),
+    custom_dashboards_parameter_type: z.enum(['scenario', 'simulation']),
   });
 
   const validationSchema = useMemo(
@@ -64,11 +65,11 @@ const CustomDashboardForm: FunctionComponent<Props> = ({
     name: 'custom_dashboard_parameters',
   });
 
-  const items: CustomDashboardParametersInput['custom_dashboards_parameter_type'][] = ['simulation'];
+  const items: Item<CustomDashboardParametersInput['custom_dashboards_parameter_type']>[] = createItems(['scenario', 'simulation']);
   const handleAddParameter = (type: CustomDashboardParametersInput['custom_dashboards_parameter_type']) => {
     if (type) {
       append({
-        custom_dashboards_parameter_name: type,
+        custom_dashboards_parameter_name: '',
         custom_dashboards_parameter_type: type,
       });
     }
@@ -108,7 +109,7 @@ const CustomDashboardForm: FunctionComponent<Props> = ({
           <IconButton
             color="secondary"
             aria-label="Add"
-            onClick={() => handleAddParameter(items[0])} // For now, we handle just one type
+            onClick={() => handleAddParameter(items[0].value)}
             size="small"
           >
             <Add fontSize="small" />
@@ -130,13 +131,11 @@ const CustomDashboardForm: FunctionComponent<Props> = ({
               required
               noHelperText
             />
-            <TextFieldController
+            <SelectFieldController
               name={`custom_dashboard_parameters.${index}.custom_dashboards_parameter_type`}
               label={t('Parameter Type')}
-              variant="standard"
+              items={items}
               required
-              disabled
-              noHelperText
             />
             <Tooltip title={t('Delete')}>
               <IconButton color="error" onClick={() => remove(index)}>

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardHeader.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardHeader.tsx
@@ -1,7 +1,5 @@
 import { Tooltip, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
 import { type FunctionComponent, useCallback, useContext } from 'react';
-import { makeStyles } from 'tss-react/mui';
 
 import { type CustomDashboard } from '../../../../utils/api-types';
 import { truncate } from '../../../../utils/String';
@@ -9,20 +7,7 @@ import { CustomDashboardContext } from './CustomDashboardContext';
 import CustomDashboardParameters from './CustomDashboardParameters';
 import CustomDashboardPopover from './CustomDashboardPopover';
 
-const useStyles = makeStyles()(() => ({
-  container: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    alignItems: 'center',
-  },
-  rightAligned: { justifySelf: 'end' },
-}));
-
 const CustomDashboardHeader: FunctionComponent = () => {
-  // Standard hooks
-  const { classes } = useStyles();
-  const theme = useTheme();
-
   const { customDashboard, setCustomDashboard } = useContext(CustomDashboardContext);
 
   const handleUpdate = useCallback(
@@ -40,27 +25,30 @@ const CustomDashboardHeader: FunctionComponent = () => {
   }
 
   return (
-    <div className={classes.container}>
+    <>
       <div style={{
         display: 'flex',
-        gap: theme.spacing(2),
-        alignItems: 'center',
+        justifyContent: 'space-between',
       }}
       >
-        <Tooltip title={customDashboard.custom_dashboard_name}>
-          <Typography variant="h1" style={{ margin: 0 }}>
-            {truncate(customDashboard.custom_dashboard_name, 80)}
-          </Typography>
-        </Tooltip>
-        <CustomDashboardParameters />
-      </div>
-      <div className={classes.rightAligned}>
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+        >
+          <Tooltip title={customDashboard.custom_dashboard_name}>
+            <Typography variant="h1" style={{ margin: 0 }}>
+              {truncate(customDashboard.custom_dashboard_name, 80)}
+            </Typography>
+          </Tooltip>
+        </div>
         <CustomDashboardPopover
           customDashboard={customDashboard}
           onUpdate={handleUpdate}
         />
       </div>
-    </div>
+      <CustomDashboardParameters />
+    </>
   );
 };
 export default CustomDashboardHeader;

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardParameters.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardParameters.tsx
@@ -3,6 +3,7 @@ import { type FunctionComponent, useContext } from 'react';
 
 import ScenarioField from '../../../../components/fields/ScenarioField';
 import SimulationField from '../../../../components/fields/SimulationField';
+import { type CustomDashboardParameters as CustomDashboardParametersType } from '../../../../utils/api-types';
 import { CustomDashboardContext } from './CustomDashboardContext';
 
 const CustomDashboardParameters: FunctionComponent = () => {
@@ -21,41 +22,44 @@ const CustomDashboardParameters: FunctionComponent = () => {
     }));
   };
 
+  const renderParameterField = (p: CustomDashboardParametersType) => {
+    switch (p.custom_dashboards_parameter_type) {
+      case 'scenario':
+        return (
+          <ScenarioField
+            label={p.custom_dashboards_parameter_name}
+            value={getParameterValue(p.custom_dashboards_parameter_id)}
+            onChange={(value: string | undefined) =>
+              handleParameters(p.custom_dashboards_parameter_id, value ?? '')}
+          />
+        );
+      case 'simulation':
+        return (
+          <SimulationField
+            label={p.custom_dashboards_parameter_name}
+            value={getParameterValue(p.custom_dashboards_parameter_id)}
+            onChange={(value: string | undefined) =>
+              handleParameters(p.custom_dashboards_parameter_id, value ?? '')}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
-    <div style={{
-      display: 'grid',
-      gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 300px))',
-      gap: theme.spacing(2),
-    }}
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 300px))',
+        gap: theme.spacing(2),
+      }}
     >
-      {(customDashboard?.custom_dashboard_parameters ?? []).map((p) => {
-        switch (p.custom_dashboards_parameter_type) {
-          case 'scenario':
-            return (
-              <div key={p.custom_dashboards_parameter_id}>
-                <ScenarioField
-                  label={p.custom_dashboards_parameter_name}
-                  value={getParameterValue(p.custom_dashboards_parameter_id)}
-                  onChange={(value: string | undefined) =>
-                    handleParameters(p.custom_dashboards_parameter_id, value ?? '')}
-                />
-              </div>
-            );
-          case 'simulation':
-            return (
-              <div key={p.custom_dashboards_parameter_id}>
-                <SimulationField
-                  label={p.custom_dashboards_parameter_name}
-                  value={getParameterValue(p.custom_dashboards_parameter_id)}
-                  onChange={(value: string | undefined) =>
-                    handleParameters(p.custom_dashboards_parameter_id, value ?? '')}
-                />
-              </div>
-            );
-          default:
-            return null;
-        }
-      })}
+      {(customDashboard?.custom_dashboard_parameters ?? []).map(p => (
+        <div key={p.custom_dashboards_parameter_id}>
+          {renderParameterField(p)}
+        </div>
+      ))}
     </div>
   );
 };

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardParameters.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardParameters.tsx
@@ -1,9 +1,12 @@
+import { useTheme } from '@mui/material/styles';
 import { type FunctionComponent, useContext } from 'react';
 
+import ScenarioField from '../../../../components/fields/ScenarioField';
 import SimulationField from '../../../../components/fields/SimulationField';
 import { CustomDashboardContext } from './CustomDashboardContext';
 
 const CustomDashboardParameters: FunctionComponent = () => {
+  const theme = useTheme();
   const { customDashboard, customDashboardParameters, setCustomDashboardParameters } = useContext(CustomDashboardContext);
 
   const getParameterValue = (parameterId: string) => {
@@ -19,11 +22,26 @@ const CustomDashboardParameters: FunctionComponent = () => {
   };
 
   return (
-    <>
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 300px))',
+      gap: theme.spacing(2),
+    }}
+    >
       {(customDashboard?.custom_dashboard_parameters ?? []).map((p) => {
-        if (p.custom_dashboards_parameter_type === 'simulation') {
+        if (p.custom_dashboards_parameter_type === 'scenario') {
           return (
-            <div key={p.custom_dashboards_parameter_id} style={{ width: 350 }}>
+            <div key={p.custom_dashboards_parameter_id}>
+              <ScenarioField
+                label={p.custom_dashboards_parameter_name}
+                value={getParameterValue(p.custom_dashboards_parameter_id)}
+                onChange={(value: string | undefined) => handleParameters(p.custom_dashboards_parameter_id, value ?? '')}
+              />
+            </div>
+          );
+        } else if (p.custom_dashboards_parameter_type === 'simulation') {
+          return (
+            <div key={p.custom_dashboards_parameter_id}>
               <SimulationField
                 label={p.custom_dashboards_parameter_name}
                 value={getParameterValue(p.custom_dashboards_parameter_id)}
@@ -35,7 +53,7 @@ const CustomDashboardParameters: FunctionComponent = () => {
           return (<></>);
         }
       })}
-    </>
+    </div>
   );
 };
 

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardParameters.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardParameters.tsx
@@ -53,7 +53,7 @@ const CustomDashboardParameters: FunctionComponent = () => {
               </div>
             );
           default:
-            return (<></>);
+            return null;
         }
       })}
     </div>

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardParameters.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardParameters.tsx
@@ -29,28 +29,31 @@ const CustomDashboardParameters: FunctionComponent = () => {
     }}
     >
       {(customDashboard?.custom_dashboard_parameters ?? []).map((p) => {
-        if (p.custom_dashboards_parameter_type === 'scenario') {
-          return (
-            <div key={p.custom_dashboards_parameter_id}>
-              <ScenarioField
-                label={p.custom_dashboards_parameter_name}
-                value={getParameterValue(p.custom_dashboards_parameter_id)}
-                onChange={(value: string | undefined) => handleParameters(p.custom_dashboards_parameter_id, value ?? '')}
-              />
-            </div>
-          );
-        } else if (p.custom_dashboards_parameter_type === 'simulation') {
-          return (
-            <div key={p.custom_dashboards_parameter_id}>
-              <SimulationField
-                label={p.custom_dashboards_parameter_name}
-                value={getParameterValue(p.custom_dashboards_parameter_id)}
-                onChange={(value: string | undefined) => handleParameters(p.custom_dashboards_parameter_id, value ?? '')}
-              />
-            </div>
-          );
-        } else {
-          return (<></>);
+        switch (p.custom_dashboards_parameter_type) {
+          case 'scenario':
+            return (
+              <div key={p.custom_dashboards_parameter_id}>
+                <ScenarioField
+                  label={p.custom_dashboards_parameter_name}
+                  value={getParameterValue(p.custom_dashboards_parameter_id)}
+                  onChange={(value: string | undefined) =>
+                    handleParameters(p.custom_dashboards_parameter_id, value ?? '')}
+                />
+              </div>
+            );
+          case 'simulation':
+            return (
+              <div key={p.custom_dashboards_parameter_id}>
+                <SimulationField
+                  label={p.custom_dashboards_parameter_name}
+                  value={getParameterValue(p.custom_dashboards_parameter_id)}
+                  onChange={(value: string | undefined) =>
+                    handleParameters(p.custom_dashboards_parameter_id, value ?? '')}
+                />
+              </div>
+            );
+          default:
+            return (<></>);
         }
       })}
     </div>

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/WidgetUtils.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/WidgetUtils.tsx
@@ -153,6 +153,24 @@ export const excludeBaseEntities = (filterGroup: FilterGroup | undefined) => {
     filters: filterGroup.filters?.filter(f => f.key !== BASE_ENTITY_FILTER_KEY) ?? [],
   };
 };
+export const getDefaultValuesForType = (
+  currentValues: Map<string, GroupOption[]>,
+  param: CustomDashboardParameters,
+  key: 'base_simulation_side' | 'base_scenario_side',
+) => {
+  const values = currentValues;
+  const items = values.get(key) ?? [];
+  const option = createGroupOption(
+    param.custom_dashboards_parameter_id,
+    param.custom_dashboards_parameter_name,
+    'Parameters',
+  );
+
+  if (!items.some(i => i.id === option.id)) {
+    values.set(key, [...items, option]);
+  }
+  return values;
+};
 
 // -- MATRIX MITRE --
 const entityFilter: Filter = {

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/AuthorizedPerspectives.ts
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/AuthorizedPerspectives.ts
@@ -4,7 +4,7 @@ const getAuthorizedPerspectives = (): Map<string, string[]> => new Map([
   ['endpoint', ['endpoint_arch', 'endpoint_platform', 'endpoint_ips', 'endpoint_hostname']],
   ['vulnerable-endpoint', ['vulnerable_endpoint_architecture', 'vulnerable_endpoint_agents_active_status', 'vulnerable_endpoint_agents_privileges', 'vulnerable_endpoint_platform', 'base_simulation_side']],
   ['inject', ['base_tags_side', 'base_assets_side', 'base_asset_groups_side', 'base_teams_side']],
-  ['simulation', ['base_tags_side', 'base_assets_side', 'base_asset_groups_side', 'base_teams_side']],
+  ['simulation', ['base_tags_side', 'base_assets_side', 'base_asset_groups_side', 'base_teams_side', 'base_scenario_side']],
   ['scenario', ['base_tags_side', 'base_assets_side', 'base_asset_groups_side', 'base_teams_side']],
 ]);
 

--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/WidgetSeriesSelection.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/WidgetSeriesSelection.tsx
@@ -12,15 +12,12 @@ import { availableOperators, buildFilter } from '../../../../../../components/co
 import { buildSearchPagination } from '../../../../../../components/common/queryable/QueryableUtils';
 import { useQueryable } from '../../../../../../components/common/queryable/useQueryableWithLocalStorage';
 import { useFormatter } from '../../../../../../components/i18n';
-import {
-  type FilterGroup,
-  type PropertySchemaDTO,
-} from '../../../../../../utils/api-types';
-import { createGroupOption, type GroupOption } from '../../../../../../utils/Option';
+import { type FilterGroup, type PropertySchemaDTO } from '../../../../../../utils/api-types';
+import { type GroupOption } from '../../../../../../utils/Option';
 import { capitalize } from '../../../../../../utils/String';
 import { MITRE_FILTER_KEY } from '../../../../common/filters/MitreFilter';
 import { CustomDashboardContext } from '../../CustomDashboardContext';
-import { BASE_ENTITY_FILTER_KEY, excludeBaseEntities } from '../WidgetUtils';
+import { BASE_ENTITY_FILTER_KEY, excludeBaseEntities, getDefaultValuesForType } from '../WidgetUtils';
 import getAuthorizedPerspectives from './AuthorizedPerspectives';
 import FilterFieldBaseEntity from './FilterFieldBaseEntity';
 
@@ -132,11 +129,12 @@ const WidgetSeriesSelection: FunctionComponent<{
     }
     (customDashboard?.custom_dashboard_parameters ?? []).forEach((p) => {
       if (p.custom_dashboards_parameter_type === 'simulation') {
-        const values = defaultValues;
-        const items = values.get('base_simulation_side') ?? [];
-        const option = createGroupOption(p.custom_dashboards_parameter_id, p.custom_dashboards_parameter_name, 'Parameters');
-        if (!items.map(i => i.id).includes(option.id)) values.set('base_simulation_side', [...items, option]);
-        setDefaultValues(values);
+        const newDefaultValues = getDefaultValuesForType(defaultValues, p, 'base_simulation_side');
+        setDefaultValues(newDefaultValues);
+      }
+      if (p.custom_dashboards_parameter_type === 'scenario') {
+        const newDefaultValues = getDefaultValuesForType(defaultValues, p, 'base_scenario_side');
+        setDefaultValues(newDefaultValues);
       }
     });
   }, [entity]);

--- a/openbas-front/src/components/common/queryable/filter/constants.ts
+++ b/openbas-front/src/components/common/queryable/filter/constants.ts
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/prefer-default-export
 export const CUSTOM_DASHBOARD = 'custom-dashboard';
+export const SCENARIOS = 'scenarios';
 export const SIMULATIONS = 'simulations';

--- a/openbas-front/src/components/common/queryable/filter/useRetrieveOptions.tsx
+++ b/openbas-front/src/components/common/queryable/filter/useRetrieveOptions.tsx
@@ -1,3 +1,4 @@
+import type { AxiosResponse } from 'axios';
 import { useState } from 'react';
 
 import { searchAssetGroupByIdAsOption } from '../../../../actions/asset_groups/assetgroup-action';
@@ -14,10 +15,21 @@ import { searchSimulationByIdAsOptions } from '../../../../actions/simulations/s
 import { searchTagByIdAsOption } from '../../../../actions/tags/tag-action';
 import { searchTeamByIdAsOption } from '../../../../actions/teams/team-actions';
 import { type GroupOption, type Option } from '../../../../utils/Option';
-import { CUSTOM_DASHBOARD, SIMULATIONS } from './constants';
+import { CUSTOM_DASHBOARD, SCENARIOS, SIMULATIONS } from './constants';
 
 const useRetrieveOptions = () => {
   const [options, setOptions] = useState<Option[]>([]);
+
+  const handleOptions = (response: AxiosResponse<GroupOption[] | Option[]>, filterDefaultValues: GroupOption[]) => {
+    if (filterDefaultValues && filterDefaultValues.length > 0) {
+      setOptions([...filterDefaultValues, ...response.data.map((d: Option) => ({
+        ...d,
+        group: 'Values',
+      }))]);
+    } else {
+      setOptions(response.data);
+    }
+  };
 
   const searchOptions = (filterKey: string, ids: string[], defaultValues: GroupOption[] = []) => {
     const filterDefaultValues = defaultValues.filter(v => ids.includes(v.id));
@@ -25,10 +37,7 @@ const useRetrieveOptions = () => {
       case SIMULATIONS:
       case 'base_simulation_side':
         searchSimulationByIdAsOptions(ids).then((response) => {
-          setOptions([...filterDefaultValues, ...response.data.map((d: Option) => ({
-            ...d,
-            group: 'Values',
-          }))]);
+          handleOptions(response, filterDefaultValues);
         });
         break;
       case 'injector_contract_injector':
@@ -116,8 +125,10 @@ const useRetrieveOptions = () => {
         break;
       case 'finding_scenario' :
       case 'exercise_scenario':
+      case 'base_scenario_side':
+      case SCENARIOS:
         searchScenarioByIdAsOption(ids).then((response) => {
-          setOptions(response.data);
+          handleOptions(response, filterDefaultValues);
         });
         break;
       case 'user_organization':

--- a/openbas-front/src/components/common/queryable/filter/useSearchOptions.tsx
+++ b/openbas-front/src/components/common/queryable/filter/useSearchOptions.tsx
@@ -1,3 +1,4 @@
+import { type AxiosResponse } from 'axios';
 import { useState } from 'react';
 
 import { searchAssetGroupAsOption, searchAssetGroupLinkedToFindingsAsOption } from '../../../../actions/asset_groups/assetgroup-action';
@@ -15,7 +16,7 @@ import { searchTagAsOption } from '../../../../actions/tags/tag-action';
 import { searchTeamsAsOption } from '../../../../actions/teams/team-actions';
 import { type GroupOption, type Option } from '../../../../utils/Option';
 import { useFormatter } from '../../../i18n';
-import { CUSTOM_DASHBOARD, SIMULATIONS } from './constants';
+import { CUSTOM_DASHBOARD, SCENARIOS, SIMULATIONS } from './constants';
 
 const useSearchOptions = () => {
   // Standard hooks
@@ -23,15 +24,23 @@ const useSearchOptions = () => {
 
   const [options, setOptions] = useState<GroupOption[] | Option[]>([]);
 
+  const handleOptions = (response: AxiosResponse<GroupOption[] | Option[]>, defaultValues: GroupOption[]) => {
+    if (defaultValues && defaultValues.length > 0) {
+      setOptions([...defaultValues, ...response.data.map((d: Option) => ({
+        ...d,
+        group: 'Values',
+      }))]);
+    } else {
+      setOptions(response.data);
+    }
+  };
+
   const searchOptions = (filterKey: string, search: string = '', contextId: string = '', defaultValues: GroupOption[] = []) => {
     switch (filterKey) {
       case SIMULATIONS:
       case 'base_simulation_side':
         searchSimulationAsOptions(search).then((response) => {
-          setOptions([...defaultValues, ...response.data.map((d: Option) => ({
-            ...d,
-            group: 'Values',
-          }))]);
+          handleOptions(response, defaultValues);
         });
         break;
       case 'injector_contract_injector':
@@ -139,8 +148,10 @@ const useSearchOptions = () => {
         break;
       case 'finding_scenario':
       case 'exercise_scenario':
+      case 'base_scenario_side':
+      case SCENARIOS:
         searchScenarioAsOption(search).then((response) => {
-          setOptions(response.data);
+          handleOptions(response, defaultValues);
         });
         break;
       case 'scenario_category':

--- a/openbas-front/src/components/fields/AutocompleteField.tsx
+++ b/openbas-front/src/components/fields/AutocompleteField.tsx
@@ -1,0 +1,111 @@
+import { Autocomplete, Checkbox, TextField, Tooltip } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { type FunctionComponent, useEffect, useMemo, useState } from 'react';
+
+import type { GroupOption, Option } from '../../utils/Option';
+import { useFormatter } from '../i18n';
+
+interface Props {
+  label: string;
+  value: string | undefined;
+  options: GroupOption[] | Option[];
+  onInputChange: (search: string) => void;
+  onChange: (value: string | undefined) => void;
+  required?: boolean;
+  error?: boolean;
+  className?: string;
+}
+
+const AutocompleteField: FunctionComponent<Props> = ({
+  label,
+  value,
+  options = [],
+  onInputChange,
+  onChange,
+  required = false,
+  error = false,
+  className = '',
+}) => {
+  const { t } = useFormatter();
+  const theme = useTheme();
+
+  const [currentValue, setCurrentValue] = useState<string | undefined>(value);
+
+  useEffect(() => {
+    setCurrentValue(value);
+  }, [value]);
+
+  const selectedOption = useMemo(() => {
+    if (!currentValue || options.length === 0) return null;
+    return options.find(o => o.id === currentValue) || null;
+  }, [currentValue, options]);
+
+  const handleValue = (optionId: string | undefined) => {
+    const newValue = currentValue === optionId ? undefined : optionId;
+    setCurrentValue(newValue);
+    onChange(newValue);
+  };
+
+  return (
+    <Autocomplete
+      selectOnFocus
+      className={className}
+      groupBy={(option: GroupOption | Option) => 'group' in option ? option.group : ''}
+      openOnFocus
+      autoHighlight
+      noOptionsText={t('No available options')}
+      options={options}
+      getOptionLabel={option => option.label ?? ''}
+      value={selectedOption}
+      isOptionEqualToValue={(option, value) => option.id === value.id}
+      onInputChange={(_, search, reason) => {
+        if (reason === 'input') {
+          onInputChange(search);
+        }
+      }}
+      onChange={(_, newValue) => {
+        const newId = newValue?.id ?? undefined;
+        handleValue(newId);
+      }}
+      renderInput={paramsInput => (
+        <TextField
+          {...paramsInput}
+          error={error}
+          label={label}
+          variant="outlined"
+          size="small"
+          required={required}
+        />
+      )}
+      renderOption={(props, option) => {
+        const checked = currentValue === option.id;
+        return (
+          <Tooltip title={option.label}>
+            <li
+              {...props}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.stopPropagation();
+                }
+              }}
+              key={option.id}
+              onClick={() => handleValue(option.id)}
+              style={{
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                padding: 0,
+                margin: 0,
+              }}
+            >
+              <Checkbox checked={checked} />
+              <span style={{ padding: `0 ${theme.spacing(1)} 0 ${theme.spacing(1)}` }}>{option.label}</span>
+            </li>
+          </Tooltip>
+        );
+      }}
+    />
+  );
+};
+
+export default AutocompleteField;

--- a/openbas-front/src/components/fields/ScenarioField.tsx
+++ b/openbas-front/src/components/fields/ScenarioField.tsx
@@ -1,7 +1,7 @@
 import { type FunctionComponent, useEffect } from 'react';
 
 import type { GroupOption } from '../../utils/Option';
-import { SIMULATIONS } from '../common/queryable/filter/constants';
+import { SCENARIOS } from '../common/queryable/filter/constants';
 import useSearchOptions from '../common/queryable/filter/useSearchOptions';
 import AutocompleteField from './AutocompleteField';
 
@@ -15,10 +15,10 @@ interface Props {
   defaultOptions?: GroupOption[];
 }
 
-const SimulationField: FunctionComponent<Props> = ({ label, value, onChange, className = '', required = false, error = false, defaultOptions = [] }) => {
+const ScenarioField: FunctionComponent<Props> = ({ label, value, onChange, className = '', required = false, error = false, defaultOptions = [] }) => {
   const { options, searchOptions } = useSearchOptions();
   useEffect(() => {
-    searchOptions(SIMULATIONS, '', '', defaultOptions);
+    searchOptions(SCENARIOS, '', '', defaultOptions);
   }, []);
 
   return (
@@ -30,9 +30,9 @@ const SimulationField: FunctionComponent<Props> = ({ label, value, onChange, cla
       required={required}
       error={error}
       options={options}
-      onInputChange={(search: string) => searchOptions(SIMULATIONS, search)}
+      onInputChange={(search: string) => searchOptions(SCENARIOS, search)}
     />
   );
 };
 
-export default SimulationField;
+export default ScenarioField;

--- a/openbas-front/src/components/fields/SelectFieldController.tsx
+++ b/openbas-front/src/components/fields/SelectFieldController.tsx
@@ -2,8 +2,8 @@ import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@mui/
 import { type CSSProperties } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-interface Item {
-  value: string;
+export interface Item<T extends string = string> {
+  value: T;
   label: string;
 }
 interface Props {
@@ -15,6 +15,13 @@ interface Props {
   disabled?: boolean;
   multiple?: boolean;
 }
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const createItems = <T extends string>(vals: readonly T[]): Item<T>[] =>
+  vals.map(v => ({
+    value: v,
+    label: v,
+  }));
 
 const SelectFieldController = ({ name, label, items, style, multiple = false, required, disabled }: Props) => {
   const { control } = useFormContext();

--- a/openbas-front/src/utils/Option.ts
+++ b/openbas-front/src/utils/Option.ts
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
 
 import countriesJson from '../static/geo/countries.json';
-import { type AttackPattern, type Document, type Exercise, type KillChainPhase, type Organization, type Scenario, type Tag } from './api-types';
+import { type AttackPattern, type Exercise, type KillChainPhase, type Organization, type Scenario, type Tag } from './api-types';
 
 interface Countries {
   features: [{
@@ -32,19 +32,6 @@ export const createGroupOption: (id: string, label: string, group: string, color
   };
 };
 
-export const documentOptions = (
-  document_ids: string[] | undefined,
-  documentsMap: Record<string, Document>,
-) => (document_ids ?? [])
-  .map(documentId => documentsMap[documentId])
-  .filter(documentItem => documentItem !== undefined)
-  .map(
-    documentItem => ({
-      id: documentItem.document_id,
-      label: documentItem.document_name,
-    }) as Option,
-  );
-
 export const tagOptions = (
   tag_ids: string[] | undefined,
   tagsMap: Record<string, Tag>,
@@ -57,18 +44,6 @@ export const tagOptions = (
       label: tagItem.tag_name,
       color: tagItem.tag_color,
     }) as Option,
-  );
-
-export const platformOptions = (
-  platform_ids: string[] | undefined,
-) => (platform_ids ?? [])
-  .map(
-    (platformId) => {
-      return {
-        id: platformId,
-        label: platformId,
-      };
-    },
   );
 
 export const attackPatternOptions = (

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -1844,6 +1844,7 @@ export interface EsSimulation {
   base_id?: string;
   base_representative?: string;
   base_restrictions?: string[];
+  base_scenario_side?: string;
   /** @uniqueItems true */
   base_tags_side?: string[];
   /** @uniqueItems true */

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -1042,14 +1042,14 @@ export interface CustomDashboardOutput {
 export interface CustomDashboardParameters {
   custom_dashboards_parameter_id: string;
   custom_dashboards_parameter_name: string;
-  custom_dashboards_parameter_type: "simulation";
+  custom_dashboards_parameter_type: "scenario" | "simulation";
   listened?: boolean;
 }
 
 export interface CustomDashboardParametersInput {
   custom_dashboards_parameter_id?: string;
   custom_dashboards_parameter_name: string;
-  custom_dashboards_parameter_type: "simulation";
+  custom_dashboards_parameter_type: "scenario" | "simulation";
 }
 
 /** Payload to create a CVE */

--- a/openbas-front/src/utils/lang/en.json
+++ b/openbas-front/src/utils/lang/en.json
@@ -955,6 +955,7 @@
   "My evaluation": "My evaluation",
   "N/A": "N/A",
   "Name": "Name",
+  "name": "Name",
   "Navigation color": "Navigation color",
   "NDR": "NDR",
   "Network Traffic": "Network Traffic",

--- a/openbas-front/src/utils/lang/fr.json
+++ b/openbas-front/src/utils/lang/fr.json
@@ -955,6 +955,7 @@
   "My evaluation": "Mon évaluation",
   "N/A": "N/A",
   "Name": "Nom",
+  "name": "Nom",
   "Navigation color": "Couleur de navigation",
   "NDR": "NDR",
   "Network Traffic": "Trafic réseau",

--- a/openbas-front/src/utils/lang/zh.json
+++ b/openbas-front/src/utils/lang/zh.json
@@ -955,6 +955,7 @@
   "My evaluation": "我的评估",
   "N/A": "不适用",
   "Name": "名称",
+  "name": "名称",
   "Navigation color": "导航颜色",
   "NDR": "NDR",
   "Network Traffic": "网络流量",

--- a/openbas-model/src/main/java/io/openbas/database/model/CustomDashboardParameters.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/CustomDashboardParameters.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.UuidGenerator;
 public class CustomDashboardParameters implements Base {
 
   public enum CustomDashboardParameterType {
+    scenario("scenario", true),
     simulation("simulation", true);
 
     public final String name;

--- a/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
@@ -5,6 +5,7 @@ import static io.openbas.database.model.Grant.GRANT_TYPE.PLANNER;
 import static io.openbas.helper.UserHelper.getUsersByType;
 import static java.time.Instant.now;
 import static java.util.Optional.ofNullable;
+import static lombok.AccessLevel.NONE;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,7 +24,6 @@ import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
@@ -97,7 +97,7 @@ public class Exercise implements Base {
 
   @Column(name = "exercise_launch_order", insertable = false, updatable = false)
   @JsonIgnore
-  @Setter(AccessLevel.NONE)
+  @Setter(NONE)
   private Long launchOrder;
 
   @Column(name = "exercise_end_date")
@@ -161,9 +161,16 @@ public class Exercise implements Base {
       inverseJoinColumns = @JoinColumn(name = "scenario_id"))
   @JsonSerialize(using = MonoIdDeserializer.class)
   @JsonProperty("exercise_scenario")
-  @Schema(type = "string")
   @Queryable(filterable = true, dynamicValues = true)
+  @Schema(type = "string")
+  @Setter(NONE)
   private Scenario scenario;
+
+  public void setScenario(Scenario scenario) {
+    scenario.setUpdatedAt(now());
+    this.scenario = scenario;
+    this.setUpdatedAt(now());
+  }
 
   // -- AUDIT --
 

--- a/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Exercise.java
@@ -167,7 +167,7 @@ public class Exercise implements Base {
   private Scenario scenario;
 
   public void setScenario(Scenario scenario) {
-    scenario.setUpdatedAt(now());
+    if (scenario != null) scenario.setUpdatedAt(now());
     this.scenario = scenario;
     this.setUpdatedAt(now());
   }

--- a/openbas-model/src/main/java/io/openbas/database/model/Scenario.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Scenario.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.*;
 import lombok.Data;
 import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
@@ -250,7 +251,16 @@ public class Scenario implements Base {
       inverseJoinColumns = @JoinColumn(name = "exercise_id"))
   @JsonSerialize(using = MultiIdListDeserializer.class)
   @JsonProperty("scenario_exercises")
+  @Setter(NONE)
   private List<Exercise> exercises;
+
+  public void setExercises(List<Exercise> exercises) {
+    for (Exercise exercise : exercises) {
+      exercise.setUpdatedAt(now());
+    }
+    this.exercises = exercises;
+    this.setUpdatedAt(now());
+  }
 
   @Getter
   @Column(name = "scenario_lessons_anonymized")

--- a/openbas-model/src/main/java/io/openbas/database/model/Scenario.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Scenario.java
@@ -256,7 +256,7 @@ public class Scenario implements Base {
 
   public void setExercises(List<Exercise> exercises) {
     for (Exercise exercise : exercises) {
-      exercise.setUpdatedAt(now());
+      if (exercise != null) exercise.setUpdatedAt(now());
     }
     this.exercises = exercises;
     this.setUpdatedAt(now());

--- a/openbas-model/src/main/java/io/openbas/database/model/Scenario.java
+++ b/openbas-model/src/main/java/io/openbas/database/model/Scenario.java
@@ -255,8 +255,10 @@ public class Scenario implements Base {
   private List<Exercise> exercises;
 
   public void setExercises(List<Exercise> exercises) {
-    for (Exercise exercise : exercises) {
-      if (exercise != null) exercise.setUpdatedAt(now());
+    if (exercises != null) {
+      for (Exercise exercise : exercises) {
+        if (exercise != null) exercise.setUpdatedAt(now());
+      }
     }
     this.exercises = exercises;
     this.setUpdatedAt(now());

--- a/openbas-model/src/main/java/io/openbas/database/repository/ExerciseRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/ExerciseRepository.java
@@ -354,7 +354,7 @@ public interface ExerciseRepository
   @Query(
       value =
           "WITH exercise_data AS ("
-              + "SELECT ex.exercise_id, ex.exercise_name, ex.exercise_created_at, "
+              + "SELECT ex.exercise_id, ex.exercise_name, ex.exercise_created_at, MAX(se.scenario_id) AS scenario_id, "
               + "GREATEST(ex.exercise_updated_at, max(inj.inject_updated_at)) as exercise_injects_updated_at, "
               + "array_agg(DISTINCT et.tag_id) FILTER ( WHERE et.tag_id IS NOT NULL ) as exercise_tags, "
               + "array_agg(DISTINCT ete.team_id) FILTER ( WHERE ete.team_id IS NOT NULL ) as exercise_teams, "
@@ -366,6 +366,7 @@ public interface ExerciseRepository
               + "LEFT JOIN injects inj ON ex.exercise_id = inj.inject_exercise "
               + "LEFT JOIN injects_assets ia ON ia.inject_id = inj.inject_id "
               + "LEFT JOIN injects_asset_groups iag ON iag.inject_id = inj.inject_id "
+              + "LEFT JOIN scenarios_exercises se ON ex.exercise_id = se.exercise_id "
               + "GROUP BY ex.exercise_id, ex.exercise_name, ex.exercise_created_at, ex.exercise_updated_at"
               + ") "
               + "SELECT * FROM exercise_data ed "

--- a/openbas-model/src/main/java/io/openbas/engine/model/simulation/EsSimulation.java
+++ b/openbas-model/src/main/java/io/openbas/engine/model/simulation/EsSimulation.java
@@ -15,7 +15,7 @@ public class EsSimulation extends EsBase {
   /* Every attribute must be uniq, so prefixed with the entity type! */
   /* Except relationships, they should have same name on every model! */
 
-  @Queryable(label = "simulation name")
+  @Queryable(label = "simulation name", filterable = true)
   private String name;
 
   // -- SIDE --
@@ -35,4 +35,8 @@ public class EsSimulation extends EsBase {
   @Queryable(label = "teams", filterable = true, dynamicValues = true)
   @EsQueryable(keyword = true)
   private Set<String> base_teams_side; // Must finish by _side
+
+  @Queryable(label = "scenario", filterable = true, dynamicValues = true)
+  @EsQueryable(keyword = true)
+  private String base_scenario_side; // Must finish by _side
 }

--- a/openbas-model/src/main/java/io/openbas/engine/model/simulation/SimulationHandler.java
+++ b/openbas-model/src/main/java/io/openbas/engine/model/simulation/SimulationHandler.java
@@ -2,6 +2,7 @@ package io.openbas.engine.model.simulation;
 
 import static io.openbas.engine.EsUtils.buildRestrictions;
 import static org.springframework.util.CollectionUtils.isEmpty;
+import static org.springframework.util.StringUtils.hasText;
 
 import io.openbas.database.raw.RawSimulation;
 import io.openbas.database.repository.ExerciseRepository;
@@ -30,9 +31,11 @@ public class SimulationHandler implements Handler<EsSimulation> {
               esSimulation.setBase_id(simulation.getExercise_id());
               esSimulation.setBase_created_at(simulation.getExercise_created_at());
               esSimulation.setBase_updated_at(simulation.getExercise_injects_updated_at());
+              esSimulation.setName(simulation.getExercise_name());
 
               esSimulation.setBase_representative(simulation.getExercise_name());
-              esSimulation.setBase_restrictions(buildRestrictions(simulation.getExercise_id()));
+              esSimulation.setBase_restrictions(
+                  buildRestrictions(simulation.getExercise_id(), simulation.getScenario_id()));
               // Specific
               // Dependencies
               List<String> dependencies = new ArrayList<>();
@@ -51,6 +54,10 @@ public class SimulationHandler implements Handler<EsSimulation> {
               if (!isEmpty(simulation.getExercise_teams())) {
                 dependencies.addAll(simulation.getExercise_teams());
                 esSimulation.setBase_teams_side(simulation.getExercise_teams());
+              }
+              if (hasText(simulation.getScenario_id())) {
+                dependencies.add(simulation.getScenario_id());
+                esSimulation.setBase_scenario_side(simulation.getScenario_id());
               }
               esSimulation.setBase_dependencies(dependencies);
               return esSimulation;


### PR DESCRIPTION
### Proposed changes

- When creating or editing a **custom dashboard**, the user can now add a **new filter parameter** called `scenario`.
- This `scenario` filter works similarly to the existing simulation filter.
- The user can:
    - Choose the `scenario` filter in any widgets for the simulation dimension.
    - Bind it to any `scenario` param.
- However, when the dashboard is displayed **inside a running simulation**:
    - The `scenario` filter is **hidden** in the UI to prevent manual override.
    - Its value is set to the scenario link to the simulation or to null.
