### PR TITLE
[backend] enable interpolation in multi email (#3876)

### DIFF
--- a/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/challenge/ChallengeExecutor.java
@@ -111,7 +111,7 @@ public class ChallengeExecutor extends Injector {
                 // Send the email.
                 emailService.sendEmail(
                     execution,
-                    userInjectContext,
+                    List.of(userInjectContext),
                     from,
                     replyTos,
                     content.getInReplyTo(),

--- a/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/channel/ChannelExecutor.java
@@ -115,7 +115,7 @@ public class ChannelExecutor extends Injector {
                   // Send the email.
                   emailService.sendEmail(
                       execution,
-                      userInjectContext,
+                      List.of(userInjectContext),
                       from,
                       replyTos,
                       content.getInReplyTo(),

--- a/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
@@ -65,7 +65,7 @@ public class EmailExecutor extends Injector {
           try {
             emailService.sendEmail(
                 execution,
-                user,
+                List.of(user),
                 from,
                 replyTos,
                 inReplyTo,

--- a/openbas-api/src/test/java/io/openbas/service/EmailServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/service/EmailServiceTest.java
@@ -36,7 +36,7 @@ class EmailServiceTest extends IntegrationTest {
     when(emailSender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));
     emailService.sendEmail(
         execution,
-        userContext,
+        List.of(userContext),
         "user@openbas.io",
         List.of("user-reply-to@openbas.io"),
         null,

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectorContractFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectorContractFixture.java
@@ -4,6 +4,7 @@ import static io.openbas.database.model.InjectorContract.CONTRACT_CONTENT_FIELDS
 import static io.openbas.database.model.InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY_TARGETED_PROPERTY;
 import static io.openbas.injector_contract.fields.ContractSelect.selectFieldWithDefault;
 import static io.openbas.injectors.email.EmailContract.EMAIL_DEFAULT;
+import static io.openbas.injectors.email.EmailContract.EMAIL_GLOBAL;
 import static io.openbas.utils.fixtures.InjectorFixture.createDefaultPayloadInjector;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,6 +35,10 @@ public class InjectorContractFixture {
 
   public InjectorContract getWellKnownSingleEmailContract() {
     return injectorContractRepository.findById(EMAIL_DEFAULT).orElseThrow();
+  }
+
+  public InjectorContract getWellKnownGlobalEmailContract() {
+    return injectorContractRepository.findById(EMAIL_GLOBAL).orElseThrow();
   }
 
   private static ObjectNode createDefaultContent(ObjectMapper objectMapper) {

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/InjectorContractComposer.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/InjectorContractComposer.java
@@ -3,6 +3,7 @@ package io.openbas.utils.fixtures.composers;
 import static io.openbas.injectors.challenge.ChallengeContract.CHALLENGE_PUBLISH;
 import static io.openbas.injectors.channel.ChannelContract.CHANNEL_PUBLISH;
 import static io.openbas.injectors.email.EmailContract.EMAIL_DEFAULT;
+import static io.openbas.injectors.email.EmailContract.EMAIL_GLOBAL;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -29,7 +30,7 @@ public class InjectorContractComposer extends ComposerBase<InjectorContract> {
 
   public class Composer extends InnerComposerBase<InjectorContract> {
     private final List<String> WELL_KNOWN_CONTRACT_IDS =
-        List.of(CHALLENGE_PUBLISH, CHANNEL_PUBLISH, EMAIL_DEFAULT);
+        List.of(CHALLENGE_PUBLISH, CHANNEL_PUBLISH, EMAIL_DEFAULT, EMAIL_GLOBAL);
 
     private final InjectorContract injectorContract;
     private final List<AttackPatternComposer.Composer> attackPatternComposer = new ArrayList<>();


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Multi email contract (aka Global email) is now doing interpolation of variable.
* Caveat: when there are multiple recipients, interpolating variables of the ${user} object will not occur.

### Testing Instructions

1. Create a scenario
2. Add some vars
3. Create inject of contract "multi email" (different from single email)
4. Test inject => vars interpolated

### Related issues

* Closes #3876 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
