### PR TITLE
[backend/frontend] RBAC Implement an api to return scenario information based on the simulation id Issue/375 

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
@@ -39,6 +39,7 @@ import io.openbas.utils.FilterUtilsJpa;
 import io.openbas.utils.InjectExpectationResultUtils.ExpectationResultsByType;
 import io.openbas.utils.pagination.SearchPaginationInput;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.persistence.criteria.Join;
@@ -945,5 +946,27 @@ public class ExerciseApi extends RestBehavior {
   public List<Document> documents(@PathVariable String exerciseId) {
     return this.documentService.documentsForSimulation(exerciseId);
   }
+
+  @GetMapping(EXERCISE_URI + "/{exerciseId}/scenario")
+  @RBAC(
+      resourceId = "#exerciseId",
+      actionPerformed = Action.READ,
+      resourceType = ResourceType.SIMULATION)
+  @Operation(
+      summary = "Get the Scenario linked to the exercise")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "The Scenario"),
+        @ApiResponse(responseCode = "404", description = "Exercise or Scenario not found")
+      })
+  public Scenario scenarioFromExercise(
+      @PathVariable @NotBlank @Schema(description = "ID of the exercise") final String exerciseId) {
+    Scenario scenario = exerciseService.getScenarioFromExercise(exerciseId);
+    if (scenario == null) {
+      throw new ElementNotFoundException("No scenario linked to exercise " + exerciseId);
+    }
+    return scenario;
+  }
+
   // end region
 }

--- a/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
@@ -948,20 +948,23 @@ public class ExerciseApi extends RestBehavior {
     return this.documentService.documentsForSimulation(exerciseId);
   }
 
-  @GetMapping(EXERCISE_URI + "/{exerciseId}/scenario")
+  @GetMapping(EXERCISE_URI + "/{simulationId}/scenario")
   @RBAC(
       resourceId = "#exerciseId",
       actionPerformed = Action.READ,
       resourceType = ResourceType.SIMULATION)
-  @Operation(summary = "Get the Scenario linked to the exercise")
+  @Operation(summary = "Get the Scenario linked to the simulation")
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "200", description = "The Scenario"),
-        @ApiResponse(responseCode = "404", description = "Exercise or Scenario not found")
+        @ApiResponse(
+            responseCode = "200",
+            description = "The Scenario related to the given simulation"),
+        @ApiResponse(responseCode = "404", description = "Simulation or Scenario not found")
       })
-  public Scenario scenarioFromExercise(
-      @PathVariable @NotBlank @Schema(description = "ID of the exercise") final String exerciseId) {
-    return scenarioService.scenarioFromExerciseId(exerciseId);
+  public Scenario scenarioFromSimulation(
+      @PathVariable @NotBlank @Schema(description = "ID of the exercise")
+          final String simulationId) {
+    return scenarioService.scenarioFromSimulationId(simulationId);
   }
 
   // end region

--- a/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
@@ -950,7 +950,7 @@ public class ExerciseApi extends RestBehavior {
 
   @GetMapping(EXERCISE_URI + "/{simulationId}/scenario")
   @RBAC(
-      resourceId = "#exerciseId",
+      resourceId = "#simulationId",
       actionPerformed = Action.READ,
       resourceType = ResourceType.SIMULATION)
   @Operation(summary = "Get the Scenario linked to the simulation")
@@ -962,7 +962,7 @@ public class ExerciseApi extends RestBehavior {
         @ApiResponse(responseCode = "404", description = "Simulation or Scenario not found")
       })
   public Scenario scenarioFromSimulation(
-      @PathVariable @NotBlank @Schema(description = "ID of the exercise")
+      @PathVariable @NotBlank @Schema(description = "ID of the simulation")
           final String simulationId) {
     return scenarioService.scenarioFromSimulationId(simulationId);
   }

--- a/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/ExerciseApi.java
@@ -108,6 +108,7 @@ public class ExerciseApi extends RestBehavior {
   private final ActionMetricCollector actionMetricCollector;
   private final ChannelService channelService;
   private final DocumentService documentService;
+  private final ScenarioService scenarioService;
 
   // endregion
 
@@ -952,8 +953,7 @@ public class ExerciseApi extends RestBehavior {
       resourceId = "#exerciseId",
       actionPerformed = Action.READ,
       resourceType = ResourceType.SIMULATION)
-  @Operation(
-      summary = "Get the Scenario linked to the exercise")
+  @Operation(summary = "Get the Scenario linked to the exercise")
   @ApiResponses(
       value = {
         @ApiResponse(responseCode = "200", description = "The Scenario"),
@@ -961,11 +961,7 @@ public class ExerciseApi extends RestBehavior {
       })
   public Scenario scenarioFromExercise(
       @PathVariable @NotBlank @Schema(description = "ID of the exercise") final String exerciseId) {
-    Scenario scenario = exerciseService.getScenarioFromExercise(exerciseId);
-    if (scenario == null) {
-      throw new ElementNotFoundException("No scenario linked to exercise " + exerciseId);
-    }
-    return scenario;
+    return scenarioService.scenarioFromExerciseId(exerciseId);
   }
 
   // end region

--- a/openbas-api/src/main/java/io/openbas/rest/exercise/service/ExerciseService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/service/ExerciseService.java
@@ -61,7 +61,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.Hibernate;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
@@ -811,20 +810,5 @@ public class ExerciseService {
       }
     }
     return false;
-  }
-
-  /**
-   * Return the scenario link to the exercise
-   *
-   * @param exerciseId
-   * @return
-   */
-  @Transactional(readOnly = true)
-  public Scenario getScenarioFromExercise(@NotBlank String exerciseId) {
-    Exercise exercise =
-        exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
-    Scenario scenario = exercise.getScenario();
-    Hibernate.initialize(scenario);
-    return scenario;
   }
 }

--- a/openbas-api/src/main/java/io/openbas/rest/exercise/service/ExerciseService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/service/ExerciseService.java
@@ -61,6 +61,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
@@ -810,5 +811,20 @@ public class ExerciseService {
       }
     }
     return false;
+  }
+
+  /**
+   * Return the scenario link to the exercise
+   *
+   * @param exerciseId
+   * @return
+   */
+  @Transactional(readOnly = true)
+  public Scenario getScenarioFromExercise(@NotBlank String exerciseId) {
+    Exercise exercise =
+        exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
+    Scenario scenario = exercise.getScenario();
+    Hibernate.initialize(scenario);
+    return scenario;
   }
 }

--- a/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
@@ -296,6 +296,12 @@ public class ScenarioService {
         .orElseThrow(() -> new ElementNotFoundException("Scenario not found"));
   }
 
+  public Scenario scenarioFromExerciseId(@NotBlank final String exerciseId) {
+    return this.scenarioRepository
+        .findByExercises_Id(exerciseId)
+        .orElseThrow(() -> new ElementNotFoundException("Scenario not found"));
+  }
+
   @Transactional(readOnly = true)
   public ExerciseSimple latestExerciseByExternalReference(
       @NotBlank final String scenarioExternalReference) {

--- a/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
+++ b/openbas-api/src/main/java/io/openbas/service/ScenarioService.java
@@ -296,10 +296,11 @@ public class ScenarioService {
         .orElseThrow(() -> new ElementNotFoundException("Scenario not found"));
   }
 
-  public Scenario scenarioFromExerciseId(@NotBlank final String exerciseId) {
+  public Scenario scenarioFromSimulationId(@NotBlank final String simulationId) {
     return this.scenarioRepository
-        .findByExercises_Id(exerciseId)
-        .orElseThrow(() -> new ElementNotFoundException("Scenario not found"));
+        .findByExercises_Id(simulationId)
+        .orElseThrow(
+            () -> new ElementNotFoundException("Scenario not found for simulation" + simulationId));
   }
 
   @Transactional(readOnly = true)

--- a/openbas-api/src/test/java/io/openbas/rest/exercise/ExerciseApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/exercise/ExerciseApiTest.java
@@ -52,6 +52,7 @@ public class ExerciseApiTest extends IntegrationTest {
   @Autowired private TagRepository tagRepository;
   @Autowired private TagRuleRepository tagRuleRepository;
   @Autowired private AssetGroupRepository assetGroupRepository;
+  @Autowired private ScenarioRepository scenarioRepository;
 
   List<ExerciseComposer.Composer> exerciseWrapperComposers = new ArrayList<>();
   private static final List<String> EXERCISE_IDS = new ArrayList<>();
@@ -144,6 +145,30 @@ public class ExerciseApiTest extends IntegrationTest {
           JsonPath.read(response, "$.global_scores_by_exercise_ids." + exercise2Saved.getId())
               .toString());
     }
+  }
+
+  @Test
+  @DisplayName("Get scenario from exercise id")
+  @WithMockAdminUser
+  void givenExerciseId_whenGettingScenarioFromExercise_thenReturnScenario() throws Exception {
+    Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
+    Scenario scenarioSaved = scenarioRepository.save(scenario);
+
+    Exercise exercise = ExerciseFixture.createDefaultCrisisExercise();
+    exercise.setScenario(scenarioSaved);
+
+    Exercise exerciseSaved = exerciseRepository.save(exercise);
+
+    String response =
+        mvc.perform(
+                get(EXERCISE_URI + "/" + exerciseSaved.getId() + "/scenario")
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    assertEquals(scenarioSaved.getId(), JsonPath.read(response, "$.scenario_id"));
   }
 
   @DisplayName("Check if a rule applies when a rule is found")

--- a/openbas-front/src/actions/exercises/exercise-action.ts
+++ b/openbas-front/src/actions/exercises/exercise-action.ts
@@ -15,6 +15,7 @@ import {
   type SearchPaginationInput,
 } from '../../utils/api-types';
 import { MESSAGING$ } from '../../utils/Environment';
+import { scenario } from '../scenarios/scenario-schema';
 import * as schema from '../Schema';
 
 export const EXERCISE_URI = '/api/exercises';
@@ -196,4 +197,9 @@ export const checkExerciseTagRules = (exerciseId: string, newTagIds: string[]) =
 export const updateCustomDashboard = (exerciseId: string, customDashboardId: string | null) => (dispatch: Dispatch) => {
   const uri = `/api/exercises/${exerciseId}/custom-dashboards/${customDashboardId}`;
   return putReferential(schema.lessonsQuestion, uri, {})(dispatch);
+};
+
+export const fetchScenarioFromSimulation = (exerciseId: string) => (dispatch: Dispatch) => {
+  const uri = `/api/exercises/${exerciseId}/scenario`;
+  return getReferential(scenario, uri)(dispatch);
 };

--- a/openbas-front/src/actions/exercises/exercise-action.ts
+++ b/openbas-front/src/actions/exercises/exercise-action.ts
@@ -199,7 +199,7 @@ export const updateCustomDashboard = (exerciseId: string, customDashboardId: str
   return putReferential(schema.lessonsQuestion, uri, {})(dispatch);
 };
 
-export const fetchScenarioFromSimulation = (exerciseId: string) => (dispatch: Dispatch) => {
-  const uri = `/api/exercises/${exerciseId}/scenario`;
+export const fetchScenarioFromSimulation = (simulationId: string) => (dispatch: Dispatch) => {
+  const uri = `/api/exercises/${simulationId}/scenario`;
   return getReferential(scenario, uri)(dispatch);
 };

--- a/openbas-front/src/admin/components/simulations/simulation/Index.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/Index.tsx
@@ -5,8 +5,8 @@ import { makeStyles } from 'tss-react/mui';
 import { useLocalStorage } from 'usehooks-ts';
 
 import { fetchExercise } from '../../../../actions/Exercise';
+import { fetchScenarioFromSimulation } from '../../../../actions/exercises/exercise-action';
 import { type ExercisesHelper } from '../../../../actions/exercises/exercise-helper';
-import { fetchScenario } from '../../../../actions/scenarios/scenario-actions';
 import { seriesForSimulation } from '../../../../actions/simulations/simulation-customdashboard-action';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { errorWrapper } from '../../../../components/Error';
@@ -226,15 +226,18 @@ const Index = () => {
   const { exercise } = useHelper((helper: ExercisesHelper) => ({ exercise: helper.getExercise(exerciseId) }));
   useDataLoader(() => {
     setLoading(true);
-    dispatch(fetchExercise(exerciseId)).finally(() => {
+    dispatch(fetchExercise(exerciseId));
+    if (!exercise) {
+      return;
+    }
+    if (!exercise?.exercise_scenario) {
       setPristine(false);
       setLoading(false);
-    });
-  });
-
-  useDataLoader(() => {
-    if (exercise?.exercise_scenario) {
-      dispatch(fetchScenario(exercise?.exercise_scenario));
+    } else {
+      dispatch(fetchScenarioFromSimulation(exercise?.exercise_id)).finally(() => {
+        setPristine(false);
+        setLoading(false);
+      });
     }
   }, [exercise]);
 

--- a/openbas-front/src/admin/components/simulations/simulation/Index.tsx
+++ b/openbas-front/src/admin/components/simulations/simulation/Index.tsx
@@ -230,11 +230,11 @@ const Index = () => {
     if (!exercise) {
       return;
     }
-    if (!exercise?.exercise_scenario) {
+    if (!exercise.exercise_scenario) {
       setPristine(false);
       setLoading(false);
     } else {
-      dispatch(fetchScenarioFromSimulation(exercise?.exercise_id)).finally(() => {
+      dispatch(fetchScenarioFromSimulation(exercise.exercise_id)).finally(() => {
         setPristine(false);
         setLoading(false);
       });

--- a/openbas-model/src/main/java/io/openbas/database/repository/ScenarioRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/ScenarioRepository.java
@@ -6,6 +6,7 @@ import io.openbas.database.raw.RawScenario;
 import io.openbas.utils.Constants;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -142,4 +143,6 @@ public interface ScenarioRepository
   @Transactional
   void removeTeams(
       @Param("scenarioId") final String scenarioId, @Param("teamIds") final List<String> teamIds);
+
+  Optional<Scenario> findByExercises_Id(String exerciseId);
 }


### PR DESCRIPTION


### Proposed changes

* Implement an api to return scenario information based on the simulation id to facilitate permission verification


### Testing Instructions

1. Open a simulation page, 
2. verify that the scenario information are displayed

### Related issues

* #375
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

