### PR TITLE
[frontend] Allow Taxonomies tabs to be seen without capa (#3774)

### DIFF
--- a/openbas-front/src/admin/Index.tsx
+++ b/openbas-front/src/admin/Index.tsx
@@ -124,8 +124,7 @@ const Index = () => {
               <Route path="agents/*" element={errorWrapper(IndexAgents)()} />
               <Route
                 path="settings/*"
-                element={logged.admin || ability.can(ACTIONS.ACCESS, SUBJECTS.PLATFORM_SETTINGS) ? errorWrapper(IndexSettings)()
-                  : <Navigate to="/" replace={true} />}
+                element={errorWrapper(IndexSettings)()}
               />
               {/* Not found */}
               <Route path="*" element={<NotFound />} />

--- a/openbas-front/src/admin/components/nav/LeftBar.tsx
+++ b/openbas-front/src/admin/components/nav/LeftBar.tsx
@@ -203,14 +203,14 @@ const LeftBar = () => {
       ],
     },
     {
-      userRight: ability.can(ACTIONS.ACCESS, SUBJECTS.PLATFORM_SETTINGS),
+      userRight: true,
       items: [
         {
           path: `/admin/settings`,
           icon: () => (<SettingsOutlined />),
           label: 'Settings',
           href: 'settings',
-          userRight: ability.can(ACTIONS.ACCESS, SUBJECTS.PLATFORM_SETTINGS),
+          userRight: true,
           subItems: [
             {
               link: '/admin/settings/parameters',
@@ -230,7 +230,7 @@ const LeftBar = () => {
             {
               link: '/admin/settings/taxonomies',
               label: 'Taxonomies',
-              userRight: ability.can(ACTIONS.ACCESS, SUBJECTS.PLATFORM_SETTINGS),
+              userRight: true,
             },
             {
               link: '/admin/settings/data_ingestion',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Free access on the left menu to Settings / Taxonomies

### Testing Instructions

1. Create a user with a role without platform settings capabilities
2. Log in to this user and check if you still have Settings / Taxonomies menu

### Related issues

* Closes #3774


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
